### PR TITLE
Tabbedpane "Show Hidden Tabs" button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ FlatLaf Change Log
 
 #### New features and improvements
 
+- TabbedPane: Replaced forward/backward scrolling arrow buttons with "Show
+  Hidden Tabs" button. If pressed, it shows a popup menu that contains (partly)
+  hidden tabs and selecting one activates that tab. If you prefer
+  forward/backward buttons, use `UIManager.put(
+  "TabbedPane.hiddenTabsNavigation", "arrowButtons" )`. (issue #40)
 - TabbedPane: Support scrolling tabs with mouse wheel (if `tabLayoutPolicy` is
   `SCROLL_TAB_LAYOUT`). (issue #40)
 - TabbedPane: Repeat scrolling as long as arrow buttons are pressed. (issue #40)

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/FlatClientProperties.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/FlatClientProperties.java
@@ -241,6 +241,30 @@ public interface FlatClientProperties
 	String TABBED_PANE_TAB_HEIGHT = "JTabbedPane.tabHeight";
 
 	/**
+	 * Specifies how to navigate to hidden tabs.
+	 * <p>
+	 * <strong>Component</strong> {@link javax.swing.JTabbedPane}<br>
+	 * <strong>Value type</strong> {@link java.lang.String}
+	 * <strong>Allowed Values</strong> {@link #TABBED_PANE_HIDDEN_TABS_NAVIGATION_MORE_TABS_BUTTON}
+	 * or {@link #TABBED_PANE_HIDDEN_TABS_NAVIGATION_ARROW_BUTTONS}
+	 */
+	String TABBED_PANE_HIDDEN_TABS_NAVIGATION = "JTabbedPane.hiddenTabsNavigation";
+
+	/**
+	 * Use "more tabs" button for navigation to hidden tabs.
+	 *
+	 * @see #TABBED_PANE_HIDDEN_TABS_NAVIGATION
+	 */
+	String TABBED_PANE_HIDDEN_TABS_NAVIGATION_MORE_TABS_BUTTON = "moreTabsButton";
+
+	/**
+	 * Use forward/backward buttons for navigation to hidden tabs.
+	 *
+	 * @see #TABBED_PANE_HIDDEN_TABS_NAVIGATION
+	 */
+	String TABBED_PANE_HIDDEN_TABS_NAVIGATION_ARROW_BUTTONS = "arrowButtons";
+
+	/**
 	 * Specifies whether all text is selected when the text component gains focus.
 	 * <p>
 	 * <strong>Component</strong> {@link javax.swing.JTextField} (and subclasses)<br>

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatTabbedPaneUI.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatTabbedPaneUI.java
@@ -435,6 +435,21 @@ public class FlatTabbedPaneUI
 		return Math.max( tabHeight, super.calculateTabHeight( tabPlacement, tabIndex, fontHeight ) - 2 /* was added by superclass */ );
 	}
 
+	@Override
+	protected Insets getTabAreaInsets( int tabPlacement ) {
+		Insets currentTabAreaInsets = super.getTabAreaInsets( tabPlacement );
+		Insets insets = (Insets) currentTabAreaInsets.clone();
+
+		// This is a "trick" to get rid of the cropped edge:
+		//     super.getTabAreaInsets() returns private field BasicTabbedPaneUI.currentTabAreaInsets,
+		//     which is also used to translate the origin of the cropped edge in
+		//     BasicTabbedPaneUI.CroppedEdge.paintComponent().
+		//     Giving it large values clips painting of the cropped edge and makes it invisible.
+		currentTabAreaInsets.top = currentTabAreaInsets.left = -10000;
+
+		return insets;
+	}
+
 	/**
 	 * The content border insets are used to create a separator between tabs and content.
 	 * If client property JTabbedPane.hasFullBorder is true, then the content border insets

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatTabbedPaneUI.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatTabbedPaneUI.java
@@ -71,6 +71,7 @@ import javax.swing.text.View;
 import com.formdev.flatlaf.FlatLaf;
 import com.formdev.flatlaf.util.Animator;
 import com.formdev.flatlaf.util.CubicBezierEasing;
+import com.formdev.flatlaf.util.JavaCompatibility;
 import com.formdev.flatlaf.util.UIScale;
 
 /**
@@ -495,6 +496,20 @@ public class FlatTabbedPaneUI
 		if( view != null ) {
 			view.paint( g, textRect );
 			return;
+		}
+
+		// clip title if "more tabs" button is used
+		// (normally this is done by invoker, but fails in this case)
+		if( hiddenTabsNavigation == MORE_TABS_BUTTON &&
+			tabViewport != null &&
+			(tabPlacement == TOP || tabPlacement == BOTTOM) )
+		{
+			Rectangle viewRect = tabViewport.getViewRect();
+			viewRect.width -= 4; // subtract width of cropped edge
+			if( !viewRect.contains( textRect ) ) {
+				Rectangle r = viewRect.intersection( textRect );
+				title = JavaCompatibility.getClippedString( null, metrics, title, r.width );
+			}
 		}
 
 		// plain text

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatTabbedPaneUI.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatTabbedPaneUI.java
@@ -188,7 +188,6 @@ public class FlatTabbedPaneUI
 		} else
 			super.installDefaults();
 
-
 		disabledForeground = UIManager.getColor( "TabbedPane.disabledForeground" );
 		selectedBackground = UIManager.getColor( "TabbedPane.selectedBackground" );
 		selectedForeground = UIManager.getColor( "TabbedPane.selectedForeground" );
@@ -508,7 +507,8 @@ public class FlatTabbedPaneUI
 			viewRect.width -= 4; // subtract width of cropped edge
 			if( !viewRect.contains( textRect ) ) {
 				Rectangle r = viewRect.intersection( textRect );
-				title = JavaCompatibility.getClippedString( null, metrics, title, r.width );
+				if( r.x > viewRect.x )
+					title = JavaCompatibility.getClippedString( null, metrics, title, r.width );
 			}
 		}
 

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/util/JavaCompatibility.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/util/JavaCompatibility.java
@@ -16,6 +16,7 @@
 
 package com.formdev.flatlaf.util;
 
+import java.awt.FontMetrics;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
 import java.lang.reflect.InvocationTargetException;
@@ -27,7 +28,7 @@ import com.formdev.flatlaf.FlatLaf;
 
 /**
  * Provides Java version compatibility methods.
- *
+ * <p>
  * WARNING: This is private API and may change.
  *
  * @author Karl Tauber
@@ -35,10 +36,12 @@ import com.formdev.flatlaf.FlatLaf;
 public class JavaCompatibility
 {
 	private static Method drawStringUnderlineCharAtMethod;
+	private static Method getClippedStringMethod;
 
 	/**
 	 * Java 8: sun.swing.SwingUtilities2.drawStringUnderlineCharAt( JComponent c,
 	 *				Graphics g, String text, int underlinedIndex, int x, int y )
+	 * <br>
 	 * Java 9: javax.swing.plaf.basic.BasicGraphicsUtils.drawStringUnderlineCharAt( JComponent c,
 	 *				Graphics2D g, String string, int underlinedIndex, float x, float y )
 	 */
@@ -66,6 +69,39 @@ public class JavaCompatibility
 				drawStringUnderlineCharAtMethod.invoke( null, c, g, text, underlinedIndex, (float) x, (float) y );
 			else
 				drawStringUnderlineCharAtMethod.invoke( null, c, g, text, underlinedIndex, x, y );
+		} catch( IllegalAccessException | IllegalArgumentException | InvocationTargetException ex ) {
+			Logger.getLogger( FlatLaf.class.getName() ).log( Level.SEVERE, null, ex );
+			throw new RuntimeException( ex );
+		}
+	}
+
+	/**
+	 * Java 8: sun.swing.SwingUtilities2.clipStringIfNecessary( JComponent c,
+	 *				FontMetrics fm, String string, int availTextWidth )
+	 * <br>
+	 * Java 9: javax.swing.plaf.basic.BasicGraphicsUtils.getClippedString( JComponent c,
+	 *				FontMetrics fm, String string, int availTextWidth )
+	 */
+	public static String getClippedString( JComponent c, FontMetrics fm, String string, int availTextWidth ) {
+		synchronized( JavaCompatibility.class ) {
+			if( getClippedStringMethod == null ) {
+				try {
+					Class<?> cls = Class.forName( SystemInfo.isJava_9_orLater
+						? "javax.swing.plaf.basic.BasicGraphicsUtils"
+						: "sun.swing.SwingUtilities2" );
+					getClippedStringMethod = cls.getMethod( SystemInfo.isJava_9_orLater
+							? "getClippedString"
+							: "clipStringIfNecessary",
+						new Class[] { JComponent.class, FontMetrics.class, String.class, int.class } );
+				} catch( Exception ex ) {
+					Logger.getLogger( FlatLaf.class.getName() ).log( Level.SEVERE, null, ex );
+					throw new RuntimeException( ex );
+				}
+			}
+		}
+
+		try {
+			return (String) getClippedStringMethod.invoke( null, c, fm, string, availTextWidth );
 		} catch( IllegalAccessException | IllegalArgumentException | InvocationTargetException ex ) {
 			Logger.getLogger( FlatLaf.class.getName() ).log( Level.SEVERE, null, ex );
 			throw new RuntimeException( ex );

--- a/flatlaf-core/src/main/resources/com/formdev/flatlaf/FlatLaf.properties
+++ b/flatlaf-core/src/main/resources/com/formdev/flatlaf/FlatLaf.properties
@@ -546,10 +546,11 @@ TabbedPane.tabInsets=4,12,4,12
 TabbedPane.tabAreaInsets=0,0,0,0
 TabbedPane.selectedTabPadInsets=0,0,0,0
 TabbedPane.tabRunOverlay=0
-TabbedPane.tabsOverlapBorder=true
+TabbedPane.tabsOverlapBorder=false
 TabbedPane.disabledForeground=@disabledText
 TabbedPane.shadow=@background
 TabbedPane.contentBorderInsets=null
+TabbedPane.hiddenTabsNavigation=moreTabsButton
 
 
 #---- Table ----

--- a/flatlaf-core/src/main/resources/com/formdev/flatlaf/resources/Bundle.properties
+++ b/flatlaf-core/src/main/resources/com/formdev/flatlaf/resources/Bundle.properties
@@ -46,3 +46,8 @@ FileChooser.refreshActionLabelText=Refresh
 FileChooser.newFolderActionLabelText=New Folder
 FileChooser.listViewActionLabelText=List
 FileChooser.detailsViewActionLabelText=Details
+
+
+#---- TabbedPane ----
+
+TabbedPane.moreTabsButtonToolTipText=Show Hidden Tabs

--- a/flatlaf-core/src/main/resources/com/formdev/flatlaf/resources/Bundle_de.properties
+++ b/flatlaf-core/src/main/resources/com/formdev/flatlaf/resources/Bundle_de.properties
@@ -46,3 +46,8 @@ FileChooser.refreshActionLabelText=Aktualisieren
 FileChooser.newFolderActionLabelText=Neuer Ordner
 FileChooser.listViewActionLabelText=Liste
 FileChooser.detailsViewActionLabelText=Details
+
+
+#---- TabbedPane ----
+
+TabbedPane.moreTabsButtonToolTipText=Verdeckte Tabs anzeigen

--- a/flatlaf-testing/dumps/uidefaults/FlatDarkLaf_1.8.0_202.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatDarkLaf_1.8.0_202.txt
@@ -916,6 +916,7 @@ TabbedPane.focusColor          #3d4b5c    javax.swing.plaf.ColorUIResource [UI]
 TabbedPane.font                [active] $defaultFont [UI]
 TabbedPane.foreground          #bbbbbb    javax.swing.plaf.ColorUIResource [UI]
 TabbedPane.hasFullBorder       false
+TabbedPane.hiddenTabsNavigation moreTabsButton
 TabbedPane.highlight           #242424    javax.swing.plaf.ColorUIResource [UI]
 TabbedPane.hoverColor          #2e3133    javax.swing.plaf.ColorUIResource [UI]
 TabbedPane.labelShift          1
@@ -932,7 +933,7 @@ TabbedPane.tabRunOverlay       0
 TabbedPane.tabSelectionHeight  3
 TabbedPane.tabSeparatorsFullHeight false
 TabbedPane.tabsOpaque          true
-TabbedPane.tabsOverlapBorder   true
+TabbedPane.tabsOverlapBorder   false
 TabbedPane.textIconGap         4
 TabbedPane.underlineColor      #4a88c7    javax.swing.plaf.ColorUIResource [UI]
 TabbedPaneUI                   com.formdev.flatlaf.ui.FlatTabbedPaneUI

--- a/flatlaf-testing/dumps/uidefaults/FlatLightLaf_1.8.0_202.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatLightLaf_1.8.0_202.txt
@@ -921,6 +921,7 @@ TabbedPane.focusColor          #dae4ed    javax.swing.plaf.ColorUIResource [UI]
 TabbedPane.font                [active] $defaultFont [UI]
 TabbedPane.foreground          #000000    javax.swing.plaf.ColorUIResource [UI]
 TabbedPane.hasFullBorder       false
+TabbedPane.hiddenTabsNavigation moreTabsButton
 TabbedPane.highlight           #ffffff    javax.swing.plaf.ColorUIResource [UI]
 TabbedPane.hoverColor          #d9d9d9    javax.swing.plaf.ColorUIResource [UI]
 TabbedPane.labelShift          1
@@ -937,7 +938,7 @@ TabbedPane.tabRunOverlay       0
 TabbedPane.tabSelectionHeight  3
 TabbedPane.tabSeparatorsFullHeight false
 TabbedPane.tabsOpaque          true
-TabbedPane.tabsOverlapBorder   true
+TabbedPane.tabsOverlapBorder   false
 TabbedPane.textIconGap         4
 TabbedPane.underlineColor      #4083c9    javax.swing.plaf.ColorUIResource [UI]
 TabbedPaneUI                   com.formdev.flatlaf.ui.FlatTabbedPaneUI

--- a/flatlaf-testing/dumps/uidefaults/FlatTestLaf_1.8.0_202.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatTestLaf_1.8.0_202.txt
@@ -909,6 +909,7 @@ TabbedPane.focusColor          #dddddd    javax.swing.plaf.ColorUIResource [UI]
 TabbedPane.font                [active] $defaultFont [UI]
 TabbedPane.foreground          #ff0000    javax.swing.plaf.ColorUIResource [UI]
 TabbedPane.hasFullBorder       false
+TabbedPane.hiddenTabsNavigation moreTabsButton
 TabbedPane.highlight           #ffffff    javax.swing.plaf.ColorUIResource [UI]
 TabbedPane.hoverColor          #eeeeee    javax.swing.plaf.ColorUIResource [UI]
 TabbedPane.labelShift          1
@@ -928,7 +929,7 @@ TabbedPane.tabSelectionHeight  3
 TabbedPane.tabSeparatorColor   #0000ff    javax.swing.plaf.ColorUIResource [UI]
 TabbedPane.tabSeparatorsFullHeight false
 TabbedPane.tabsOpaque          true
-TabbedPane.tabsOverlapBorder   true
+TabbedPane.tabsOverlapBorder   false
 TabbedPane.textIconGap         4
 TabbedPane.underlineColor      #4a88c7    javax.swing.plaf.ColorUIResource [UI]
 TabbedPaneUI                   com.formdev.flatlaf.ui.FlatTabbedPaneUI

--- a/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatContainerTest.java
+++ b/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatContainerTest.java
@@ -215,6 +215,27 @@ public class FlatContainerTest
 		return tab;
 	}
 
+	private void tabPlacementChanged() {
+		int tabPlacement = -1;
+		switch( (String) tabPlacementField.getSelectedItem() ) {
+			case "top":		tabPlacement = SwingConstants.TOP; break;
+			case "bottom":	tabPlacement = SwingConstants.BOTTOM; break;
+			case "left":	tabPlacement = SwingConstants.LEFT; break;
+			case "right":	tabPlacement = SwingConstants.RIGHT; break;
+		}
+
+		tabbedPane1.setTabPlacement( (tabPlacement >= 0) ? tabPlacement : SwingConstants.TOP );
+		tabbedPane2.setTabPlacement( (tabPlacement >= 0) ? tabPlacement : SwingConstants.BOTTOM );
+		tabbedPane3.setTabPlacement( (tabPlacement >= 0) ? tabPlacement : SwingConstants.LEFT );
+		tabbedPane4.setTabPlacement( (tabPlacement >= 0) ? tabPlacement : SwingConstants.RIGHT );
+	}
+
+	private void tabBackForegroundChanged() {
+		boolean enabled = tabBackForegroundCheckBox.isSelected();
+		tabbedPane1.setBackgroundAt( 0, enabled ? Color.red : null );
+		tabbedPane1.setForegroundAt( 1, enabled ? Color.red : null );
+	}
+
 	private void initComponents() {
 		// JFormDesigner - Component initialization - DO NOT MODIFY  //GEN-BEGIN:initComponents
 		JPanel panel9 = new JPanel();
@@ -244,6 +265,9 @@ public class FlatContainerTest
 		customBorderCheckBox = new JCheckBox();
 		customTabsCheckBox = new JCheckBox();
 		hasFullBorderCheckBox = new JCheckBox();
+		JLabel tabPlacementLabel = new JLabel();
+		tabPlacementField = new JComboBox<>();
+		tabBackForegroundCheckBox = new JCheckBox();
 		CellConstraints cc = new CellConstraints();
 
 		//======== this ========
@@ -356,6 +380,7 @@ public class FlatContainerTest
 					"[fill]",
 					// rows
 					"[center]" +
+					"[]" +
 					"[]"));
 
 				//---- moreTabsCheckBox ----
@@ -411,6 +436,26 @@ public class FlatContainerTest
 				hasFullBorderCheckBox.setText("Show content border");
 				hasFullBorderCheckBox.addActionListener(e -> hasFullBorderChanged());
 				panel14.add(hasFullBorderCheckBox, "cell 4 1,alignx left,growx 0");
+
+				//---- tabPlacementLabel ----
+				tabPlacementLabel.setText("Tab placement:");
+				panel14.add(tabPlacementLabel, "cell 0 2");
+
+				//---- tabPlacementField ----
+				tabPlacementField.setModel(new DefaultComboBoxModel<>(new String[] {
+					"default",
+					"top",
+					"bottom",
+					"left",
+					"right"
+				}));
+				tabPlacementField.addActionListener(e -> tabPlacementChanged());
+				panel14.add(tabPlacementField, "cell 1 2");
+
+				//---- tabBackForegroundCheckBox ----
+				tabBackForegroundCheckBox.setText("Tab back/foreground");
+				tabBackForegroundCheckBox.addActionListener(e -> tabBackForegroundChanged());
+				panel14.add(tabBackForegroundCheckBox, "cell 4 2");
 			}
 			panel9.add(panel14, cc.xywh(1, 11, 3, 1));
 		}
@@ -433,6 +478,8 @@ public class FlatContainerTest
 	private JCheckBox customBorderCheckBox;
 	private JCheckBox customTabsCheckBox;
 	private JCheckBox hasFullBorderCheckBox;
+	private JComboBox<String> tabPlacementField;
+	private JCheckBox tabBackForegroundCheckBox;
 	// JFormDesigner - End of variables declaration  //GEN-END:variables
 
 	//---- class Tab1Panel ----------------------------------------------------

--- a/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatContainerTest.java
+++ b/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatContainerTest.java
@@ -38,6 +38,7 @@ public class FlatContainerTest
 	public static void main( String[] args ) {
 		SwingUtilities.invokeLater( () -> {
 			FlatTestFrame frame = FlatTestFrame.create( args, "FlatContainerTest" );
+			frame.useApplyComponentOrientation = true;
 			frame.showFrame( FlatContainerTest::new );
 		} );
 	}
@@ -115,7 +116,7 @@ public class FlatContainerTest
 			for( int i = oldTabCount + 1; i <= newTabCount; i++ )
 				addTab( tabbedPane, "Tab " + i, "tab content " + i );
 		} else if( newTabCount < oldTabCount ) {
-			while( tabbedPane.getTabCount() > 4 )
+			while( tabbedPane.getTabCount() > newTabCount )
 				tabbedPane.removeTabAt( tabbedPane.getTabCount() - 1 );
 		}
 	}
@@ -171,7 +172,7 @@ public class FlatContainerTest
 
 	private void customBorderChanged() {
 		Border border = customBorderCheckBox.isSelected()
-			? new LineBorder( Color.magenta, 20 )
+			? new MatteBorder( 10, 20, 25, 35, Color.green )
 			: null;
 
 		tabbedPane1.setBorder( border );

--- a/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatContainerTest.java
+++ b/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatContainerTest.java
@@ -16,9 +16,7 @@
 
 package com.formdev.flatlaf.testing;
 
-import static com.formdev.flatlaf.FlatClientProperties.TABBED_PANE_HAS_FULL_BORDER;
-import static com.formdev.flatlaf.FlatClientProperties.TABBED_PANE_SHOW_CONTENT_SEPARATOR;
-import static com.formdev.flatlaf.FlatClientProperties.TABBED_PANE_SHOW_TAB_SEPARATORS;
+import static com.formdev.flatlaf.FlatClientProperties.*;
 import java.awt.*;
 import javax.swing.*;
 import javax.swing.border.*;
@@ -230,6 +228,19 @@ public class FlatContainerTest
 		tabbedPane4.setTabPlacement( (tabPlacement >= 0) ? tabPlacement : SwingConstants.RIGHT );
 	}
 
+	private void hiddenTabsNavigationChanged() {
+		String value = null;
+		switch( (String) hiddenTabsNavigationField.getSelectedItem() ) {
+			case "moreTabsButton":	value = TABBED_PANE_HIDDEN_TABS_NAVIGATION_MORE_TABS_BUTTON; break;
+			case "arrowButtons":	value = TABBED_PANE_HIDDEN_TABS_NAVIGATION_ARROW_BUTTONS; break;
+		}
+
+		tabbedPane1.putClientProperty( TABBED_PANE_HIDDEN_TABS_NAVIGATION, value );
+		tabbedPane2.putClientProperty( TABBED_PANE_HIDDEN_TABS_NAVIGATION, value );
+		tabbedPane3.putClientProperty( TABBED_PANE_HIDDEN_TABS_NAVIGATION, value );
+		tabbedPane4.putClientProperty( TABBED_PANE_HIDDEN_TABS_NAVIGATION, value );
+	}
+
 	private void tabBackForegroundChanged() {
 		boolean enabled = tabBackForegroundCheckBox.isSelected();
 		tabbedPane1.setBackgroundAt( 0, enabled ? Color.red : null );
@@ -267,6 +278,8 @@ public class FlatContainerTest
 		hasFullBorderCheckBox = new JCheckBox();
 		JLabel tabPlacementLabel = new JLabel();
 		tabPlacementField = new JComboBox<>();
+		JLabel hiddenTabsNavigationLabel = new JLabel();
+		hiddenTabsNavigationField = new JComboBox<>();
 		tabBackForegroundCheckBox = new JCheckBox();
 		CellConstraints cc = new CellConstraints();
 
@@ -452,6 +465,19 @@ public class FlatContainerTest
 				tabPlacementField.addActionListener(e -> tabPlacementChanged());
 				panel14.add(tabPlacementField, "cell 1 2");
 
+				//---- hiddenTabsNavigationLabel ----
+				hiddenTabsNavigationLabel.setText("Hidden tabs navigation:");
+				panel14.add(hiddenTabsNavigationLabel, "cell 2 2");
+
+				//---- hiddenTabsNavigationField ----
+				hiddenTabsNavigationField.setModel(new DefaultComboBoxModel<>(new String[] {
+					"default",
+					"moreTabsButton",
+					"arrowButtons"
+				}));
+				hiddenTabsNavigationField.addActionListener(e -> hiddenTabsNavigationChanged());
+				panel14.add(hiddenTabsNavigationField, "cell 3 2");
+
 				//---- tabBackForegroundCheckBox ----
 				tabBackForegroundCheckBox.setText("Tab back/foreground");
 				tabBackForegroundCheckBox.addActionListener(e -> tabBackForegroundChanged());
@@ -479,6 +505,7 @@ public class FlatContainerTest
 	private JCheckBox customTabsCheckBox;
 	private JCheckBox hasFullBorderCheckBox;
 	private JComboBox<String> tabPlacementField;
+	private JComboBox<String> hiddenTabsNavigationField;
 	private JCheckBox tabBackForegroundCheckBox;
 	// JFormDesigner - End of variables declaration  //GEN-END:variables
 

--- a/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatContainerTest.jfd
+++ b/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatContainerTest.jfd
@@ -132,7 +132,7 @@ new FormModel {
 				add( new FormContainer( "javax.swing.JPanel", new FormLayoutManager( class net.miginfocom.swing.MigLayout ) {
 					"$layoutConstraints": "insets 0,hidemode 3"
 					"$columnConstraints": "[][fill][][][fill]"
-					"$rowConstraints": "[center][]"
+					"$rowConstraints": "[center][][]"
 				} ) {
 					name: "panel14"
 					"opaque": false
@@ -251,6 +251,40 @@ new FormModel {
 					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
 						"value": "cell 4 1,alignx left,growx 0"
 					} )
+					add( new FormComponent( "javax.swing.JLabel" ) {
+						name: "tabPlacementLabel"
+						"text": "Tab placement:"
+					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+						"value": "cell 0 2"
+					} )
+					add( new FormComponent( "javax.swing.JComboBox" ) {
+						name: "tabPlacementField"
+						"model": new javax.swing.DefaultComboBoxModel {
+							selectedItem: "default"
+							addElement( "default" )
+							addElement( "top" )
+							addElement( "bottom" )
+							addElement( "left" )
+							addElement( "right" )
+						}
+						auxiliary() {
+							"JavaCodeGenerator.variableLocal": false
+							"JavaCodeGenerator.typeParameters": "String"
+						}
+						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "tabPlacementChanged", false ) )
+					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+						"value": "cell 1 2"
+					} )
+					add( new FormComponent( "javax.swing.JCheckBox" ) {
+						name: "tabBackForegroundCheckBox"
+						"text": "Tab back/foreground"
+						auxiliary() {
+							"JavaCodeGenerator.variableLocal": false
+						}
+						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "tabBackForegroundChanged", false ) )
+					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+						"value": "cell 4 2"
+					} )
 				}, new FormLayoutConstraints( class com.jgoodies.forms.layout.CellConstraints ) {
 					"gridY": 11
 					"gridWidth": 3
@@ -260,7 +294,7 @@ new FormModel {
 			} )
 		}, new FormLayoutConstraints( null ) {
 			"location": new java.awt.Point( 0, 0 )
-			"size": new java.awt.Dimension( 810, 515 )
+			"size": new java.awt.Dimension( 810, 570 )
 		} )
 		add( new FormContainer( "javax.swing.JPanel", new FormLayoutManager( class net.miginfocom.swing.MigLayout ) {
 			"$layoutConstraints": "hidemode 3,align center center"

--- a/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatContainerTest.jfd
+++ b/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatContainerTest.jfd
@@ -275,6 +275,28 @@ new FormModel {
 					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
 						"value": "cell 1 2"
 					} )
+					add( new FormComponent( "javax.swing.JLabel" ) {
+						name: "hiddenTabsNavigationLabel"
+						"text": "Hidden tabs navigation:"
+					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+						"value": "cell 2 2"
+					} )
+					add( new FormComponent( "javax.swing.JComboBox" ) {
+						name: "hiddenTabsNavigationField"
+						"model": new javax.swing.DefaultComboBoxModel {
+							selectedItem: "default"
+							addElement( "default" )
+							addElement( "moreTabsButton" )
+							addElement( "arrowButtons" )
+						}
+						auxiliary() {
+							"JavaCodeGenerator.variableLocal": false
+							"JavaCodeGenerator.typeParameters": "String"
+						}
+						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "hiddenTabsNavigationChanged", false ) )
+					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+						"value": "cell 3 2"
+					} )
 					add( new FormComponent( "javax.swing.JCheckBox" ) {
 						name: "tabBackForegroundCheckBox"
 						"text": "Tab back/foreground"

--- a/flatlaf-theme-editor/src/main/resources/com/formdev/flatlaf/themeeditor/FlatLafUIKeys.txt
+++ b/flatlaf-theme-editor/src/main/resources/com/formdev/flatlaf/themeeditor/FlatLafUIKeys.txt
@@ -646,6 +646,7 @@ TabbedPane.focusInputMap
 TabbedPane.font
 TabbedPane.foreground
 TabbedPane.hasFullBorder
+TabbedPane.hiddenTabsNavigation
 TabbedPane.highlight
 TabbedPane.hoverColor
 TabbedPane.labelShift


### PR DESCRIPTION
This PR replaces forward/backward scrolling arrow buttons with a "Show Hidden Tabs" button.
If pressed, it shows a popup menu that contains (partly) hidden tabs and selecting one activates that tab.

![image](https://user-images.githubusercontent.com/5604048/96129277-b668d780-0ef6-11eb-8adf-214ea70387a1.png)

Leading and trailing hidden tabs are separated with a line in the popup menu.

Custom tab components (set with `JTabbedPane.setTabComponentAt(int index, Component component)`)
are **not** used in the popup menu. So make sure that the tab title is also set.

If you prefer forward/backward buttons, use 
~~~java
UIManager.put( "TabbedPane.hiddenTabsNavigation", "arrowButtons" );
~~~

It is also possible to specify hiddenTabsNavigation type per tabbedpane via client property:

~~~java
myTabbedPane.putClientProperty( "JTabbedPane.hiddenTabsNavigation", "moreTabsButton" );
or
myTabbedPane.putClientProperty( "JTabbedPane.hiddenTabsNavigation", "arrowButtons" );
~~~

This is part of TabbedPane improvements as discussed in issue https://github.com/JFormDesigner/FlatLaf/issues/40#issuecomment-573681056.

CC @smileatom @Chrriis