### PR TITLE
Fix relative resource location

### DIFF
--- a/flatlaf-intellij-themes/src/main/java/com/formdev/flatlaf/intellijthemes/materialthemeuilite/Utils.java
+++ b/flatlaf-intellij-themes/src/main/java/com/formdev/flatlaf/intellijthemes/materialthemeuilite/Utils.java
@@ -32,7 +32,7 @@ class Utils
 
 	static IntelliJTheme loadTheme( String name ) {
 		try {
-			return new IntelliJTheme( Utils.class.getResourceAsStream( "../themes/material-theme-ui-lite/" + name ) );
+			return new IntelliJTheme( Utils.class.getResourceAsStream( "themes/material-theme-ui-lite/" + name ) );
 		} catch( ParseException | IOException ex ) {
 			String msg = "FlatLaf: Failed to load IntelliJ theme '" + name + "'";
 			LOG.log( Level.SEVERE, msg, ex );


### PR DESCRIPTION
Using flatlaf intellijthemes as a dependency does not work for all themes from the subfolder 'material-theme-ui-lite' because of the usage of ".." to  to load the resource.
