### PR TITLE
Smooth scrolling

### DIFF
--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatScrollBarUI.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatScrollBarUI.java
@@ -28,8 +28,6 @@ import java.awt.event.MouseEvent;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.util.Objects;
-import javax.swing.BoundedRangeModel;
-import javax.swing.DefaultBoundedRangeModel;
 import javax.swing.InputMap;
 import javax.swing.JButton;
 import javax.swing.JComponent;
@@ -37,7 +35,6 @@ import javax.swing.JScrollBar;
 import javax.swing.JScrollPane;
 import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
-import javax.swing.event.ChangeListener;
 import javax.swing.plaf.ComponentUI;
 import javax.swing.plaf.basic.BasicScrollBarUI;
 import com.formdev.flatlaf.FlatClientProperties;
@@ -312,7 +309,11 @@ public class FlatScrollBarUI
 		} );
 	}
 
-	protected void runAndSetValueAnimated( Runnable r ) {
+	/**
+	 * Runs the given runnable, which should modify the scroll bar value,
+	 * and then animate scroll bar value from old value to new value.
+	 */
+	public void runAndSetValueAnimated( Runnable r ) {
 		if( !isSmoothScrollingEnabled() ) {
 			r.run();
 			return;
@@ -321,30 +322,26 @@ public class FlatScrollBarUI
 		if( animator != null )
 			animator.cancel();
 
-		int[] newValue = new int[1];
+		// if invoked while animation is running, calculation of new value
+		// should start at the previous target value
+		if( targetValue != Integer.MIN_VALUE )
+			scrollbar.setValue( targetValue );
 
-		runWithoutValueChangeEvents( scrollbar, () -> {
-			// if invoked while animation is running, calculation of new value
-			// should start at the previous target value
-			if( targetValue != Integer.MIN_VALUE )
-				scrollbar.setValue( targetValue );
+		int oldValue = scrollbar.getValue();
 
-			int oldValue = scrollbar.getValue();
+		r.run();
 
-			r.run();
+		int newValue = scrollbar.getValue();
+		scrollbar.setValue( oldValue );
 
-			newValue[0] = scrollbar.getValue();
-			scrollbar.setValue( oldValue );
-		} );
-
-		setValueAnimated( newValue[0] );
+		setValueAnimated( newValue );
 	}
 
 	private Animator animator;
 	private int targetValue = Integer.MIN_VALUE;
 	private int delta;
 
-	protected void setValueAnimated( int value ) {
+	public void setValueAnimated( int value ) {
 		// create animator
 		if( animator == null ) {
 			int duration = FlatUIUtils.getUIInt( "ScrollPane.smoothScrolling.duration", 200 );
@@ -387,29 +384,6 @@ public class FlatScrollBarUI
 		// applications to turn smooth scrolling on or off at any time
 		// (e.g. in application options dialog).
 		return UIManager.getBoolean( "ScrollPane.smoothScrolling" );
-	}
-
-	protected static void runWithoutValueChangeEvents( JScrollBar scrollBar, Runnable r ) {
-		BoundedRangeModel model = scrollBar.getModel();
-		if( !(model instanceof DefaultBoundedRangeModel) ) {
-			r.run();
-			return;
-		}
-
-		DefaultBoundedRangeModel m = (DefaultBoundedRangeModel) model;
-
-		// remove all listeners
-		ChangeListener[] changeListeners = m.getChangeListeners();
-		for( ChangeListener l : changeListeners )
-			m.removeChangeListener( l );
-
-		try {
-			r.run();
-		} finally {
-			// add all listeners
-			for( ChangeListener l : changeListeners )
-				m.addChangeListener( l );
-		}
 	}
 
 	//---- class ScrollBarHoverListener ---------------------------------------

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatScrollBarUI.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatScrollBarUI.java
@@ -23,6 +23,7 @@ import java.awt.Graphics;
 import java.awt.Graphics2D;
 import java.awt.Insets;
 import java.awt.Rectangle;
+import java.awt.event.ActionEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.beans.PropertyChangeEvent;
@@ -162,6 +163,16 @@ public class FlatScrollBarUI
 		buttonDisabledArrowColor = null;
 		hoverButtonBackground = null;
 		pressedButtonBackground = null;
+	}
+
+	@Override
+	protected TrackListener createTrackListener() {
+		return new FlatTrackListener();
+	}
+
+	@Override
+	protected ScrollListener createScrollListener() {
+		return new FlatScrollListener();
 	}
 
 	@Override
@@ -314,10 +325,12 @@ public class FlatScrollBarUI
 	 * and then animate scroll bar value from old value to new value.
 	 */
 	public void runAndSetValueAnimated( Runnable r ) {
-		if( !isSmoothScrollingEnabled() ) {
+		if( inRunAndSetValueAnimated || !isSmoothScrollingEnabled() ) {
 			r.run();
 			return;
 		}
+
+		inRunAndSetValueAnimated = true;
 
 		if( animator != null )
 			animator.cancel();
@@ -332,11 +345,16 @@ public class FlatScrollBarUI
 		r.run();
 
 		int newValue = scrollbar.getValue();
-		scrollbar.setValue( oldValue );
+		if( newValue != oldValue ) {
+			scrollbar.setValue( oldValue );
 
-		setValueAnimated( newValue );
+			setValueAnimated( newValue );
+		}
+
+		inRunAndSetValueAnimated = false;
 	}
 
+	private boolean inRunAndSetValueAnimated;
 	private Animator animator;
 	private int targetValue = Integer.MIN_VALUE;
 	private int delta;
@@ -384,6 +402,32 @@ public class FlatScrollBarUI
 		// applications to turn smooth scrolling on or off at any time
 		// (e.g. in application options dialog).
 		return UIManager.getBoolean( "ScrollPane.smoothScrolling" );
+	}
+
+	//---- class FlatTrackListener --------------------------------------------
+
+	protected class FlatTrackListener
+		extends TrackListener
+	{
+		@Override
+		public void mousePressed( MouseEvent e ) {
+			runAndSetValueAnimated( () -> {
+				super.mousePressed( e );
+			} );
+		}
+	}
+
+	//---- class FlatScrollListener -------------------------------------------
+
+	protected class FlatScrollListener
+		extends ScrollListener
+	{
+		@Override
+		public void actionPerformed( ActionEvent e ) {
+			runAndSetValueAnimated( () -> {
+				super.actionPerformed( e );
+			} );
+		}
 	}
 
 	//---- class ScrollBarHoverListener ---------------------------------------

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatScrollBarUI.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatScrollBarUI.java
@@ -17,6 +17,7 @@
 package com.formdev.flatlaf.ui;
 
 import java.awt.Color;
+import java.awt.Container;
 import java.awt.Dimension;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
@@ -27,6 +28,8 @@ import java.awt.event.MouseEvent;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.util.Objects;
+import javax.swing.BoundedRangeModel;
+import javax.swing.DefaultBoundedRangeModel;
 import javax.swing.InputMap;
 import javax.swing.JButton;
 import javax.swing.JComponent;
@@ -34,9 +37,12 @@ import javax.swing.JScrollBar;
 import javax.swing.JScrollPane;
 import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
+import javax.swing.event.ChangeListener;
 import javax.swing.plaf.ComponentUI;
 import javax.swing.plaf.basic.BasicScrollBarUI;
 import com.formdev.flatlaf.FlatClientProperties;
+import com.formdev.flatlaf.util.Animator;
+import com.formdev.flatlaf.util.CubicBezierEasing;
 import com.formdev.flatlaf.util.UIScale;
 
 /**
@@ -290,6 +296,120 @@ public class FlatScrollBarUI
 	@Override
 	protected Dimension getMaximumThumbSize() {
 		return UIScale.scale( FlatUIUtils.addInsets( super.getMaximumThumbSize(), thumbInsets ) );
+	}
+
+	@Override
+	protected void scrollByBlock( int direction ) {
+		runAndSetValueAnimated( () -> {
+			super.scrollByBlock( direction );
+		} );
+	}
+
+	@Override
+	protected void scrollByUnit( int direction ) {
+		runAndSetValueAnimated( () -> {
+			super.scrollByUnit( direction );
+		} );
+	}
+
+	protected void runAndSetValueAnimated( Runnable r ) {
+		if( !isSmoothScrollingEnabled() ) {
+			r.run();
+			return;
+		}
+
+		if( animator != null )
+			animator.cancel();
+
+		int[] newValue = new int[1];
+
+		runWithoutValueChangeEvents( scrollbar, () -> {
+			// if invoked while animation is running, calculation of new value
+			// should start at the previous target value
+			if( targetValue != Integer.MIN_VALUE )
+				scrollbar.setValue( targetValue );
+
+			int oldValue = scrollbar.getValue();
+
+			r.run();
+
+			newValue[0] = scrollbar.getValue();
+			scrollbar.setValue( oldValue );
+		} );
+
+		setValueAnimated( newValue[0] );
+	}
+
+	private Animator animator;
+	private int targetValue = Integer.MIN_VALUE;
+	private int delta;
+
+	protected void setValueAnimated( int value ) {
+		// create animator
+		if( animator == null ) {
+			int duration = FlatUIUtils.getUIInt( "ScrollPane.smoothScrolling.duration", 200 );
+			int resolution = FlatUIUtils.getUIInt( "ScrollPane.smoothScrolling.resolution", 10 );
+			Object interpolator = UIManager.get( "ScrollPane.smoothScrolling.interpolator" );
+
+			animator = new Animator( duration, fraction -> {
+				if( !scrollbar.isShowing() ) {
+					animator.cancel();
+					return;
+				}
+
+				scrollbar.setValue( targetValue - delta + Math.round( delta * fraction ) );
+			}, () -> {
+				targetValue = Integer.MIN_VALUE;
+			});
+
+			animator.setResolution( resolution );
+			animator.setInterpolator( (interpolator instanceof Animator.Interpolator)
+				? (Animator.Interpolator) interpolator
+				: new CubicBezierEasing( 0.5f, 0.5f, 0.5f, 1 ) );
+		}
+
+		targetValue = value;
+		delta = targetValue - scrollbar.getValue();
+
+		animator.cancel();
+		animator.start();
+	}
+
+	protected boolean isSmoothScrollingEnabled() {
+		// if scroll bar is child of scroll pane, check only client property of scroll pane
+		Container parent = scrollbar.getParent();
+		JComponent c = (parent instanceof JScrollPane) ? (JScrollPane) parent : scrollbar;
+		Object smoothScrolling = c.getClientProperty( FlatClientProperties.SCROLL_PANE_SMOOTH_SCROLLING );
+		if( smoothScrolling instanceof Boolean )
+			return (Boolean) smoothScrolling;
+
+		// Note: Getting UI value "ScrollPane.smoothScrolling" here to allow
+		// applications to turn smooth scrolling on or off at any time
+		// (e.g. in application options dialog).
+		return UIManager.getBoolean( "ScrollPane.smoothScrolling" );
+	}
+
+	protected static void runWithoutValueChangeEvents( JScrollBar scrollBar, Runnable r ) {
+		BoundedRangeModel model = scrollBar.getModel();
+		if( !(model instanceof DefaultBoundedRangeModel) ) {
+			r.run();
+			return;
+		}
+
+		DefaultBoundedRangeModel m = (DefaultBoundedRangeModel) model;
+
+		// remove all listeners
+		ChangeListener[] changeListeners = m.getChangeListeners();
+		for( ChangeListener l : changeListeners )
+			m.removeChangeListener( l );
+
+		try {
+			r.run();
+		} finally {
+			// add all listeners
+			for( ChangeListener l : changeListeners )
+				m.addChangeListener( l );
+		}
 	}
 
 	//---- class ScrollBarHoverListener ---------------------------------------

--- a/flatlaf-demo/src/main/java/com/formdev/flatlaf/demo/DemoFrame.java
+++ b/flatlaf-demo/src/main/java/com/formdev/flatlaf/demo/DemoFrame.java
@@ -106,6 +106,10 @@ class DemoFrame
 		repaint();
 	}
 
+	private void smoothScrollingChanged() {
+		UIManager.put( "ScrollPane.smoothScrolling", smoothScrollingMenuItem.isSelected() );
+	}
+
 	private void animatedLafChangeChanged() {
 		System.setProperty( "flatlaf.animatedLafChange", String.valueOf( animatedLafChangeMenuItem.isSelected() ) );
 	}
@@ -256,6 +260,7 @@ class DemoFrame
 		menuBarEmbeddedCheckBoxMenuItem = new JCheckBoxMenuItem();
 		underlineMenuSelectionMenuItem = new JCheckBoxMenuItem();
 		alwaysShowMnemonicsMenuItem = new JCheckBoxMenuItem();
+		smoothScrollingMenuItem = new JCheckBoxMenuItem();
 		animatedLafChangeMenuItem = new JCheckBoxMenuItem();
 		JMenu helpMenu = new JMenu();
 		JMenuItem aboutMenuItem = new JMenuItem();
@@ -511,6 +516,12 @@ class DemoFrame
 				alwaysShowMnemonicsMenuItem.addActionListener(e -> alwaysShowMnemonics());
 				optionsMenu.add(alwaysShowMnemonicsMenuItem);
 
+				//---- smoothScrollingMenuItem ----
+				smoothScrollingMenuItem.setText("Smooth Scrolling");
+				smoothScrollingMenuItem.setSelected(true);
+				smoothScrollingMenuItem.addActionListener(e -> smoothScrollingChanged());
+				optionsMenu.add(smoothScrollingMenuItem);
+
 				//---- animatedLafChangeMenuItem ----
 				animatedLafChangeMenuItem.setText("Animated Laf Change");
 				animatedLafChangeMenuItem.setSelected(true);
@@ -635,6 +646,7 @@ class DemoFrame
 	private JCheckBoxMenuItem menuBarEmbeddedCheckBoxMenuItem;
 	private JCheckBoxMenuItem underlineMenuSelectionMenuItem;
 	private JCheckBoxMenuItem alwaysShowMnemonicsMenuItem;
+	private JCheckBoxMenuItem smoothScrollingMenuItem;
 	private JCheckBoxMenuItem animatedLafChangeMenuItem;
 	private JTabbedPane tabbedPane;
 	private ControlBar controlBar;

--- a/flatlaf-demo/src/main/java/com/formdev/flatlaf/demo/DemoFrame.jfd
+++ b/flatlaf-demo/src/main/java/com/formdev/flatlaf/demo/DemoFrame.jfd
@@ -357,6 +357,15 @@ new FormModel {
 						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "alwaysShowMnemonics", false ) )
 					} )
 					add( new FormComponent( "javax.swing.JCheckBoxMenuItem" ) {
+						name: "smoothScrollingMenuItem"
+						"text": "Smooth Scrolling"
+						"selected": true
+						auxiliary() {
+							"JavaCodeGenerator.variableLocal": false
+						}
+						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "smoothScrollingChanged", false ) )
+					} )
+					add( new FormComponent( "javax.swing.JCheckBoxMenuItem" ) {
 						name: "animatedLafChangeMenuItem"
 						"text": "Animated Laf Change"
 						"selected": true


### PR DESCRIPTION
This PR adds smooth scrolling, as used in modern Web browsers, to FlatLaf. (issue #50)

Instead of simply painting scroll pane content at new view position, smooth scrolling animates the painting so that it looks like the content is "moving" to the new view position.

![ssc2](https://user-images.githubusercontent.com/5604048/89313691-20ecd400-d679-11ea-974f-6a42a70249d2.gif)

Please **try this with real world applications** (on various platforms if possible) and give feedback. Thanks.


Current state:

- rotating mouse wheel does smooth scrolling
- clicking on scroll bar track (or arrows if visible) does smooth scrolling
- smooth scrolling with keys (e.g. PageUp) not implemented

Smooth scrolling is enabled by default.

Can be disabled for the whole application (at any time) with (e.g. via some Settings dialog):
~~~java
UIManager.put( "ScrollPane.smoothScrolling", false );
~~~

Can be disabled for single scroll panes (at any time) with:
~~~java
myScrollPane.putClientProperty( "JScrollPane.smoothScrolling", false );
~~~

It is also possible to customize the animation by changing the duration of the scroll animation and the resolution (time between repaints). Both values are in milliseconds. E.g.
~~~java
UIManager.put( "ScrollPane.smoothScrolling.duration", 500 );
UIManager.put( "ScrollPane.smoothScrolling.resolution", 20 );
~~~
Default duration is 200ms and default resolution is 10ms.