### PR TITLE
TabbedPane: split forward/backward scrolling buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,18 @@ FlatLaf Change Log
   Hidden Tabs" button. If pressed, it shows a popup menu that contains (partly)
   hidden tabs and selecting one activates that tab. If you prefer
   forward/backward buttons, use `UIManager.put(
-  "TabbedPane.hiddenTabsNavigation", "arrowButtons" )`. (issue #40)
+  "TabbedPane.hiddenTabsNavigation", "arrowButtons" )`. (PR #190; issue #40)
+- TabbedPane: Support split forward/backward scrolling buttons. Backward button
+  is on the left/top side of the tabs area, forward button on the right/bottom
+  side. Optionally hide disabled buttons. (PR #195; issue #40)
 - TabbedPane: Support scrolling tabs with mouse wheel (if `tabLayoutPolicy` is
-  `SCROLL_TAB_LAYOUT`). (issue #40)
-- TabbedPane: Repeat scrolling as long as arrow buttons are pressed. (issue #40)
+  `SCROLL_TAB_LAYOUT`). (PR #187; issue #40)
+- TabbedPane: Repeat scrolling as long as arrow buttons are pressed. (PR #187;
+  issue #40)
 - TabbedPane: Support adding custom components to left and right sides of tabs
   area. (set client property `JTabbedPane.leadingComponent` or
   `JTabbedPane.trailingComponent` to a `java.awt.Component`) (issue #40)
-- TabbedPane: Support closable tabs. (issues #31 and #40)
+- TabbedPane: Support closable tabs. (PR #193; issues #31 and #40)
 - Support painting separator line between window title and content (use UI value
   `TitlePane.borderColor`). (issue #184)
 

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/FlatClientProperties.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/FlatClientProperties.java
@@ -351,6 +351,25 @@ public interface FlatClientProperties
 	String TABBED_PANE_HIDDEN_TABS_NAVIGATION_ARROW_BUTTONS = "arrowButtons";
 
 	/**
+	 * Use split forward/backward buttons for navigation to hidden tabs.
+	 * Backward button is on the left/top side of the tabs area,
+	 * forward button on the right/bottom side.
+	 *
+	 * @see #TABBED_PANE_HIDDEN_TABS_NAVIGATION
+	 */
+	String TABBED_PANE_HIDDEN_TABS_NAVIGATION_ARROW_BUTTONS_SPLIT = "arrowButtonsSplit";
+
+	/**
+	 * Use split forward/backward buttons for navigation to hidden tabs.
+	 * Backward button is on the left/top side of the tabs area,
+	 * forward button on the right/bottom side.
+	 * Disabled buttons are hidden.
+	 *
+	 * @see #TABBED_PANE_HIDDEN_TABS_NAVIGATION
+	 */
+	String TABBED_PANE_HIDDEN_TABS_NAVIGATION_ARROW_BUTTONS_SPLIT_HIDE = "arrowButtonsSplitHide";
+
+	/**
 	 * Specifies a component that will be placed at the leading edge of the tabs area.
 	 * <p>
 	 * <strong>Component</strong> {@link javax.swing.JTabbedPane}<br>

--- a/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatContainerTest.java
+++ b/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatContainerTest.java
@@ -240,8 +240,10 @@ public class FlatContainerTest
 	private void hiddenTabsNavigationChanged() {
 		String value = null;
 		switch( (String) hiddenTabsNavigationField.getSelectedItem() ) {
-			case "moreTabsButton":	value = TABBED_PANE_HIDDEN_TABS_NAVIGATION_MORE_TABS_BUTTON; break;
-			case "arrowButtons":	value = TABBED_PANE_HIDDEN_TABS_NAVIGATION_ARROW_BUTTONS; break;
+			case "moreTabsButton":			value = TABBED_PANE_HIDDEN_TABS_NAVIGATION_MORE_TABS_BUTTON; break;
+			case "arrowButtons":			value = TABBED_PANE_HIDDEN_TABS_NAVIGATION_ARROW_BUTTONS; break;
+			case "arrowButtonsSplit":		value = TABBED_PANE_HIDDEN_TABS_NAVIGATION_ARROW_BUTTONS_SPLIT; break;
+			case "arrowButtonsSplitHide":	value = TABBED_PANE_HIDDEN_TABS_NAVIGATION_ARROW_BUTTONS_SPLIT_HIDE; break;
 		}
 
 		putTabbedPanesClientProperty( TABBED_PANE_HIDDEN_TABS_NAVIGATION, value );
@@ -556,7 +558,9 @@ public class FlatContainerTest
 				hiddenTabsNavigationField.setModel(new DefaultComboBoxModel<>(new String[] {
 					"default",
 					"moreTabsButton",
-					"arrowButtons"
+					"arrowButtons",
+					"arrowButtonsSplit",
+					"arrowButtonsSplitHide"
 				}));
 				hiddenTabsNavigationField.addActionListener(e -> hiddenTabsNavigationChanged());
 				panel14.add(hiddenTabsNavigationField, "cell 3 2");

--- a/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatContainerTest.jfd
+++ b/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatContainerTest.jfd
@@ -288,6 +288,8 @@ new FormModel {
 							addElement( "default" )
 							addElement( "moreTabsButton" )
 							addElement( "arrowButtons" )
+							addElement( "arrowButtonsSplit" )
+							addElement( "arrowButtonsSplitHide" )
 						}
 						auxiliary() {
 							"JavaCodeGenerator.variableLocal": false


### PR DESCRIPTION
This PR adds support for split forward/backward scrolling buttons.
Backward button is on the left side of the tabs area, forward button on the right side.

![grafik](https://user-images.githubusercontent.com/5604048/96935600-b3588300-14c4-11eb-89fb-0641499f7afe.png)

Optionally disabled buttons can be hidden.

![grafik](https://user-images.githubusercontent.com/5604048/96935615-bce1eb00-14c4-11eb-84ad-8c07c2f864f1.png)
![grafik](https://user-images.githubusercontent.com/5604048/96935623-c10e0880-14c4-11eb-9942-3f5bfd9394c4.png)

To enable use:
~~~java
UIManager.put( "TabbedPane.hiddenTabsNavigation", "arrowButtonsSplit" );
or
UIManager.put( "TabbedPane.hiddenTabsNavigation", "arrowButtonsSplitHide" );
~~~

It is also possible to specify hiddenTabsNavigation type per tabbedpane via client property:

~~~java
myTabbedPane.putClientProperty( "JTabbedPane.hiddenTabsNavigation", "arrowButtonsSplit" );
or
myTabbedPane.putClientProperty( "JTabbedPane.hiddenTabsNavigation", "arrowButtonsSplitHide" );
~~~

This is part of TabbedPane improvements as discussed in issue https://github.com/JFormDesigner/FlatLaf/issues/40#issuecomment-573681056.
