### PR TITLE
FlatButtonUI getPreferredSize nullPointer fix

### DIFF
--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatButtonUI.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatButtonUI.java
@@ -398,7 +398,7 @@ public class FlatButtonUI
 		if( isHelpButton( c ) )
 			return new Dimension( helpButtonIcon.getIconWidth(), helpButtonIcon.getIconHeight() );
 
-		Dimension prefSize = super.getPreferredSize(c);
+		Dimension prefSize = super.getPreferredSize( c );
 		if ( prefSize == null )
 			return null;
 

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatButtonUI.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatButtonUI.java
@@ -398,7 +398,9 @@ public class FlatButtonUI
 		if( isHelpButton( c ) )
 			return new Dimension( helpButtonIcon.getIconWidth(), helpButtonIcon.getIconHeight() );
 
-		Dimension prefSize = super.getPreferredSize( c );
+		Dimension prefSize = super.getPreferredSize(c);
+		if ( prefSize == null )
+			return null;
 
 		// make button square if it is a icon-only button
 		// or apply minimum width, if not in toolbar and not a icon-only button


### PR DESCRIPTION
FlatButtonUI.getPreferredSize throw exception when button.getComponentCount()>0.
In that case we should return null as same way of BasicButtonUI.
