### PR TITLE
TabbedPane custom components on left and right sides of tabs area

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ FlatLaf Change Log
 - TabbedPane: Support scrolling tabs with mouse wheel (if `tabLayoutPolicy` is
   `SCROLL_TAB_LAYOUT`). (issue #40)
 - TabbedPane: Repeat scrolling as long as arrow buttons are pressed. (issue #40)
+- TabbedPane: Support adding custom components to left and right sides of tabs
+  area. (set client property `JTabbedPane.leadingComponent` or
+  `JTabbedPane.trailingComponent` to a `java.awt.Component`) (issue #40)
 - Support painting separator line between window title and content (use UI value
   `TitlePane.borderColor`). (issue #184)
 

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/FlatClientProperties.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/FlatClientProperties.java
@@ -265,6 +265,22 @@ public interface FlatClientProperties
 	String TABBED_PANE_HIDDEN_TABS_NAVIGATION_ARROW_BUTTONS = "arrowButtons";
 
 	/**
+	 * Specifies a component that will be placed at the leading edge of the tabs area.
+	 * <p>
+	 * <strong>Component</strong> {@link javax.swing.JTabbedPane}<br>
+	 * <strong>Value type</strong> {@link java.awt.Component}
+	 */
+	String TABBED_PANE_LEADING_COMPONENT = "JTabbedPane.leadingComponent";
+
+	/**
+	 * Specifies a component that will be placed at the trailing edge of the tabs area.
+	 * <p>
+	 * <strong>Component</strong> {@link javax.swing.JTabbedPane}<br>
+	 * <strong>Value type</strong> {@link java.awt.Component}
+	 */
+	String TABBED_PANE_TRAILING_COMPONENT = "JTabbedPane.trailingComponent";
+
+	/**
 	 * Specifies whether all text is selected when the text component gains focus.
 	 * <p>
 	 * <strong>Component</strong> {@link javax.swing.JTextField} (and subclasses)<br>

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatTabbedPaneUI.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatTabbedPaneUI.java
@@ -1435,7 +1435,7 @@ public class FlatTabbedPaneUI
 	//---- class FlatTabbedPaneScrollLayout -----------------------------------
 
 	/**
-	 * Layout manager used if "TabbedPane.hiddenTabsNavigation" is "moreTabsButton".
+	 * Layout manager used for scroll tab layout policy.
 	 * <p>
 	 * Although this class delegates all methods to the original layout manager
 	 * {@link BasicTabbedPaneUI.TabbedPaneScrollLayout}, which extends
@@ -1468,36 +1468,6 @@ public class FlatTabbedPaneUI
 		@Override
 		public void removeLayoutComponent( Component comp ) {
 			delegate.removeLayoutComponent( comp );
-		}
-
-		@Override
-		public Dimension preferredLayoutSize( Container parent ) {
-			Dimension size = delegate.preferredLayoutSize( parent );
-			size = addLayoutSize( size, leadingComponent, false );
-			size = addLayoutSize( size, trailingComponent, false );
-			return size;
-		}
-
-		@Override
-		public Dimension minimumLayoutSize( Container parent ) {
-			Dimension size = delegate.minimumLayoutSize( parent );
-			size = addLayoutSize( size, leadingComponent, true );
-			size = addLayoutSize( size, trailingComponent, true );
-			return size;
-		}
-
-		private Dimension addLayoutSize( Dimension size, Container c, boolean minimum ) {
-			if( c == null )
-				return size;
-
-			Dimension compSize = minimum ? c.getMinimumSize() : c.getPreferredSize();
-
-			size = (Dimension) size.clone();
-			if( isHorizontalTabPlacement() )
-				size.width += compSize.width;
-			else
-				size.height += compSize.height;
-			return size;
 		}
 
 		@Override

--- a/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatContainerTest.java
+++ b/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatContainerTest.java
@@ -248,6 +248,28 @@ public class FlatContainerTest
 		tabbedPane1.setForegroundAt( 1, enabled ? Color.red : null );
 	}
 
+	private void leadingComponentChanged() {
+		leadingTrailingComponentChanged( leadingComponentCheckBox.isSelected(), TABBED_PANE_LEADING_COMPONENT, "Leading", 4 );
+	}
+
+	private void trailingComponentChanged() {
+		leadingTrailingComponentChanged( trailingComponentCheckBox.isSelected(), TABBED_PANE_TRAILING_COMPONENT, "Trailing", 12 );
+	}
+
+	private void leadingTrailingComponentChanged( boolean enabled, String key, String text, int gap ) {
+		JTabbedPane[] tabbedPanes = new JTabbedPane[] { tabbedPane1, tabbedPane2, tabbedPane3, tabbedPane4 };
+		for( JTabbedPane tabbedPane : tabbedPanes ) {
+			JComponent c = null;
+			if( enabled ) {
+				c = new JLabel( text );
+				c.setOpaque( true );
+				c.setBackground( Color.cyan );
+				c.setBorder( new EmptyBorder( gap, gap, gap, gap ) );
+			}
+			tabbedPane.putClientProperty( key, c );
+		}
+	}
+
 	private void initComponents() {
 		// JFormDesigner - Component initialization - DO NOT MODIFY  //GEN-BEGIN:initComponents
 		JPanel panel9 = new JPanel();
@@ -282,6 +304,8 @@ public class FlatContainerTest
 		JLabel hiddenTabsNavigationLabel = new JLabel();
 		hiddenTabsNavigationField = new JComboBox<>();
 		tabBackForegroundCheckBox = new JCheckBox();
+		leadingComponentCheckBox = new JCheckBox();
+		trailingComponentCheckBox = new JCheckBox();
 		CellConstraints cc = new CellConstraints();
 
 		//======== this ========
@@ -395,6 +419,7 @@ public class FlatContainerTest
 					// rows
 					"[center]" +
 					"[]" +
+					"[]" +
 					"[]"));
 
 				//---- moreTabsCheckBox ----
@@ -483,6 +508,16 @@ public class FlatContainerTest
 				tabBackForegroundCheckBox.setText("Tab back/foreground");
 				tabBackForegroundCheckBox.addActionListener(e -> tabBackForegroundChanged());
 				panel14.add(tabBackForegroundCheckBox, "cell 4 2");
+
+				//---- leadingComponentCheckBox ----
+				leadingComponentCheckBox.setText("Leading");
+				leadingComponentCheckBox.addActionListener(e -> leadingComponentChanged());
+				panel14.add(leadingComponentCheckBox, "cell 0 3");
+
+				//---- trailingComponentCheckBox ----
+				trailingComponentCheckBox.setText("Trailing");
+				trailingComponentCheckBox.addActionListener(e -> trailingComponentChanged());
+				panel14.add(trailingComponentCheckBox, "cell 1 3");
 			}
 			panel9.add(panel14, cc.xywh(1, 11, 3, 1));
 		}
@@ -508,6 +543,8 @@ public class FlatContainerTest
 	private JComboBox<String> tabPlacementField;
 	private JComboBox<String> hiddenTabsNavigationField;
 	private JCheckBox tabBackForegroundCheckBox;
+	private JCheckBox leadingComponentCheckBox;
+	private JCheckBox trailingComponentCheckBox;
 	// JFormDesigner - End of variables declaration  //GEN-END:variables
 
 	//---- class Tab1Panel ----------------------------------------------------

--- a/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatContainerTest.jfd
+++ b/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatContainerTest.jfd
@@ -132,7 +132,7 @@ new FormModel {
 				add( new FormContainer( "javax.swing.JPanel", new FormLayoutManager( class net.miginfocom.swing.MigLayout ) {
 					"$layoutConstraints": "insets 0,hidemode 3"
 					"$columnConstraints": "[][fill][][][fill]"
-					"$rowConstraints": "[center][][]"
+					"$rowConstraints": "[center][][][]"
 				} ) {
 					name: "panel14"
 					"opaque": false
@@ -306,6 +306,26 @@ new FormModel {
 						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "tabBackForegroundChanged", false ) )
 					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
 						"value": "cell 4 2"
+					} )
+					add( new FormComponent( "javax.swing.JCheckBox" ) {
+						name: "leadingComponentCheckBox"
+						"text": "Leading"
+						auxiliary() {
+							"JavaCodeGenerator.variableLocal": false
+						}
+						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "leadingComponentChanged", false ) )
+					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+						"value": "cell 0 3"
+					} )
+					add( new FormComponent( "javax.swing.JCheckBox" ) {
+						name: "trailingComponentCheckBox"
+						"text": "Trailing"
+						auxiliary() {
+							"JavaCodeGenerator.variableLocal": false
+						}
+						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "trailingComponentChanged", false ) )
+					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+						"value": "cell 1 3"
 					} )
 				}, new FormLayoutConstraints( class com.jgoodies.forms.layout.CellConstraints ) {
 					"gridY": 11


### PR DESCRIPTION
This PR introduces support for adding custom components to left and right sides of tabs area.

![image](https://user-images.githubusercontent.com/5604048/96338488-b7cd0800-108e-11eb-8209-7d78fb272fcf.png)

Set client properties `JTabbedPane.leadingComponent` or `JTabbedPane.trailingComponent` on a `JTabbedPane` to add components:

~~~java
myTabbedPane.putClientProperty( "JTabbedPane.leadingComponent", new JButton( "Hello" ) );
myTabbedPane.putClientProperty( "JTabbedPane.trailingComponent", new JButton( "World" ) );
~~~

The preferred width of the added components is used, but the height is always set to the tab height.
Use an additional panel if your component should have a smaller height.

At the moment there is no gap between the leading/trailing components and the tabs.
I'm undecided whether FlatLaf should add a gap or the leading/trailing components should do (if necessary).

This is part of TabbedPane improvements as discussed in issue https://github.com/JFormDesigner/FlatLaf/issues/40#issuecomment-573681056.

CC @smileatom @Chrriis