### PR TITLE
TabbedPane closable tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ FlatLaf Change Log
 - TabbedPane: Support adding custom components to left and right sides of tabs
   area. (set client property `JTabbedPane.leadingComponent` or
   `JTabbedPane.trailingComponent` to a `java.awt.Component`) (issue #40)
-- TabbedPane: Support closable tabs. (issue #40)
+- TabbedPane: Support closable tabs. (issues #31 and #40)
 - Support painting separator line between window title and content (use UI value
   `TitlePane.borderColor`). (issue #184)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ FlatLaf Change Log
 - TabbedPane: Support adding custom components to left and right sides of tabs
   area. (set client property `JTabbedPane.leadingComponent` or
   `JTabbedPane.trailingComponent` to a `java.awt.Component`) (issue #40)
+- TabbedPane: Support closable tabs. (issue #40)
 - Support painting separator line between window title and content (use UI value
   `TitlePane.borderColor`). (issue #184)
 

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/FlatClientProperties.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/FlatClientProperties.java
@@ -25,6 +25,8 @@ import javax.swing.JComponent;
  */
 public interface FlatClientProperties
 {
+	//---- JButton ------------------------------------------------------------
+
 	/**
 	 * Specifies type of a button.
 	 * <p>
@@ -104,6 +106,8 @@ public interface FlatClientProperties
 	 */
 	String SQUARE_SIZE = "JButton.squareSize";
 
+	//---- JComponent ---------------------------------------------------------
+
 	/**
 	 * Specifies minimum width of a component.
 	 * <p>
@@ -158,6 +162,8 @@ public interface FlatClientProperties
 	 */
 	String COMPONENT_ROUND_RECT = "JComponent.roundRect";
 
+	//---- Popup --------------------------------------------------------------
+
 	/**
 	 * Specifies whether a drop shadow is painted if the component is shown in a popup
 	 * or if the component is the owner of another component that is shown in a popup.
@@ -166,6 +172,8 @@ public interface FlatClientProperties
 	 * <strong>Value type</strong> {@link java.lang.Boolean}
 	 */
 	String POPUP_DROP_SHADOW_PAINTED = "Popup.dropShadowPainted";
+
+	//---- JProgressBar -------------------------------------------------------
 
 	/**
 	 * Specifies whether the progress bar has always the larger height even if no string is painted.
@@ -183,6 +191,8 @@ public interface FlatClientProperties
 	 */
 	String PROGRESS_BAR_SQUARE = "JProgressBar.square";
 
+	//---- JRootPane ----------------------------------------------------------
+
 	/**
 	 * Specifies whether the menu bar is embedded into the title pane if custom
 	 * window decorations are enabled. Default is {@code true}.
@@ -191,6 +201,8 @@ public interface FlatClientProperties
 	 * <strong>Value type</strong> {@link java.lang.Boolean}
 	 */
 	String MENU_BAR_EMBEDDED = "JRootPane.menuBarEmbedded";
+
+	//---- JScrollBar ---------------------------------------------------------
 
 	/**
 	 * Specifies whether the decrease/increase arrow buttons of a scrollbar are shown.
@@ -207,6 +219,8 @@ public interface FlatClientProperties
 	 * <strong>Value type</strong> {@link java.lang.Boolean}
 	 */
 	String SCROLL_PANE_SMOOTH_SCROLLING = "JScrollPane.smoothScrolling";
+
+	//---- JTabbedPane --------------------------------------------------------
 
 	/**
 	 * Specifies whether separators are shown between tabs.
@@ -239,6 +253,60 @@ public interface FlatClientProperties
 	 * <strong>Value type</strong> {@link java.lang.Integer}
 	 */
 	String TABBED_PANE_TAB_HEIGHT = "JTabbedPane.tabHeight";
+
+	/**
+	 * Specifies whether tabs are closable.
+	 * If set to {@code true} on a tabbed pane component, all tabs in that tabbed pane are closable.
+	 * To make individual tabs closable, set it to {@code true} on a tab content component.
+	 * <p>
+	 * Note that you have to specify a callback (see {@link #TABBED_PANE_TAB_CLOSABLE})
+	 * that is invoked when the user clicks a tab close button.
+	 * The callback is responsible for closing the tab.
+	 * <p>
+	 * <strong>Component</strong> {@link javax.swing.JTabbedPane}
+	 * or tab content components (see {@link javax.swing.JTabbedPane#setComponentAt(int, java.awt.Component)})<br>
+	 * <strong>Value type</strong> {@link java.lang.Boolean}
+	 *
+	 * @see #TABBED_PANE_TAB_CLOSE_CALLBACK
+	 */
+	String TABBED_PANE_TAB_CLOSABLE = "JTabbedPane.tabClosable";
+
+	/**
+	 * Specifies the callback that is invoked when a tab close button is clicked.
+	 * The callback is responsible for closing the tab.
+	 * <p>
+	 * Either use a {@link java.util.function.IntConsumer} that received the tab index as parameter:
+	 * <pre>{@code
+	 * myTabbedPane.putClientProperty( "JTabbedPane.tabCloseCallback",
+	 *     (IntConsumer) tabIndex -> {
+	 *         // close tab here
+	 *     } );
+	 * }</pre>
+	 * Or use a {@link java.util.function.BiConsumer}&lt;javax.swing.JTabbedPane, Integer&gt;
+	 * that received the tabbed pane and the tab index as parameters:
+	 * <pre>{@code
+	 * myTabbedPane.putClientProperty( "JTabbedPane.tabCloseCallback",
+	 *     (BiConsumer<JTabbedPane, Integer>) (tabbedPane, tabIndex) -> {
+	 *         // close tab here
+	 *     } );
+	 * }</pre>
+	 * If you need to check whether a modifier key (e.g. Alt or Shift) was pressed
+	 * while the user clicked the tab close button, use {@link java.awt.EventQueue#getCurrentEvent}
+	 * to get current event, check whether it is a {@link java.awt.event.MouseEvent}
+	 * and invoke its methods. E.g.
+	 * <pre>{@code
+	 * AWTEvent e = EventQueue.getCurrentEvent();
+	 * boolean shift = (e instanceof MouseEvent) ? ((MouseEvent)e).isShiftDown() : false;
+	 * }</pre>
+	 * <p>
+	 * <strong>Component</strong> {@link javax.swing.JTabbedPane}
+	 * or tab content components (see {@link javax.swing.JTabbedPane#setComponentAt(int, java.awt.Component)})<br>
+	 * <strong>Value type</strong> {@link java.util.function.IntConsumer}
+	 * or {@link java.util.function.BiConsumer}&lt;javax.swing.JTabbedPane, Integer&gt;
+	 *
+	 * @see #TABBED_PANE_TAB_CLOSABLE
+	 */
+	String TABBED_PANE_TAB_CLOSE_CALLBACK = "JTabbedPane.tabCloseCallback";
 
 	/**
 	 * Specifies how to navigate to hidden tabs.
@@ -279,6 +347,8 @@ public interface FlatClientProperties
 	 * <strong>Value type</strong> {@link java.awt.Component}
 	 */
 	String TABBED_PANE_TRAILING_COMPONENT = "JTabbedPane.trailingComponent";
+
+	//---- JTextField ---------------------------------------------------------
 
 	/**
 	 * Specifies whether all text is selected when the text component gains focus.
@@ -322,6 +392,8 @@ public interface FlatClientProperties
 	 */
 	String PLACEHOLDER_TEXT = "JTextField.placeholderText";
 
+	//---- JToggleButton ------------------------------------------------------
+
 	/**
 	 * Height of underline if toggle button type is {@link #BUTTON_TYPE_TAB}.
 	 * <p>
@@ -345,6 +417,8 @@ public interface FlatClientProperties
 	 * <strong>Value type</strong> {@link java.awt.Color}
 	 */
 	String TAB_BUTTON_SELECTED_BACKGROUND = "JToggleButton.tab.selectedBackground";
+
+	//---- helper methods -----------------------------------------------------
 
 	/**
 	 * Checks whether a client property of a component has the given value.

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/FlatClientProperties.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/FlatClientProperties.java
@@ -255,6 +255,15 @@ public interface FlatClientProperties
 	String TABBED_PANE_TAB_HEIGHT = "JTabbedPane.tabHeight";
 
 	/**
+	 * Specifies the insets of a tab.
+	 * <p>
+	 * <strong>Component</strong> {@link javax.swing.JTabbedPane}
+	 * or tab content components (see {@link javax.swing.JTabbedPane#setComponentAt(int, java.awt.Component)})<br>
+	 * <strong>Value type</strong> {@link java.awt.Insets}
+	 */
+	String TABBED_PANE_TAB_INSETS = "JTabbedPane.tabInsets";
+
+	/**
 	 * Specifies whether tabs are closable.
 	 * If set to {@code true} on a tabbed pane component, all tabs in that tabbed pane are closable.
 	 * To make individual tabs closable, set it to {@code true} on a tab content component.

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/FlatClientProperties.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/FlatClientProperties.java
@@ -281,6 +281,15 @@ public interface FlatClientProperties
 	String TABBED_PANE_TAB_CLOSABLE = "JTabbedPane.tabClosable";
 
 	/**
+	 * Specifies the tooltip text used for tab close buttons.
+	 * <p>
+	 * <strong>Component</strong> {@link javax.swing.JTabbedPane}
+	 * or tab content components (see {@link javax.swing.JTabbedPane#setComponentAt(int, java.awt.Component)})<br>
+	 * <strong>Value type</strong> {@link java.lang.String}
+	 */
+	String TABBED_PANE_TAB_CLOSE_TOOLTIPTEXT = "JTabbedPane.tabCloseToolTipText";
+
+	/**
 	 * Specifies the callback that is invoked when a tab close button is clicked.
 	 * The callback is responsible for closing the tab.
 	 * <p>

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/icons/FlatTabbedPaneCloseIcon.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/icons/FlatTabbedPaneCloseIcon.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2020 FormDev Software GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.formdev.flatlaf.icons;
+
+import java.awt.BasicStroke;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.Graphics2D;
+import java.awt.geom.Line2D;
+import java.awt.geom.Path2D;
+import javax.swing.UIManager;
+import com.formdev.flatlaf.ui.FlatButtonUI;
+import com.formdev.flatlaf.ui.FlatUIUtils;
+
+/**
+ * "close" icon for closable tabs in {@link javax.swing.JTabbedPane}.
+ *
+ * @uiDefault TabbedPane.closeSize						Dimension
+ * @uiDefault TabbedPane.closeArc						int
+ * @uiDefault TabbedPane.closeCrossPlainSize			float
+ * @uiDefault TabbedPane.closeCrossFilledSize			float
+ * @uiDefault TabbedPane.closeCrossLineWidth			float
+ * @uiDefault TabbedPane.closeBackground				Color
+ * @uiDefault TabbedPane.closeForeground				Color
+ * @uiDefault TabbedPane.closeHoverBackground			Color
+ * @uiDefault TabbedPane.closeHoverForeground			Color
+ * @uiDefault TabbedPane.closePressedBackground			Color
+ * @uiDefault TabbedPane.closePressedForeground			Color
+ *
+ * @author Karl Tauber
+ */
+public class FlatTabbedPaneCloseIcon
+	extends FlatAbstractIcon
+{
+	protected final Dimension size = UIManager.getDimension( "TabbedPane.closeSize" );
+	protected final int arc = UIManager.getInt( "TabbedPane.closeArc" );
+	protected final float crossPlainSize = FlatUIUtils.getUIFloat( "TabbedPane.closeCrossPlainSize", 7.5f );
+	protected final float crossFilledSize = FlatUIUtils.getUIFloat( "TabbedPane.closeCrossFilledSize", crossPlainSize );
+	protected final float closeCrossLineWidth = FlatUIUtils.getUIFloat( "TabbedPane.closeCrossLineWidth", 1f );
+	protected final Color background = UIManager.getColor( "TabbedPane.closeBackground" );
+	protected final Color foreground = UIManager.getColor( "TabbedPane.closeForeground" );
+	protected final Color hoverBackground = UIManager.getColor( "TabbedPane.closeHoverBackground" );
+	protected final Color hoverForeground = UIManager.getColor( "TabbedPane.closeHoverForeground" );
+	protected final Color pressedBackground = UIManager.getColor( "TabbedPane.closePressedBackground" );
+	protected final Color pressedForeground = UIManager.getColor( "TabbedPane.closePressedForeground" );
+
+	public FlatTabbedPaneCloseIcon() {
+		super( 16, 16, null );
+	}
+
+	@Override
+	protected void paintIcon( Component c, Graphics2D g ) {
+		// paint background
+		Color bg = FlatButtonUI.buttonStateColor( c, background, null, null, hoverBackground, pressedBackground );
+		if( bg != null ) {
+			g.setColor( bg );
+			g.fillRoundRect( (width - size.width) / 2, (height - size.height) / 2,
+				size.width, size.height, arc, arc );
+		}
+
+		// set cross color
+		g.setColor( FlatButtonUI.buttonStateColor( c, foreground, null, null, hoverForeground, pressedForeground ) );
+
+		float mx = width / 2;
+		float my = height / 2;
+		float r = ((bg != null) ? crossFilledSize : crossPlainSize) / 2;
+
+		// paint cross
+		Path2D path = new Path2D.Float( Path2D.WIND_EVEN_ODD );
+		path.append( new Line2D.Float( mx - r, my - r, mx + r, my + r ), false );
+		path.append( new Line2D.Float( mx - r, my + r, mx + r, my - r ), false );
+		g.setStroke( new BasicStroke( closeCrossLineWidth ) );
+		g.draw( path );
+	}
+}

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatTabbedPaneUI.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatTabbedPaneUI.java
@@ -1844,6 +1844,13 @@ public class FlatTabbedPaneUI
 			if( !useMoreButton && (backwardButton == null || forwardButton == null) )
 				return; // should never occur
 
+			if( rects.length == 0 ) {
+				moreTabsButton.setVisible( false );
+				backwardButton.setVisible( false );
+				forwardButton.setVisible( false );
+				return;
+			}
+
 			Rectangle bounds = tabPane.getBounds();
 			Insets insets = tabPane.getInsets();
 			int tabPlacement = tabPane.getTabPlacement();

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatTabbedPaneUI.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatTabbedPaneUI.java
@@ -38,11 +38,14 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.event.ComponentEvent;
 import java.awt.event.ComponentListener;
+import java.awt.event.ContainerEvent;
+import java.awt.event.ContainerListener;
 import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
+import java.awt.event.MouseMotionListener;
 import java.awt.event.MouseWheelEvent;
 import java.awt.geom.Path2D;
 import java.awt.geom.Rectangle2D;
@@ -51,6 +54,10 @@ import java.beans.PropertyChangeListener;
 import java.util.Collections;
 import java.util.Locale;
 import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.IntConsumer;
+import javax.swing.ButtonModel;
+import javax.swing.Icon;
 import javax.swing.JButton;
 import javax.swing.JComponent;
 import javax.swing.JMenuItem;
@@ -119,6 +126,7 @@ import com.formdev.flatlaf.util.UIScale;
  * @uiDefault TabbedPane.hasFullBorder					boolean
  * @uiDefault TabbedPane.hiddenTabsNavigation			String	moreTabsButton (default) or arrowButtons
  * @uiDefault ScrollPane.smoothScrolling				boolean
+ * @uiDefault TabbedPane.closeIcon						Icon
  *
  * @uiDefault TabbedPane.moreTabsButtonToolTipText		String
  *
@@ -152,18 +160,22 @@ public class FlatTabbedPaneUI
 	protected boolean hasFullBorder;
 
 	private String hiddenTabsNavigationStr;
+	protected Icon closeIcon;
 
 	protected String moreTabsButtonToolTipText;
 
 	protected JViewport tabViewport;
 	protected FlatWheelTabScroller wheelTabScroller;
 
+	private JButton tabCloseButton;
 	private JButton moreTabsButton;
 	private Container leadingComponent;
 	private Container trailingComponent;
 
 	private Handler handler;
 	private boolean blockRollover;
+	private boolean rolloverTabClose;
+	private boolean pressedTabClose;
 
 	public static ComponentUI createUI( JComponent c ) {
 		return new FlatTabbedPaneUI();
@@ -210,6 +222,7 @@ public class FlatTabbedPaneUI
 		tabSeparatorsFullHeight = UIManager.getBoolean( "TabbedPane.tabSeparatorsFullHeight" );
 		hasFullBorder = UIManager.getBoolean( "TabbedPane.hasFullBorder" );
 		hiddenTabsNavigationStr = UIManager.getString( "TabbedPane.hiddenTabsNavigation" );
+		closeIcon = UIManager.getIcon( "TabbedPane.closeIcon" );
 
 		Locale l = tabPane.getLocale();
 		moreTabsButtonToolTipText = UIManager.getString( "TabbedPane.moreTabsButtonToolTipText", l );
@@ -255,12 +268,19 @@ public class FlatTabbedPaneUI
 		tabSeparatorColor = null;
 		contentAreaColor = null;
 
+		closeIcon = null;
+
 		MigLayoutVisualPadding.uninstall( tabPane );
 	}
 
 	@Override
 	protected void installComponents() {
 		super.installComponents();
+
+		// create tab close button
+		tabCloseButton = new TabCloseButton();
+		tabCloseButton.setVisible( false );
+		tabPane.add( tabCloseButton );
 
 		// find scrollable tab viewport
 		tabViewport = null;
@@ -287,6 +307,11 @@ public class FlatTabbedPaneUI
 		uninstallTrailingComponent();
 
 		super.uninstallComponents();
+
+		if( tabCloseButton != null ) {
+			tabPane.remove( tabCloseButton );
+			tabCloseButton = null;
+		}
 
 		tabViewport = null;
 	}
@@ -354,9 +379,7 @@ public class FlatTabbedPaneUI
 	protected void installListeners() {
 		super.installListeners();
 
-		tabPane.addMouseListener( getHandler() );
-		tabPane.addMouseMotionListener( getHandler() );
-		tabPane.addComponentListener( getHandler() );
+		getHandler().installListeners();
 
 		if( tabViewport != null && (wheelTabScroller = createWheelTabScroller()) != null ) {
 			// ideally we would add the mouse listeners to the viewport, but then the
@@ -373,9 +396,7 @@ public class FlatTabbedPaneUI
 		super.uninstallListeners();
 
 		if( handler != null ) {
-			tabPane.removeMouseListener( handler );
-			tabPane.removeMouseMotionListener( handler );
-			tabPane.removeComponentListener( handler );
+			handler.uninstallListeners();
 			handler = null;
 		}
 
@@ -397,6 +418,13 @@ public class FlatTabbedPaneUI
 
 	protected FlatWheelTabScroller createWheelTabScroller() {
 		return new FlatWheelTabScroller();
+	}
+
+	@Override
+	protected MouseListener createMouseListener() {
+		Handler handler = getHandler();
+		handler.mouseDelegate = super.createMouseListener();
+		return handler;
 	}
 
 	@Override
@@ -454,6 +482,30 @@ public class FlatTabbedPaneUI
 		repaintTab( index );
 	}
 
+	protected boolean isRolloverTabClose() {
+		return rolloverTabClose;
+	}
+
+	protected void setRolloverTabClose( boolean rollover ) {
+		if( rolloverTabClose == rollover )
+			return;
+
+		rolloverTabClose = rollover;
+		repaintTab( getRolloverTab() );
+	}
+
+	protected boolean isPressedTabClose() {
+		return pressedTabClose;
+	}
+
+	protected void setPressedTabClose( boolean pressed ) {
+		if( pressedTabClose == pressed )
+			return;
+
+		pressedTabClose = pressed;
+		repaintTab( getRolloverTab() );
+	}
+
 	private void repaintTab( int tabIndex ) {
 		if( tabIndex < 0 || tabIndex >= tabPane.getTabCount() )
 			return;
@@ -465,7 +517,10 @@ public class FlatTabbedPaneUI
 
 	@Override
 	protected int calculateTabWidth( int tabPlacement, int tabIndex, FontMetrics metrics ) {
-		return super.calculateTabWidth( tabPlacement, tabIndex, metrics ) - 3 /* was added by superclass */;
+		int tabWidth = super.calculateTabWidth( tabPlacement, tabIndex, metrics ) - 3 /* was added by superclass */;
+		if( isTabClosable( tabIndex ) )
+			tabWidth += closeIcon.getIconWidth();
+		return tabWidth;
 	}
 
 	@Override
@@ -528,6 +583,10 @@ public class FlatTabbedPaneUI
 
 	@Override
 	protected int getTabLabelShiftX( int tabPlacement, int tabIndex, boolean isSelected ) {
+		if( isTabClosable( tabIndex ) ) {
+			int shift = closeIcon.getIconWidth() / 2;
+			return isLeftToRight() ? -shift : shift;
+		}
 		return 0;
 	}
 
@@ -619,6 +678,10 @@ public class FlatTabbedPaneUI
 	protected void paintTabBorder( Graphics g, int tabPlacement, int tabIndex,
 		int x, int y, int w, int h, boolean isSelected )
 	{
+		// paint tab close button
+		if( isTabClosable( tabIndex ) )
+			paintTabCloseButton( g, tabIndex, x, y, w, h );
+
 		// paint tab separators
 		if( clientPropertyBoolean( tabPane, TABBED_PANE_SHOW_TAB_SEPARATORS, showTabSeparators ) &&
 			!isLastInRun( tabIndex ) )
@@ -626,6 +689,18 @@ public class FlatTabbedPaneUI
 
 		if( isSelected )
 			paintTabSelection( g, tabPlacement, x, y, w, h );
+	}
+
+	protected void paintTabCloseButton( Graphics g, int tabIndex, int x, int y, int w, int h ) {
+		// update state of tab close button
+		boolean rollover = (tabIndex == getRolloverTab());
+		ButtonModel bm = tabCloseButton.getModel();
+		bm.setRollover( rollover && isRolloverTabClose() );
+		bm.setPressed( rollover && isPressedTabClose() );
+
+		// paint tab close icon
+		Rectangle tabCloseRect = getTabCloseBounds( x, y, w, h, calcRect );
+		closeIcon.paintIcon( tabCloseButton, g, tabCloseRect.x, tabCloseRect.y );
 	}
 
 	protected void paintTabSeparator( Graphics g, int tabPlacement, int x, int y, int w, int h ) {
@@ -636,7 +711,7 @@ public class FlatTabbedPaneUI
 		if( tabPlacement == LEFT || tabPlacement == RIGHT ) {
 			// paint tab separator at bottom side
 			((Graphics2D)g).fill( new Rectangle2D.Float( x + offset, y + h - sepWidth, w - (offset * 2), sepWidth ) );
-		} else if( tabPane.getComponentOrientation().isLeftToRight() ) {
+		} else if( isLeftToRight() ) {
 			// paint tab separator at right side
 			((Graphics2D)g).fill( new Rectangle2D.Float( x + w - sepWidth, y + offset, sepWidth, h - (offset * 2) ) );
 		} else {
@@ -819,6 +894,55 @@ public class FlatTabbedPaneUI
 			return super.getTabBounds( tabIndex, dest );
 	}
 
+	protected Rectangle getTabCloseBounds( int x, int y, int w, int h, Rectangle dest ) {
+		dest.width = closeIcon.getIconWidth();
+		dest.height = closeIcon.getIconHeight();
+		int xoffset = (h - dest.width) / 2;
+		int yoffset = (h - dest.height) / 2;
+		dest.x = isLeftToRight() ? (x + w - xoffset - dest.width) : (x + xoffset);
+		dest.y = y + yoffset;
+		return dest;
+	}
+
+	protected Rectangle getTabCloseHitArea( int tabIndex ) {
+		Rectangle tabRect = getTabBounds( tabPane, tabIndex );
+		Rectangle tabCloseRect = getTabCloseBounds( tabRect.x, tabRect.y, tabRect.width, tabRect.height, calcRect );
+		return new Rectangle( tabCloseRect.x, tabRect.y, tabCloseRect.width, tabRect.height );
+	}
+
+	protected boolean isTabClosable( int tabIndex ) {
+		Object value = getTabClientProperty( tabIndex, TABBED_PANE_TAB_CLOSABLE );
+		return (value instanceof Boolean) ? (boolean) value : false;
+	}
+
+	@SuppressWarnings( { "unchecked" } )
+	protected void closeTab( int tabIndex ) {
+		Object callback = getTabClientProperty( tabIndex, TABBED_PANE_TAB_CLOSE_CALLBACK );
+		if( callback instanceof IntConsumer )
+			((IntConsumer)callback).accept( tabIndex );
+		else if( callback instanceof BiConsumer )
+			((BiConsumer<JTabbedPane, Integer>)callback).accept( tabPane, tabIndex );
+		else {
+			throw new RuntimeException( "Missing tab close callback. "
+				+ "Set client property 'JTabbedPane.tabCloseCallback' "
+				+ "to a 'java.util.function.IntConsumer' "
+				+ "or 'java.util.function.BiConsumer<JTabbedPane, Integer>'" );
+		}
+	}
+
+	protected Object getTabClientProperty( int tabIndex, String key ) {
+		if( tabIndex < 0 )
+			return null;
+
+		Component c = tabPane.getComponentAt( tabIndex );
+		if( c instanceof JComponent ) {
+			Object value = ((JComponent)c).getClientProperty( key );
+			if( value != null )
+				return value;
+		}
+		return tabPane.getClientProperty( key );
+	}
+
 	protected void ensureCurrentLayout() {
 		// since super.ensureCurrentLayout() is private,
 		// use super.getTabRunCount() as workaround
@@ -832,6 +956,10 @@ public class FlatTabbedPaneUI
 
 	private boolean isScrollTabLayout() {
 		return tabPane.getTabLayoutPolicy() == JTabbedPane.SCROLL_TAB_LAYOUT;
+	}
+
+	private boolean isLeftToRight() {
+		return tabPane.getComponentOrientation().isLeftToRight();
 	}
 
 	protected boolean isHorizontalTabPlacement() {
@@ -911,6 +1039,16 @@ public class FlatTabbedPaneUI
 			Component c = tabPane.getTabComponentAt( i );
 			if( c != null )
 				c.setLocation( c.getX() + sx, c.getY() + sy );
+		}
+	}
+
+	//---- class TabCloseButton -----------------------------------------------
+
+	private class TabCloseButton
+		extends JButton
+		implements UIResource
+	{
+		private TabCloseButton() {
 		}
 	}
 
@@ -1011,9 +1149,8 @@ public class FlatTabbedPaneUI
 			int buttonWidth = getWidth();
 			int buttonHeight = getHeight();
 			Dimension popupSize = popupMenu.getPreferredSize();
-			boolean leftToRight = tabPane.getComponentOrientation().isLeftToRight();
 
-			int x = leftToRight ? buttonWidth - popupSize.width : 0;
+			int x = isLeftToRight() ? buttonWidth - popupSize.width : 0;
 			int y = buttonHeight - popupSize.height;
 			switch( tabPane.getTabPlacement() ) {
 				default:
@@ -1185,8 +1322,7 @@ public class FlatTabbedPaneUI
 			int y = viewPosition.y;
 			int tabPlacement = tabPane.getTabPlacement();
 			if( tabPlacement == TOP || tabPlacement == BOTTOM ) {
-				boolean leftToRight = tabPane.getComponentOrientation().isLeftToRight();
-				x += leftToRight ? amount : -amount;
+				x += isLeftToRight() ? amount : -amount;
 				x = Math.min( Math.max( x, 0 ), viewSize.width - tabViewport.getWidth() );
 			} else {
 				y += amount;
@@ -1360,18 +1496,69 @@ public class FlatTabbedPaneUI
 	//---- class Handler ------------------------------------------------------
 
 	private class Handler
-		extends MouseAdapter
-		implements PropertyChangeListener, ChangeListener, ComponentListener
+		implements MouseListener, MouseMotionListener, PropertyChangeListener,
+			ChangeListener, ComponentListener, ContainerListener
 	{
+		MouseListener mouseDelegate;
 		PropertyChangeListener propertyChangeDelegate;
 		ChangeListener changeDelegate;
+
+		private int pressedTabIndex = -1;
+
+		void installListeners() {
+			tabPane.addMouseMotionListener( this );
+			tabPane.addComponentListener( this );
+			tabPane.addContainerListener( this );
+
+			for( Component c : tabPane.getComponents() ) {
+				if( !(c instanceof UIResource) )
+					c.addPropertyChangeListener( TABBED_PANE_TAB_CLOSABLE, this );
+			}
+		}
+
+		void uninstallListeners() {
+			tabPane.removeMouseMotionListener( this );
+			tabPane.removeComponentListener( this );
+			tabPane.removeContainerListener( this );
+
+			for( Component c : tabPane.getComponents() ) {
+				if( !(c instanceof UIResource) )
+					c.removePropertyChangeListener( TABBED_PANE_TAB_CLOSABLE, this );
+			}
+		}
 
 		//---- interface MouseListener ----
 
 		@Override
+		public void mouseClicked( MouseEvent e ) {
+			mouseDelegate.mouseClicked( e );
+		}
+
+		@Override
+		public void mousePressed( MouseEvent e ) {
+			updateRollover( e, true );
+
+			if( !isPressedTabClose() )
+				mouseDelegate.mousePressed( e );
+		}
+
+		@Override
+		public void mouseReleased( MouseEvent e ) {
+			if( isPressedTabClose() ) {
+				updateRollover( e, false );
+				if( pressedTabIndex >= 0 && pressedTabIndex == getRolloverTab() )
+					closeTab( pressedTabIndex );
+			} else
+				mouseDelegate.mouseReleased( e );
+
+			pressedTabIndex = -1;
+			updateRollover( e, false );
+		}
+
+		@Override
 		public void mouseEntered( MouseEvent e ) {
 			// this is necessary for "more tabs" button
-			setRolloverTab( e.getX(), e.getY() );
+			updateRollover( e, false );
 		}
 
 		@Override
@@ -1379,15 +1566,37 @@ public class FlatTabbedPaneUI
 			// this event occurs also if mouse is moved to a custom tab component
 			// that handles mouse events (e.g. a close button)
 			// --> make sure that the tab stays highlighted
-			setRolloverTab( e.getX(), e.getY() );
+			updateRollover( e, false );
 		}
 
 		//---- interface MouseMotionListener ----
 
 		@Override
+		public void mouseDragged( MouseEvent e ) {
+			updateRollover( e, false );
+		}
+
+		@Override
 		public void mouseMoved( MouseEvent e ) {
-			// this is necessary for "more tabs" button
-			setRolloverTab( e.getX(), e.getY() );
+			updateRollover( e, false );
+		}
+
+		private void updateRollover( MouseEvent e, boolean pressed ) {
+			int x = e.getX();
+			int y = e.getY();
+
+			int tabIndex = tabForCoordinate( tabPane, x, y );
+
+			setRolloverTab( tabIndex );
+
+			// check whether mouse hit tab close area
+			boolean hitClose = isTabClosable( tabIndex )
+				? getTabCloseHitArea( tabIndex ).contains( x, y )
+				: false;
+			if( pressed )
+				pressedTabIndex = hitClose ? tabIndex : -1;
+			setRolloverTabClose( hitClose );
+			setPressedTabClose( hitClose && tabIndex == pressedTabIndex );
 		}
 
 		//---- interface PropertyChangeListener ----
@@ -1395,19 +1604,21 @@ public class FlatTabbedPaneUI
 		@Override
 		public void propertyChange( PropertyChangeEvent e ) {
 			// invoke delegate listener
-			switch( e.getPropertyName() ) {
-				case "tabPlacement":
-				case "opaque":
-				case "background":
-				case "indexForTabComponent":
-					runWithOriginalLayoutManager( () -> {
-						propertyChangeDelegate.propertyChange( e );
-					} );
-					break;
+			if( e.getSource() instanceof JTabbedPane ) {
+				switch( e.getPropertyName() ) {
+					case "tabPlacement":
+					case "opaque":
+					case "background":
+					case "indexForTabComponent":
+						runWithOriginalLayoutManager( () -> {
+							propertyChangeDelegate.propertyChange( e );
+						} );
+						break;
 
-				default:
-					propertyChangeDelegate.propertyChange( e );
-					break;
+					default:
+						propertyChangeDelegate.propertyChange( e );
+						break;
+				}
 			}
 
 			// handle event
@@ -1426,6 +1637,7 @@ public class FlatTabbedPaneUI
 				case TABBED_PANE_HAS_FULL_BORDER:
 				case TABBED_PANE_TAB_HEIGHT:
 				case TABBED_PANE_HIDDEN_TABS_NAVIGATION:
+				case TABBED_PANE_TAB_CLOSABLE:
 					tabPane.revalidate();
 					tabPane.repaint();
 					break;
@@ -1470,6 +1682,22 @@ public class FlatTabbedPaneUI
 		@Override public void componentMoved( ComponentEvent e ) {}
 		@Override public void componentShown( ComponentEvent e ) {}
 		@Override public void componentHidden( ComponentEvent e ) {}
+
+		//---- interface ContainerListener ----
+
+		@Override
+		public void componentAdded( ContainerEvent e ) {
+			Component c = e.getChild();
+			if( !(c instanceof UIResource) )
+				c.addPropertyChangeListener( TABBED_PANE_TAB_CLOSABLE, this );
+		}
+
+		@Override
+		public void componentRemoved( ContainerEvent e ) {
+			Component c = e.getChild();
+			if( !(c instanceof UIResource) )
+				c.removePropertyChangeListener( TABBED_PANE_TAB_CLOSABLE, this );
+		}
 	}
 
 	//---- class FlatTabbedPaneLayout -----------------------------------------
@@ -1485,7 +1713,7 @@ public class FlatTabbedPaneUI
 			Insets insets = tabPane.getInsets();
 			int tabPlacement = tabPane.getTabPlacement();
 			Insets tabAreaInsets = getTabAreaInsets( tabPlacement );
-			boolean leftToRight = tabPane.getComponentOrientation().isLeftToRight();
+			boolean leftToRight = isLeftToRight();
 
 			// layout leading and trailing components in tab area
 			if( tabPlacement == TOP || tabPlacement == BOTTOM ) {
@@ -1556,7 +1784,7 @@ public class FlatTabbedPaneUI
 	 * Layout manager used for scroll tab layout policy.
 	 * <p>
 	 * Although this class delegates all methods to the original layout manager
-	 * {@link BasicTabbedPaneUI.TabbedPaneScrollLayout}, which extends
+	 * {@code BasicTabbedPaneUI.TabbedPaneScrollLayout}, which extends
 	 * {@link BasicTabbedPaneUI.TabbedPaneLayout}, it is necessary that this class
 	 * also extends {@link TabbedPaneLayout} to avoid a {@code ClassCastException}
 	 * in {@link BasicTabbedPaneUI}.ensureCurrentLayout().
@@ -1624,7 +1852,7 @@ public class FlatTabbedPaneUI
 			Dimension moreButtonSize = useMoreButton ? moreTabsButton.getPreferredSize() : null;
 			Dimension backwardButtonSize = useMoreButton ? null : backwardButton.getPreferredSize();
 			Dimension forwardButtonSize = useMoreButton ? null : forwardButton.getPreferredSize();
-			boolean leftToRight = tabPane.getComponentOrientation().isLeftToRight();
+			boolean leftToRight = isLeftToRight();
 			boolean buttonsVisible = false;
 
 			// TabbedPaneScrollLayout adds tabAreaInsets to tab coordinates,

--- a/flatlaf-core/src/main/resources/com/formdev/flatlaf/FlatDarkLaf.properties
+++ b/flatlaf-core/src/main/resources/com/formdev/flatlaf/FlatDarkLaf.properties
@@ -258,6 +258,13 @@ TabbedPane.hoverColor=#2e3133
 TabbedPane.focusColor=#3d4b5c
 TabbedPane.contentAreaColor=#646464
 
+TabbedPane.closeBackground=null
+TabbedPane.closeForeground=@disabledText
+TabbedPane.closeHoverBackground=lighten($TabbedPane.hoverColor,10%)
+TabbedPane.closeHoverForeground=@foreground
+TabbedPane.closePressedBackground=lighten($TabbedPane.hoverColor,15%)
+TabbedPane.closePressedForeground=$TabbedPane.closeHoverForeground
+
 
 #---- Table ----
 

--- a/flatlaf-core/src/main/resources/com/formdev/flatlaf/FlatLaf.properties
+++ b/flatlaf-core/src/main/resources/com/formdev/flatlaf/FlatLaf.properties
@@ -552,6 +552,13 @@ TabbedPane.shadow=@background
 TabbedPane.contentBorderInsets=null
 TabbedPane.hiddenTabsNavigation=moreTabsButton
 
+TabbedPane.closeIcon=com.formdev.flatlaf.icons.FlatTabbedPaneCloseIcon
+TabbedPane.closeSize=16,16
+TabbedPane.closeArc=4
+TabbedPane.closeCrossPlainSize={float}7.5
+TabbedPane.closeCrossFilledSize=$TabbedPane.closeCrossPlainSize
+TabbedPane.closeCrossLineWidth={float}1
+
 
 #---- Table ----
 

--- a/flatlaf-core/src/main/resources/com/formdev/flatlaf/FlatLightLaf.properties
+++ b/flatlaf-core/src/main/resources/com/formdev/flatlaf/FlatLightLaf.properties
@@ -270,6 +270,13 @@ TabbedPane.hoverColor=#d9d9d9
 TabbedPane.focusColor=#dae4ed
 TabbedPane.contentAreaColor=#bfbfbf
 
+TabbedPane.closeBackground=null
+TabbedPane.closeForeground=@disabledText
+TabbedPane.closeHoverBackground=darken($TabbedPane.hoverColor,10%)
+TabbedPane.closeHoverForeground=@foreground
+TabbedPane.closePressedBackground=darken($TabbedPane.hoverColor,15%)
+TabbedPane.closePressedForeground=$TabbedPane.closeHoverForeground
+
 
 #---- Table ----
 

--- a/flatlaf-extras/src/main/java/com/formdev/flatlaf/extras/TriStateCheckBox.java
+++ b/flatlaf-extras/src/main/java/com/formdev/flatlaf/extras/TriStateCheckBox.java
@@ -95,6 +95,19 @@ public class TriStateCheckBox
 		repaint();
 	}
 
+	public Boolean getValue() {
+		switch( state ) {
+			default:
+			case INDETERMINATE:	return null;
+			case SELECTED:		return true;
+			case UNSELECTED:	return false;
+		}
+	}
+
+	public void setValue( Boolean value ) {
+		setState( value == null ? State.INDETERMINATE : (value ? State.SELECTED : State.UNSELECTED) );
+	}
+
 	public boolean isThirdStateEnabled() {
 		return thirdStateEnabled;
 	}

--- a/flatlaf-testing/dumps/uidefaults/FlatDarkLaf_1.8.0_202.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatDarkLaf_1.8.0_202.txt
@@ -905,6 +905,17 @@ SplitPaneUI                    com.formdev.flatlaf.ui.FlatSplitPaneUI
 #---- TabbedPane ----
 
 TabbedPane.background          #3c3f41    javax.swing.plaf.ColorUIResource [UI]
+TabbedPane.closeArc            4
+TabbedPane.closeCrossFilledSize 7.5
+TabbedPane.closeCrossLineWidth 1.0
+TabbedPane.closeCrossPlainSize 7.5
+TabbedPane.closeForeground     #888888    javax.swing.plaf.ColorUIResource [UI]
+TabbedPane.closeHoverBackground #464b4e    javax.swing.plaf.ColorUIResource [UI]
+TabbedPane.closeHoverForeground #bbbbbb    javax.swing.plaf.ColorUIResource [UI]
+TabbedPane.closeIcon           [lazy] 16,16    com.formdev.flatlaf.icons.FlatTabbedPaneCloseIcon [UI]
+TabbedPane.closePressedBackground #52585b    javax.swing.plaf.ColorUIResource [UI]
+TabbedPane.closePressedForeground #bbbbbb    javax.swing.plaf.ColorUIResource [UI]
+TabbedPane.closeSize           16,16    javax.swing.plaf.DimensionUIResource [UI]
 TabbedPane.contentAreaColor    #646464    javax.swing.plaf.ColorUIResource [UI]
 TabbedPane.contentOpaque       true
 TabbedPane.contentSeparatorHeight 1

--- a/flatlaf-testing/dumps/uidefaults/FlatLightLaf_1.8.0_202.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatLightLaf_1.8.0_202.txt
@@ -910,6 +910,17 @@ SplitPaneUI                    com.formdev.flatlaf.ui.FlatSplitPaneUI
 #---- TabbedPane ----
 
 TabbedPane.background          #f2f2f2    javax.swing.plaf.ColorUIResource [UI]
+TabbedPane.closeArc            4
+TabbedPane.closeCrossFilledSize 7.5
+TabbedPane.closeCrossLineWidth 1.0
+TabbedPane.closeCrossPlainSize 7.5
+TabbedPane.closeForeground     #8c8c8c    javax.swing.plaf.ColorUIResource [UI]
+TabbedPane.closeHoverBackground #c0c0c0    javax.swing.plaf.ColorUIResource [UI]
+TabbedPane.closeHoverForeground #000000    javax.swing.plaf.ColorUIResource [UI]
+TabbedPane.closeIcon           [lazy] 16,16    com.formdev.flatlaf.icons.FlatTabbedPaneCloseIcon [UI]
+TabbedPane.closePressedBackground #b3b3b3    javax.swing.plaf.ColorUIResource [UI]
+TabbedPane.closePressedForeground #000000    javax.swing.plaf.ColorUIResource [UI]
+TabbedPane.closeSize           16,16    javax.swing.plaf.DimensionUIResource [UI]
 TabbedPane.contentAreaColor    #bfbfbf    javax.swing.plaf.ColorUIResource [UI]
 TabbedPane.contentOpaque       true
 TabbedPane.contentSeparatorHeight 1

--- a/flatlaf-testing/dumps/uidefaults/FlatTestLaf_1.8.0_202.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatTestLaf_1.8.0_202.txt
@@ -898,6 +898,17 @@ SplitPaneUI                    com.formdev.flatlaf.ui.FlatSplitPaneUI
 #---- TabbedPane ----
 
 TabbedPane.background          #ccffcc    javax.swing.plaf.ColorUIResource [UI]
+TabbedPane.closeArc            999
+TabbedPane.closeCrossFilledSize 6.5
+TabbedPane.closeCrossLineWidth 2.0
+TabbedPane.closeCrossPlainSize 12.0
+TabbedPane.closeForeground     #ff0000    javax.swing.plaf.ColorUIResource [UI]
+TabbedPane.closeHoverBackground #aa0000    javax.swing.plaf.ColorUIResource [UI]
+TabbedPane.closeHoverForeground #ffffff    javax.swing.plaf.ColorUIResource [UI]
+TabbedPane.closeIcon           [lazy] 16,16    com.formdev.flatlaf.icons.FlatTabbedPaneCloseIcon [UI]
+TabbedPane.closePressedBackground #00ff00    javax.swing.plaf.ColorUIResource [UI]
+TabbedPane.closePressedForeground #000000    javax.swing.plaf.ColorUIResource [UI]
+TabbedPane.closeSize           16,16    javax.swing.plaf.DimensionUIResource [UI]
 TabbedPane.contentAreaColor    #bbbbbb    javax.swing.plaf.ColorUIResource [UI]
 TabbedPane.contentOpaque       true
 TabbedPane.contentSeparatorHeight 1

--- a/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatContainerTest.java
+++ b/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatContainerTest.java
@@ -300,7 +300,7 @@ public class FlatContainerTest
 	}
 
 	private void smallerTabHeightChanged() {
-		Integer tabHeight = smallerTabHeightCheckBox.isSelected() ? 20 : null;
+		Integer tabHeight = smallerTabHeightCheckBox.isSelected() ? 26 : null;
 		putTabbedPanesClientProperty( TABBED_PANE_TAB_HEIGHT, tabHeight );
 	}
 

--- a/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatContainerTest.java
+++ b/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatContainerTest.java
@@ -18,9 +18,12 @@ package com.formdev.flatlaf.testing;
 
 import static com.formdev.flatlaf.FlatClientProperties.*;
 import java.awt.*;
+import java.awt.event.MouseEvent;
+import java.util.function.BiConsumer;
 import javax.swing.*;
 import javax.swing.border.*;
 import com.formdev.flatlaf.FlatLaf;
+import com.formdev.flatlaf.extras.TriStateCheckBox;
 import com.formdev.flatlaf.icons.FlatInternalFrameCloseIcon;
 import com.formdev.flatlaf.util.ScaledImageIcon;
 import com.jgoodies.forms.layout.*;
@@ -48,6 +51,9 @@ public class FlatContainerTest
 
 		addInitialTabs( tabbedPane1, tabbedPane2, tabbedPane3, tabbedPane4 );
 		initialTabCount = tabbedPane1.getTabCount();
+
+		tabsClosableCheckBox.setSelected( true );
+		tabsClosableChanged();
 
 		tabScrollCheckBox.setSelected( true );
 		tabScrollChanged();
@@ -236,10 +242,7 @@ public class FlatContainerTest
 			case "arrowButtons":	value = TABBED_PANE_HIDDEN_TABS_NAVIGATION_ARROW_BUTTONS; break;
 		}
 
-		tabbedPane1.putClientProperty( TABBED_PANE_HIDDEN_TABS_NAVIGATION, value );
-		tabbedPane2.putClientProperty( TABBED_PANE_HIDDEN_TABS_NAVIGATION, value );
-		tabbedPane3.putClientProperty( TABBED_PANE_HIDDEN_TABS_NAVIGATION, value );
-		tabbedPane4.putClientProperty( TABBED_PANE_HIDDEN_TABS_NAVIGATION, value );
+		putTabbedPanesClientProperty( TABBED_PANE_HIDDEN_TABS_NAVIGATION, value );
 	}
 
 	private void tabBackForegroundChanged() {
@@ -267,6 +270,32 @@ public class FlatContainerTest
 				c.setBorder( new EmptyBorder( gap, gap, gap, gap ) );
 			}
 			tabbedPane.putClientProperty( key, c );
+		}
+	}
+
+	private void tabsClosableChanged() {
+		boolean closable = tabsClosableCheckBox.isSelected();
+		putTabbedPanesClientProperty( TABBED_PANE_TAB_CLOSABLE, closable ? true : null );
+
+		if( closable ) {
+			putTabbedPanesClientProperty( TABBED_PANE_TAB_CLOSE_CALLBACK,
+				(BiConsumer<JTabbedPane, Integer>) (tabbedPane, tabIndex) -> {
+					AWTEvent e = EventQueue.getCurrentEvent();
+					int modifiers = (e instanceof MouseEvent) ? ((MouseEvent)e).getModifiers() : 0;
+					JOptionPane.showMessageDialog( this, "Closed tab '" + tabbedPane.getTitleAt( tabIndex ) + "'."
+						+ "\n\n(modifiers: " + MouseEvent.getMouseModifiersText( modifiers ) + ")",
+						"Tab Closed", JOptionPane.PLAIN_MESSAGE );
+				} );
+		}
+	}
+
+	private void secondTabClosableChanged() {
+		Boolean value = secondTabClosableCheckBox.getValue();
+
+		JTabbedPane[] tabbedPanes = new JTabbedPane[] { tabbedPane1, tabbedPane2, tabbedPane3, tabbedPane4 };
+		for( JTabbedPane tabbedPane : tabbedPanes ) {
+			Component c = tabbedPane.getComponentAt( 1 );
+			((JComponent)c).putClientProperty( TABBED_PANE_TAB_CLOSABLE, value );
 		}
 	}
 
@@ -306,6 +335,8 @@ public class FlatContainerTest
 		tabBackForegroundCheckBox = new JCheckBox();
 		leadingComponentCheckBox = new JCheckBox();
 		trailingComponentCheckBox = new JCheckBox();
+		tabsClosableCheckBox = new JCheckBox();
+		secondTabClosableCheckBox = new TriStateCheckBox();
 		CellConstraints cc = new CellConstraints();
 
 		//======== this ========
@@ -518,6 +549,16 @@ public class FlatContainerTest
 				trailingComponentCheckBox.setText("Trailing");
 				trailingComponentCheckBox.addActionListener(e -> trailingComponentChanged());
 				panel14.add(trailingComponentCheckBox, "cell 1 3");
+
+				//---- tabsClosableCheckBox ----
+				tabsClosableCheckBox.setText("Tabs closable");
+				tabsClosableCheckBox.addActionListener(e -> tabsClosableChanged());
+				panel14.add(tabsClosableCheckBox, "cell 2 3");
+
+				//---- secondTabClosableCheckBox ----
+				secondTabClosableCheckBox.setText("Second Tab closable");
+				secondTabClosableCheckBox.addActionListener(e -> secondTabClosableChanged());
+				panel14.add(secondTabClosableCheckBox, "cell 3 3");
 			}
 			panel9.add(panel14, cc.xywh(1, 11, 3, 1));
 		}
@@ -545,6 +586,8 @@ public class FlatContainerTest
 	private JCheckBox tabBackForegroundCheckBox;
 	private JCheckBox leadingComponentCheckBox;
 	private JCheckBox trailingComponentCheckBox;
+	private JCheckBox tabsClosableCheckBox;
+	private TriStateCheckBox secondTabClosableCheckBox;
 	// JFormDesigner - End of variables declaration  //GEN-END:variables
 
 	//---- class Tab1Panel ----------------------------------------------------

--- a/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatContainerTest.java
+++ b/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatContainerTest.java
@@ -299,6 +299,26 @@ public class FlatContainerTest
 		}
 	}
 
+	private void smallerTabHeightChanged() {
+		Integer tabHeight = smallerTabHeightCheckBox.isSelected() ? 20 : null;
+		putTabbedPanesClientProperty( TABBED_PANE_TAB_HEIGHT, tabHeight );
+	}
+
+	private void smallerInsetsChanged() {
+		Insets insets = smallerInsetsCheckBox.isSelected() ? new Insets( 2, 2, 2, 2 ) : null;
+		putTabbedPanesClientProperty( TABBED_PANE_TAB_INSETS, insets );
+	}
+
+	private void secondTabWiderChanged() {
+		Insets insets = secondTabWiderCheckBox.isSelected() ? new Insets( 4, 20, 4, 20 ) : null;
+
+		JTabbedPane[] tabbedPanes = new JTabbedPane[] { tabbedPane1, tabbedPane2, tabbedPane3, tabbedPane4 };
+		for( JTabbedPane tabbedPane : tabbedPanes ) {
+			Component c = tabbedPane.getComponentAt( 1 );
+			((JComponent)c).putClientProperty( TABBED_PANE_TAB_INSETS, insets );
+		}
+	}
+
 	private void initComponents() {
 		// JFormDesigner - Component initialization - DO NOT MODIFY  //GEN-BEGIN:initComponents
 		JPanel panel9 = new JPanel();
@@ -337,6 +357,9 @@ public class FlatContainerTest
 		trailingComponentCheckBox = new JCheckBox();
 		tabsClosableCheckBox = new JCheckBox();
 		secondTabClosableCheckBox = new TriStateCheckBox();
+		smallerTabHeightCheckBox = new JCheckBox();
+		smallerInsetsCheckBox = new JCheckBox();
+		secondTabWiderCheckBox = new JCheckBox();
 		CellConstraints cc = new CellConstraints();
 
 		//======== this ========
@@ -451,6 +474,7 @@ public class FlatContainerTest
 					"[center]" +
 					"[]" +
 					"[]" +
+					"[]" +
 					"[]"));
 
 				//---- moreTabsCheckBox ----
@@ -559,6 +583,21 @@ public class FlatContainerTest
 				secondTabClosableCheckBox.setText("Second Tab closable");
 				secondTabClosableCheckBox.addActionListener(e -> secondTabClosableChanged());
 				panel14.add(secondTabClosableCheckBox, "cell 3 3");
+
+				//---- smallerTabHeightCheckBox ----
+				smallerTabHeightCheckBox.setText("Smaller tab height");
+				smallerTabHeightCheckBox.addActionListener(e -> smallerTabHeightChanged());
+				panel14.add(smallerTabHeightCheckBox, "cell 0 4 2 1");
+
+				//---- smallerInsetsCheckBox ----
+				smallerInsetsCheckBox.setText("Smaller insets");
+				smallerInsetsCheckBox.addActionListener(e -> smallerInsetsChanged());
+				panel14.add(smallerInsetsCheckBox, "cell 2 4");
+
+				//---- secondTabWiderCheckBox ----
+				secondTabWiderCheckBox.setText("Second Tab wider");
+				secondTabWiderCheckBox.addActionListener(e -> secondTabWiderChanged());
+				panel14.add(secondTabWiderCheckBox, "cell 3 4");
 			}
 			panel9.add(panel14, cc.xywh(1, 11, 3, 1));
 		}
@@ -588,6 +627,9 @@ public class FlatContainerTest
 	private JCheckBox trailingComponentCheckBox;
 	private JCheckBox tabsClosableCheckBox;
 	private TriStateCheckBox secondTabClosableCheckBox;
+	private JCheckBox smallerTabHeightCheckBox;
+	private JCheckBox smallerInsetsCheckBox;
+	private JCheckBox secondTabWiderCheckBox;
 	// JFormDesigner - End of variables declaration  //GEN-END:variables
 
 	//---- class Tab1Panel ----------------------------------------------------

--- a/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatContainerTest.java
+++ b/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatContainerTest.java
@@ -54,6 +54,7 @@ public class FlatContainerTest
 
 		tabsClosableCheckBox.setSelected( true );
 		tabsClosableChanged();
+		putTabbedPanesClientProperty( TABBED_PANE_TAB_CLOSE_TOOLTIPTEXT, "Close" );
 
 		tabScrollCheckBox.setSelected( true );
 		tabScrollChanged();
@@ -129,14 +130,15 @@ public class FlatContainerTest
 
 	private void addInitialTabs( JTabbedPane... tabbedPanes ) {
 		for( JTabbedPane tabbedPane : tabbedPanes ) {
-			tabbedPane.addTab( "Tab 1", new Panel1() );
+			tabbedPane.addTab( "Tab 1", null, new Panel1(), "First tab." );
 
 			JComponent tab2 = new Panel2();
 			tab2.setBorder( new LineBorder( Color.magenta ) );
-			tabbedPane.addTab( "Second Tab", tab2 );
+			tabbedPane.addTab( "Second Tab", null, tab2, "This is the second tab." );
 
 			addTab( tabbedPane, "Disabled", "tab content 3" );
 			tabbedPane.setEnabledAt( 2, false );
+			tabbedPane.setToolTipTextAt( 2, "Disabled tab." );
 
 			tabbedPane.addTab( "Tab 4", new JLabel( "non-opaque content", SwingConstants.CENTER ) );
 		}

--- a/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatContainerTest.jfd
+++ b/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatContainerTest.jfd
@@ -327,6 +327,26 @@ new FormModel {
 					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
 						"value": "cell 1 3"
 					} )
+					add( new FormComponent( "javax.swing.JCheckBox" ) {
+						name: "tabsClosableCheckBox"
+						"text": "Tabs closable"
+						auxiliary() {
+							"JavaCodeGenerator.variableLocal": false
+						}
+						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "tabsClosableChanged", false ) )
+					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+						"value": "cell 2 3"
+					} )
+					add( new FormComponent( "com.formdev.flatlaf.extras.TriStateCheckBox" ) {
+						name: "secondTabClosableCheckBox"
+						"text": "Second Tab closable"
+						auxiliary() {
+							"JavaCodeGenerator.variableLocal": false
+						}
+						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "secondTabClosableChanged", false ) )
+					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+						"value": "cell 3 3"
+					} )
 				}, new FormLayoutConstraints( class com.jgoodies.forms.layout.CellConstraints ) {
 					"gridY": 11
 					"gridWidth": 3

--- a/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatContainerTest.jfd
+++ b/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatContainerTest.jfd
@@ -132,7 +132,7 @@ new FormModel {
 				add( new FormContainer( "javax.swing.JPanel", new FormLayoutManager( class net.miginfocom.swing.MigLayout ) {
 					"$layoutConstraints": "insets 0,hidemode 3"
 					"$columnConstraints": "[][fill][][][fill]"
-					"$rowConstraints": "[center][][][]"
+					"$rowConstraints": "[center][][][][]"
 				} ) {
 					name: "panel14"
 					"opaque": false
@@ -346,6 +346,36 @@ new FormModel {
 						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "secondTabClosableChanged", false ) )
 					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
 						"value": "cell 3 3"
+					} )
+					add( new FormComponent( "javax.swing.JCheckBox" ) {
+						name: "smallerTabHeightCheckBox"
+						"text": "Smaller tab height"
+						auxiliary() {
+							"JavaCodeGenerator.variableLocal": false
+						}
+						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "smallerTabHeightChanged", false ) )
+					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+						"value": "cell 0 4 2 1"
+					} )
+					add( new FormComponent( "javax.swing.JCheckBox" ) {
+						name: "smallerInsetsCheckBox"
+						"text": "Smaller insets"
+						auxiliary() {
+							"JavaCodeGenerator.variableLocal": false
+						}
+						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "smallerInsetsChanged", false ) )
+					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+						"value": "cell 2 4"
+					} )
+					add( new FormComponent( "javax.swing.JCheckBox" ) {
+						name: "secondTabWiderCheckBox"
+						"text": "Second Tab wider"
+						auxiliary() {
+							"JavaCodeGenerator.variableLocal": false
+						}
+						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "secondTabWiderChanged", false ) )
+					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+						"value": "cell 3 4"
 					} )
 				}, new FormLayoutConstraints( class com.jgoodies.forms.layout.CellConstraints ) {
 					"gridY": 11

--- a/flatlaf-testing/src/main/resources/com/formdev/flatlaf/testing/FlatTestLaf.properties
+++ b/flatlaf-testing/src/main/resources/com/formdev/flatlaf/testing/FlatTestLaf.properties
@@ -284,6 +284,18 @@ TabbedPane.focusColor=#ddd
 TabbedPane.tabSeparatorColor=#00f
 TabbedPane.contentAreaColor=#bbb
 
+TabbedPane.closeSize=16,16
+TabbedPane.closeArc=999
+TabbedPane.closeCrossPlainSize={float}12
+TabbedPane.closeCrossFilledSize={float}6.5
+TabbedPane.closeCrossLineWidth={float}2
+#TabbedPane.closeBackground=#faa
+TabbedPane.closeForeground=#f00
+TabbedPane.closeHoverBackground=#a00
+TabbedPane.closeHoverForeground=#fff
+TabbedPane.closePressedBackground=#0f0
+TabbedPane.closePressedForeground=#000
+
 
 #---- Table ----
 

--- a/flatlaf-theme-editor/src/main/resources/com/formdev/flatlaf/themeeditor/FlatLafUIKeys.txt
+++ b/flatlaf-theme-editor/src/main/resources/com/formdev/flatlaf/themeeditor/FlatLafUIKeys.txt
@@ -634,6 +634,17 @@ SplitPaneDivider.oneTouchHoverArrowColor
 SplitPaneUI
 TabbedPane.ancestorInputMap
 TabbedPane.background
+TabbedPane.closeArc
+TabbedPane.closeCrossFilledSize
+TabbedPane.closeCrossLineWidth
+TabbedPane.closeCrossPlainSize
+TabbedPane.closeForeground
+TabbedPane.closeHoverBackground
+TabbedPane.closeHoverForeground
+TabbedPane.closeIcon
+TabbedPane.closePressedBackground
+TabbedPane.closePressedForeground
+TabbedPane.closeSize
 TabbedPane.contentAreaColor
 TabbedPane.contentOpaque
 TabbedPane.contentSeparatorHeight


### PR DESCRIPTION
This PR introduces support for closable tabs.

![image](https://user-images.githubusercontent.com/5604048/96561980-83409280-12c0-11eb-9e60-48a1536fd8a2.png)

Set client property `JTabbedPane.tabClosable` to `true` on a `JTabbedPane` to enable closing tabs.
You also have to provide a callback in client property `JTabbedPane.tabCloseCallback` that is responsible for closing the tab.

~~~java
myTabbedPane.putClientProperty( "JTabbedPane.tabClosable", true );
myTabbedPane.putClientProperty( "JTabbedPane.tabCloseCallback",
    (java.util.function.BiConsumer<JTabbedPane, Integer>) (tabbedPane, tabIndex) -> {
        // close tab here
        tabbedPane.removeTabAt( tabIndex );
    } );
~~~

If you do not need the tabbed pane in the callback, it is possible to use a `java.util.function.IntConsumer`:
~~~java
myTabbedPane.putClientProperty( "JTabbedPane.tabCloseCallback",
    (java.util.function.IntConsumer) tabIndex -> {
        // close tab here
        myTabbedPane.removeTabAt( tabIndex );
    } );
~~~

You can set the two client properties also on single tabs. E.g. if not all tabs should be closeable. Or if only some tabs should be closable.

~~~java
Component c = tabbedPane.getComponentAt( 1 );
((JComponent)c).putClientProperty( "JTabbedPane.tabClosable", false );
~~~

The style of the close button can be changed via UI properties. Here are the defaults for light themes:
~~~
TabbedPane.closeSize=16,16
TabbedPane.closeArc=4
TabbedPane.closeCrossPlainSize={float}7.5
TabbedPane.closeCrossFilledSize=$TabbedPane.closeCrossPlainSize
TabbedPane.closeCrossLineWidth={float}1

TabbedPane.closeBackground=null
TabbedPane.closeForeground=@disabledText
TabbedPane.closeHoverBackground=darken($TabbedPane.hoverColor,10%)
TabbedPane.closeHoverForeground=@foreground
TabbedPane.closePressedBackground=darken($TabbedPane.hoverColor,15%)
TabbedPane.closePressedForeground=$TabbedPane.closeHoverForeground
~~~

If you prefer circle close buttons, set arc to a large value and make filled cross smaller:
~~~java
UIManager.put( "TabbedPane.closeArc", 999 );
UIManager.put( "TabbedPane.closeCrossFilledSize", 5.5f );
~~~
![image](https://user-images.githubusercontent.com/5604048/96565270-758d0c00-12c4-11eb-9352-171ca0813915.png)

If you don't want a filled button on hover, but change cross color to red, try:
~~~java
UIManager.put( "TabbedPane.closeHoverForeground", Color.red );
UIManager.put( "TabbedPane.closePressedForeground", Color.red );
UIManager.getLookAndFeelDefaults().put( "TabbedPane.closeHoverBackground", null );
~~~
![image](https://user-images.githubusercontent.com/5604048/96567032-98b8bb00-12c6-11eb-9ee7-94ec4baf4276.png)


This is part of TabbedPane improvements as discussed in issue https://github.com/JFormDesigner/FlatLaf/issues/40#issuecomment-573681056 and #31.

CC @Gaarco @swordmaster2k