### PR TITLE
TabbedPane: tab area alignment; min/max tab widths; tab icon placement; tab width mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,16 @@ FlatLaf Change Log
   Hidden Tabs" button. If pressed, it shows a popup menu that contains (partly)
   hidden tabs and selecting one activates that tab. If you prefer
   forward/backward buttons, use `UIManager.put(
-  "TabbedPane.hiddenTabsNavigation", "arrowButtons" )`. (issue #40)
+  "TabbedPane.hiddenTabsNavigation", "arrowButtons" )`. (PR #190; issue #40)
 - TabbedPane: Support scrolling tabs with mouse wheel (if `tabLayoutPolicy` is
-  `SCROLL_TAB_LAYOUT`). (issue #40)
-- TabbedPane: Repeat scrolling as long as arrow buttons are pressed. (issue #40)
+  `SCROLL_TAB_LAYOUT`). (PR #187; issue #40)
+- TabbedPane: Repeat scrolling as long as arrow buttons are pressed. (PR #187;
+  issue #40)
 - TabbedPane: Support adding custom components to left and right sides of tabs
   area. (set client property `JTabbedPane.leadingComponent` or
-  `JTabbedPane.trailingComponent` to a `java.awt.Component`) (issue #40)
-- TabbedPane: Support closable tabs. (issues #31 and #40)
+  `JTabbedPane.trailingComponent` to a `java.awt.Component`) (PR #192; issue
+  #40)
+- TabbedPane: Support closable tabs. (PR #193; issues #31 and #40)
 - Support painting separator line between window title and content (use UI value
   `TitlePane.borderColor`). (issue #184)
 - Extras: `FlatSVGIcon` now allows specifying icon width and height in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ FlatLaf Change Log
 - TabbedPane: Support equal and compact tab width modes. (set client property
   `JTabbedPane.tabWidthMode` to `"preferred"`, `"equal"` or `"compact"`) (PR
   #199)
+- TabbedPane: Support left, right, top and bottom tab icon placement. (set
+  client property `JTabbedPane.tabIconPlacement` to `SwingConstants.LEADING`,
+  `SwingConstants.TRAILING`, `SwingConstants.TOP` or `SwingConstants.BOTTOM`)
+  (PR #199)
 - Support painting separator line between window title and content (use UI value
   `TitlePane.borderColor`). (issue #184)
 - Extras: `FlatSVGIcon` now allows specifying icon width and height in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ FlatLaf Change Log
 - TabbedPane: Support closable tabs. (PR #193; issues #31 and #40)
 - TabbedPane: Support minimum or maximum tab widths. (set client property
   `JTabbedPane.minimumTabWidth` or `JTabbedPane.maximumTabWidth` to an integer)
+- TabbedPane: Support alignment of tab area. (set client property
+  `JTabbedPane.tabAreaAlignment` to `"leading"`, `"trailing"`, `"center"` or
+  `"fill"`)
 - Support painting separator line between window title and content (use UI value
   `TitlePane.borderColor`). (issue #184)
 - Extras: `FlatSVGIcon` now allows specifying icon width and height in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,13 @@ FlatLaf Change Log
 - TabbedPane: Support closable tabs. (PR #193; issues #31 and #40)
 - TabbedPane: Support minimum or maximum tab widths. (set client property
   `JTabbedPane.minimumTabWidth` or `JTabbedPane.maximumTabWidth` to an integer)
+  (PR #199)
 - TabbedPane: Support alignment of tab area. (set client property
   `JTabbedPane.tabAreaAlignment` to `"leading"`, `"trailing"`, `"center"` or
-  `"fill"`)
+  `"fill"`) (PR #199)
+- TabbedPane: Support equal and compact tab width modes. (set client property
+  `JTabbedPane.tabWidthMode` to `"preferred"`, `"equal"` or `"compact"`) (PR
+  #199)
 - Support painting separator line between window title and content (use UI value
   `TitlePane.borderColor`). (issue #184)
 - Extras: `FlatSVGIcon` now allows specifying icon width and height in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ FlatLaf Change Log
   `JTabbedPane.trailingComponent` to a `java.awt.Component`) (PR #192; issue
   #40)
 - TabbedPane: Support closable tabs. (PR #193; issues #31 and #40)
+- TabbedPane: Support minimum or maximum tab widths. (set client property
+  `JTabbedPane.minimumTabWidth` or `JTabbedPane.maximumTabWidth` to an integer)
 - Support painting separator line between window title and content (use UI value
   `TitlePane.borderColor`). (issue #184)
 - Extras: `FlatSVGIcon` now allows specifying icon width and height in

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/FlatClientProperties.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/FlatClientProperties.java
@@ -411,6 +411,38 @@ public interface FlatClientProperties
 	String TABBED_PANE_TAB_AREA_ALIGN_FILL = "fill";
 
 	/**
+	 * Specifies how the tabs should be sized.
+	 * <p>
+	 * <strong>Component</strong> {@link javax.swing.JTabbedPane}<br>
+	 * <strong>Value type</strong> {@link java.lang.String}
+	 * <strong>Allowed Values</strong> {@link #TABBED_PANE_TAB_WIDTH_MODE_PREFERRED} (default),
+	 * {@link #TABBED_PANE_TAB_WIDTH_MODE_EQUAL} or {@link #TABBED_PANE_TAB_WIDTH_MODE_COMPACT}
+	 */
+	String TABBED_PANE_TAB_WIDTH_MODE = "JTabbedPane.tabWidthMode";
+
+	/**
+	 * Tab width is adjusted to tab icon and title.
+	 *
+	 * @see #TABBED_PANE_TAB_WIDTH_MODE
+	 */
+	String TABBED_PANE_TAB_WIDTH_MODE_PREFERRED = "preferred";
+
+	/**
+	 * All tabs in a tabbed pane has same width.
+	 *
+	 * @see #TABBED_PANE_TAB_WIDTH_MODE
+	 */
+	String TABBED_PANE_TAB_WIDTH_MODE_EQUAL = "equal";
+
+	/**
+	 * Unselected tabs are smaller because they show only the tab icon, but no tab title.
+	 * Selected tabs show both.
+	 *
+	 * @see #TABBED_PANE_TAB_WIDTH_MODE
+	 */
+	String TABBED_PANE_TAB_WIDTH_MODE_COMPACT = "compact";
+
+	/**
 	 * Specifies a component that will be placed at the leading edge of the tabs area.
 	 * <p>
 	 * For top and bottom tab placement, the layed out component size will be

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/FlatClientProperties.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/FlatClientProperties.java
@@ -372,6 +372,45 @@ public interface FlatClientProperties
 	String TABBED_PANE_HIDDEN_TABS_NAVIGATION_ARROW_BUTTONS = "arrowButtons";
 
 	/**
+	 * Specifies the alignment of the tab area.
+	 * <p>
+	 * <strong>Component</strong> {@link javax.swing.JTabbedPane}<br>
+	 * <strong>Value type</strong> {@link java.lang.String}
+	 * <strong>Allowed Values</strong> {@link #TABBED_PANE_TAB_AREA_ALIGN_LEADING} (default),
+	 * {@link #TABBED_PANE_TAB_AREA_ALIGN_TRAILING}, {@link #TABBED_PANE_TAB_AREA_ALIGN_CENTER}
+	 * or {@link #TABBED_PANE_TAB_AREA_ALIGN_FILL}
+	 */
+	String TABBED_PANE_TAB_AREA_ALIGNMENT = "JTabbedPane.tabAreaAlignment";
+
+	/**
+	 * Align the tab area to the leading edge.
+	 *
+	 * @see #TABBED_PANE_TAB_AREA_ALIGNMENT
+	 */
+	String TABBED_PANE_TAB_AREA_ALIGN_LEADING = "leading";
+
+	/**
+	 * Align the tab area to the trailing edge.
+	 *
+	 * @see #TABBED_PANE_TAB_AREA_ALIGNMENT
+	 */
+	String TABBED_PANE_TAB_AREA_ALIGN_TRAILING = "trailing";
+
+	/**
+	 * Align the tab area to center.
+	 *
+	 * @see #TABBED_PANE_TAB_AREA_ALIGNMENT
+	 */
+	String TABBED_PANE_TAB_AREA_ALIGN_CENTER = "center";
+
+	/**
+	 * Stretch tabs to fill all available space.
+	 *
+	 * @see #TABBED_PANE_TAB_AREA_ALIGNMENT
+	 */
+	String TABBED_PANE_TAB_AREA_ALIGN_FILL = "fill";
+
+	/**
 	 * Specifies a component that will be placed at the leading edge of the tabs area.
 	 * <p>
 	 * For top and bottom tab placement, the layed out component size will be

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/FlatClientProperties.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/FlatClientProperties.java
@@ -247,6 +247,27 @@ public interface FlatClientProperties
 	String TABBED_PANE_HAS_FULL_BORDER = "JTabbedPane.hasFullBorder";
 
 	/**
+	 * Specifies the minimum width of a tab.
+	 * <p>
+	 * <strong>Component</strong> {@link javax.swing.JTabbedPane}<br>
+	 * or tab content components (see {@link javax.swing.JTabbedPane#setComponentAt(int, java.awt.Component)})<br>
+	 * <strong>Value type</strong> {@link java.lang.Integer}
+	 */
+	String TABBED_PANE_MINIMUM_TAB_WIDTH = "JTabbedPane.minimumTabWidth";
+
+	/**
+	 * Specifies the maximum width of a tab.
+	 * <p>
+	 * Applied only if tab does not have a custom tab component
+	 * (see {@link javax.swing.JTabbedPane#setTabComponentAt(int, java.awt.Component)}).
+	 * <p>
+	 * <strong>Component</strong> {@link javax.swing.JTabbedPane}<br>
+	 * or tab content components (see {@link javax.swing.JTabbedPane#setComponentAt(int, java.awt.Component)})<br>
+	 * <strong>Value type</strong> {@link java.lang.Integer}
+	 */
+	String TABBED_PANE_MAXIMUM_TAB_WIDTH = "JTabbedPane.maximumTabWidth";
+
+	/**
 	 * Specifies the height of a tab.
 	 * <p>
 	 * <strong>Component</strong> {@link javax.swing.JTabbedPane}<br>

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/FlatClientProperties.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/FlatClientProperties.java
@@ -285,6 +285,14 @@ public interface FlatClientProperties
 	String TABBED_PANE_TAB_INSETS = "JTabbedPane.tabInsets";
 
 	/**
+	 * Specifies the insets of the tab area.
+	 * <p>
+	 * <strong>Component</strong> {@link javax.swing.JTabbedPane}
+	 * <strong>Value type</strong> {@link java.awt.Insets}
+	 */
+	String TABBED_PANE_TAB_AREA_INSETS = "JTabbedPane.tabAreaInsets";
+
+	/**
 	 * Specifies whether tabs are closable.
 	 * If set to {@code true} on a tabbed pane component, all tabs in that tabbed pane are closable.
 	 * To make individual tabs closable, set it to {@code true} on a tab content component.

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/FlatClientProperties.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/FlatClientProperties.java
@@ -19,6 +19,7 @@ package com.formdev.flatlaf;
 import java.awt.Color;
 import java.util.Objects;
 import javax.swing.JComponent;
+import javax.swing.SwingConstants;
 
 /**
  * @author Karl Tauber
@@ -101,7 +102,7 @@ public interface FlatClientProperties
 	/**
 	 * Specifies whether the button preferred size will be made square (quadratically).
 	 * <p>
-	 * <strong>Components</strong> {@link javax.swing.JButton} and {@link javax.swing.JToggleButton}
+	 * <strong>Components</strong> {@link javax.swing.JButton} and {@link javax.swing.JToggleButton}<br>
 	 * <strong>Value type</strong> {@link java.lang.Boolean}
 	 */
 	String SQUARE_SIZE = "JButton.squareSize";
@@ -113,7 +114,7 @@ public interface FlatClientProperties
 	 * <p>
 	 * <strong>Component</strong> {@link javax.swing.JButton}, {@link javax.swing.JToggleButton},
 	 * {@link javax.swing.JComboBox}, {@link javax.swing.JSpinner} and {@link javax.swing.text.JTextComponent}<br>
-	 * <strong>Value type</strong> {@link java.lang.Integer}<br>
+	 * <strong>Value type</strong> {@link java.lang.Integer}
 	 */
 	String MINIMUM_WIDTH = "JComponent.minimumWidth";
 
@@ -121,7 +122,7 @@ public interface FlatClientProperties
 	 * Specifies minimum height of a component.
 	 * <p>
 	 * <strong>Component</strong> {@link javax.swing.JButton} and {@link javax.swing.JToggleButton}<br>
-	 * <strong>Value type</strong> {@link java.lang.Integer}<br>
+	 * <strong>Value type</strong> {@link java.lang.Integer}
 	 */
 	String MINIMUM_HEIGHT = "JComponent.minimumHeight";
 
@@ -157,7 +158,7 @@ public interface FlatClientProperties
 	 * Paint the component with round edges.
 	 * <p>
 	 * <strong>Components</strong> {@link javax.swing.JComboBox}, {@link javax.swing.JSpinner},
-	 * {@link javax.swing.JTextField}, {@link javax.swing.JFormattedTextField} and {@link javax.swing.JPasswordField}
+	 * {@link javax.swing.JTextField}, {@link javax.swing.JFormattedTextField} and {@link javax.swing.JPasswordField}<br>
 	 * <strong>Value type</strong> {@link java.lang.Boolean}
 	 */
 	String COMPONENT_ROUND_RECT = "JComponent.roundRect";
@@ -249,7 +250,7 @@ public interface FlatClientProperties
 	/**
 	 * Specifies the minimum width of a tab.
 	 * <p>
-	 * <strong>Component</strong> {@link javax.swing.JTabbedPane}<br>
+	 * <strong>Component</strong> {@link javax.swing.JTabbedPane}
 	 * or tab content components (see {@link javax.swing.JTabbedPane#setComponentAt(int, java.awt.Component)})<br>
 	 * <strong>Value type</strong> {@link java.lang.Integer}
 	 */
@@ -261,7 +262,7 @@ public interface FlatClientProperties
 	 * Applied only if tab does not have a custom tab component
 	 * (see {@link javax.swing.JTabbedPane#setTabComponentAt(int, java.awt.Component)}).
 	 * <p>
-	 * <strong>Component</strong> {@link javax.swing.JTabbedPane}<br>
+	 * <strong>Component</strong> {@link javax.swing.JTabbedPane}
 	 * or tab content components (see {@link javax.swing.JTabbedPane#setComponentAt(int, java.awt.Component)})<br>
 	 * <strong>Value type</strong> {@link java.lang.Integer}
 	 */
@@ -287,7 +288,7 @@ public interface FlatClientProperties
 	/**
 	 * Specifies the insets of the tab area.
 	 * <p>
-	 * <strong>Component</strong> {@link javax.swing.JTabbedPane}
+	 * <strong>Component</strong> {@link javax.swing.JTabbedPane}<br>
 	 * <strong>Value type</strong> {@link java.awt.Insets}
 	 */
 	String TABBED_PANE_TAB_AREA_INSETS = "JTabbedPane.tabAreaInsets";
@@ -359,7 +360,7 @@ public interface FlatClientProperties
 	 * Specifies how to navigate to hidden tabs.
 	 * <p>
 	 * <strong>Component</strong> {@link javax.swing.JTabbedPane}<br>
-	 * <strong>Value type</strong> {@link java.lang.String}
+	 * <strong>Value type</strong> {@link java.lang.String}<br>
 	 * <strong>Allowed Values</strong> {@link #TABBED_PANE_HIDDEN_TABS_NAVIGATION_MORE_TABS_BUTTON}
 	 * or {@link #TABBED_PANE_HIDDEN_TABS_NAVIGATION_ARROW_BUTTONS}
 	 */
@@ -383,7 +384,7 @@ public interface FlatClientProperties
 	 * Specifies the alignment of the tab area.
 	 * <p>
 	 * <strong>Component</strong> {@link javax.swing.JTabbedPane}<br>
-	 * <strong>Value type</strong> {@link java.lang.String}
+	 * <strong>Value type</strong> {@link java.lang.String}<br>
 	 * <strong>Allowed Values</strong> {@link #TABBED_PANE_TAB_AREA_ALIGN_LEADING} (default),
 	 * {@link #TABBED_PANE_TAB_AREA_ALIGN_TRAILING}, {@link #TABBED_PANE_TAB_AREA_ALIGN_CENTER}
 	 * or {@link #TABBED_PANE_TAB_AREA_ALIGN_FILL}
@@ -422,7 +423,7 @@ public interface FlatClientProperties
 	 * Specifies how the tabs should be sized.
 	 * <p>
 	 * <strong>Component</strong> {@link javax.swing.JTabbedPane}<br>
-	 * <strong>Value type</strong> {@link java.lang.String}
+	 * <strong>Value type</strong> {@link java.lang.String}<br>
 	 * <strong>Allowed Values</strong> {@link #TABBED_PANE_TAB_WIDTH_MODE_PREFERRED} (default),
 	 * {@link #TABBED_PANE_TAB_WIDTH_MODE_EQUAL} or {@link #TABBED_PANE_TAB_WIDTH_MODE_COMPACT}
 	 */
@@ -449,6 +450,17 @@ public interface FlatClientProperties
 	 * @see #TABBED_PANE_TAB_WIDTH_MODE
 	 */
 	String TABBED_PANE_TAB_WIDTH_MODE_COMPACT = "compact";
+
+	/**
+	 * Specifies the tab icon placement (relative to tab title).
+	 * <p>
+	 * <strong>Component</strong> {@link javax.swing.JTabbedPane}<br>
+	 * <strong>Value type</strong> {@link java.lang.Integer}<br>
+	 * <strong>Allowed Values</strong> {@link SwingConstants#LEADING} (default),
+	 * {@link SwingConstants#TRAILING}, {@link SwingConstants#TOP}
+	 * or {@link SwingConstants#BOTTOM}
+	 */
+	String TABBED_PANE_TAB_ICON_PLACEMENT = "JTabbedPane.tabIconPlacement";
 
 	/**
 	 * Specifies a component that will be placed at the leading edge of the tabs area.

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatTabbedPaneUI.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatTabbedPaneUI.java
@@ -875,42 +875,10 @@ public class FlatTabbedPaneUI
 	}
 
 	protected void paintTabSelection( Graphics g, int tabPlacement, int x, int y, int w, int h ) {
-		// increase clip bounds in scroll-tab-layout to paint over the separator line
-		Rectangle clipBounds = isScrollTabLayout() ? g.getClipBounds() : null;
-		if( clipBounds != null &&
-			this.contentSeparatorHeight != 0 &&
-			clientPropertyBoolean( tabPane, TABBED_PANE_SHOW_CONTENT_SEPARATOR, true ) )
-		{
-			Rectangle newClipBounds = new Rectangle( clipBounds );
-			int contentSeparatorHeight = scale( this.contentSeparatorHeight );
-			switch( tabPlacement ) {
-				case TOP:
-				default:
-					newClipBounds.height += contentSeparatorHeight;
-					break;
-
-				case BOTTOM:
-					newClipBounds.y -= contentSeparatorHeight;
-					newClipBounds.height += contentSeparatorHeight;
-					break;
-
-				case LEFT:
-					newClipBounds.width += contentSeparatorHeight;
-					break;
-
-				case RIGHT:
-					newClipBounds.x -= contentSeparatorHeight;
-					newClipBounds.width += contentSeparatorHeight;
-					break;
-			}
-			g.setClip( newClipBounds );
-		}
-
 		g.setColor( tabPane.isEnabled() ? underlineColor : disabledUnderlineColor );
 
-		Insets contentInsets = getContentBorderInsets( tabPlacement );
-
 		// paint underline selection
+		Insets contentInsets = getContentBorderInsets( tabPlacement );
 		int tabSelectionHeight = scale( this.tabSelectionHeight );
 		switch( tabPlacement ) {
 			case TOP:
@@ -932,9 +900,6 @@ public class FlatTabbedPaneUI
 				g.fillRect( x - contentInsets.right, y, tabSelectionHeight, h );
 				break;
 		}
-
-		if( clipBounds != null )
-			g.setClip( clipBounds );
 	}
 
 	/**
@@ -1005,8 +970,15 @@ public class FlatTabbedPaneUI
 		if( isScrollTabLayout() && selectedIndex >= 0 && tabViewport != null ) {
 			Rectangle tabRect = getTabBounds( tabPane, selectedIndex );
 
+			// clip to "scrolling sides" of viewport
+			// (left and right if horizontal, top and bottom if vertical)
 			Shape oldClip = g.getClip();
-			g.setClip( tabViewport.getBounds() );
+			Rectangle vr = tabViewport.getBounds();
+			if( isHorizontalTabPlacement() )
+				g.clipRect( vr.x, 0, vr.width, tabPane.getHeight() );
+			else
+				g.clipRect( 0, vr.y, tabPane.getWidth(), vr.height );
+
 			paintTabSelection( g, tabPlacement, tabRect.x, tabRect.y, tabRect.width, tabRect.height );
 			g.setClip( oldClip );
 		}

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatTabbedPaneUI.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatTabbedPaneUI.java
@@ -604,6 +604,10 @@ public class FlatTabbedPaneUI
 		Insets currentTabAreaInsets = super.getTabAreaInsets( tabPlacement );
 		Insets insets = (Insets) currentTabAreaInsets.clone();
 
+		Object value = tabPane.getClientProperty( TABBED_PANE_TAB_AREA_INSETS );
+		if( value instanceof Insets )
+			rotateInsets( (Insets) value, insets, tabPlacement );
+
 		// This is a "trick" to get rid of the cropped edge:
 		//     super.getTabAreaInsets() returns private field BasicTabbedPaneUI.currentTabAreaInsets,
 		//     which is also used to translate the origin of the cropped edge in
@@ -1937,6 +1941,7 @@ public class FlatTabbedPaneUI
 				case TABBED_PANE_MAXIMUM_TAB_WIDTH:
 				case TABBED_PANE_TAB_HEIGHT:
 				case TABBED_PANE_TAB_INSETS:
+				case TABBED_PANE_TAB_AREA_INSETS:
 				case TABBED_PANE_HIDDEN_TABS_NAVIGATION:
 				case TABBED_PANE_TAB_AREA_ALIGNMENT:
 				case TABBED_PANE_TAB_WIDTH_MODE:

--- a/flatlaf-core/src/main/resources/com/formdev/flatlaf/FlatLaf.properties
+++ b/flatlaf-core/src/main/resources/com/formdev/flatlaf/FlatLaf.properties
@@ -551,6 +551,7 @@ TabbedPane.disabledForeground=@disabledText
 TabbedPane.shadow=@background
 TabbedPane.contentBorderInsets=null
 TabbedPane.hiddenTabsNavigation=moreTabsButton
+TabbedPane.tabAreaAlignment=leading
 
 TabbedPane.closeIcon=com.formdev.flatlaf.icons.FlatTabbedPaneCloseIcon
 TabbedPane.closeSize=16,16

--- a/flatlaf-testing/dumps/uidefaults/FlatDarkLaf_1.8.0_202.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatDarkLaf_1.8.0_202.txt
@@ -937,6 +937,7 @@ TabbedPane.selectedTabPadInsets 0,0,0,0    javax.swing.plaf.InsetsUIResource [UI
 TabbedPane.selectionFollowsFocus true
 TabbedPane.shadow              #3c3f41    javax.swing.plaf.ColorUIResource [UI]
 TabbedPane.showTabSeparators   false
+TabbedPane.tabAreaAlignment    leading
 TabbedPane.tabAreaInsets       0,0,0,0    javax.swing.plaf.InsetsUIResource [UI]
 TabbedPane.tabHeight           32
 TabbedPane.tabInsets           4,12,4,12    javax.swing.plaf.InsetsUIResource [UI]

--- a/flatlaf-testing/dumps/uidefaults/FlatLightLaf_1.8.0_202.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatLightLaf_1.8.0_202.txt
@@ -942,6 +942,7 @@ TabbedPane.selectedTabPadInsets 0,0,0,0    javax.swing.plaf.InsetsUIResource [UI
 TabbedPane.selectionFollowsFocus true
 TabbedPane.shadow              #f2f2f2    javax.swing.plaf.ColorUIResource [UI]
 TabbedPane.showTabSeparators   false
+TabbedPane.tabAreaAlignment    leading
 TabbedPane.tabAreaInsets       0,0,0,0    javax.swing.plaf.InsetsUIResource [UI]
 TabbedPane.tabHeight           32
 TabbedPane.tabInsets           4,12,4,12    javax.swing.plaf.InsetsUIResource [UI]

--- a/flatlaf-testing/dumps/uidefaults/FlatTestLaf_1.8.0_202.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatTestLaf_1.8.0_202.txt
@@ -932,6 +932,7 @@ TabbedPane.selectedTabPadInsets 0,0,0,0    javax.swing.plaf.InsetsUIResource [UI
 TabbedPane.selectionFollowsFocus true
 TabbedPane.shadow              #ccffcc    javax.swing.plaf.ColorUIResource [UI]
 TabbedPane.showTabSeparators   false
+TabbedPane.tabAreaAlignment    leading
 TabbedPane.tabAreaInsets       0,0,0,0    javax.swing.plaf.InsetsUIResource [UI]
 TabbedPane.tabHeight           32
 TabbedPane.tabInsets           4,12,4,12    javax.swing.plaf.InsetsUIResource [UI]

--- a/flatlaf-testing/dumps/uidefaults/FlatTestLaf_1.8.0_202.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatTestLaf_1.8.0_202.txt
@@ -551,7 +551,7 @@ MenuItem.textAcceleratorGap    24
 MenuItem.textNoAcceleratorGap  6
 MenuItem.underlineSelectionBackground #e6e6e6    javax.swing.plaf.ColorUIResource [UI]
 MenuItem.underlineSelectionCheckBackground #ccccff    javax.swing.plaf.ColorUIResource [UI]
-MenuItem.underlineSelectionColor #4a88c7    javax.swing.plaf.ColorUIResource [UI]
+MenuItem.underlineSelectionColor #ffff00    javax.swing.plaf.ColorUIResource [UI]
 MenuItem.underlineSelectionHeight 3
 
 
@@ -909,7 +909,7 @@ TabbedPane.closeIcon           [lazy] 16,16    com.formdev.flatlaf.icons.FlatTab
 TabbedPane.closePressedBackground #00ff00    javax.swing.plaf.ColorUIResource [UI]
 TabbedPane.closePressedForeground #000000    javax.swing.plaf.ColorUIResource [UI]
 TabbedPane.closeSize           16,16    javax.swing.plaf.DimensionUIResource [UI]
-TabbedPane.contentAreaColor    #bbbbbb    javax.swing.plaf.ColorUIResource [UI]
+TabbedPane.contentAreaColor    #ff0000    javax.swing.plaf.ColorUIResource [UI]
 TabbedPane.contentOpaque       true
 TabbedPane.contentSeparatorHeight 1
 TabbedPane.darkShadow          #696969    javax.swing.plaf.ColorUIResource [UI]
@@ -943,7 +943,7 @@ TabbedPane.tabSeparatorsFullHeight false
 TabbedPane.tabsOpaque          true
 TabbedPane.tabsOverlapBorder   false
 TabbedPane.textIconGap         4
-TabbedPane.underlineColor      #4a88c7    javax.swing.plaf.ColorUIResource [UI]
+TabbedPane.underlineColor      #ffff00    javax.swing.plaf.ColorUIResource [UI]
 TabbedPaneUI                   com.formdev.flatlaf.ui.FlatTabbedPaneUI
 
 
@@ -1138,7 +1138,7 @@ ToggleButton.tab.disabledUnderlineColor #7a7a7a    javax.swing.plaf.ColorUIResou
 ToggleButton.tab.focusBackground #dddddd    javax.swing.plaf.ColorUIResource [UI]
 ToggleButton.tab.hoverBackground #eeeeee    javax.swing.plaf.ColorUIResource [UI]
 ToggleButton.tab.selectedBackground #00ff00    javax.swing.plaf.ColorUIResource [UI]
-ToggleButton.tab.underlineColor #4a88c7    javax.swing.plaf.ColorUIResource [UI]
+ToggleButton.tab.underlineColor #ffff00    javax.swing.plaf.ColorUIResource [UI]
 ToggleButton.tab.underlineHeight 2
 ToggleButton.textIconGap       4
 ToggleButton.textShiftOffset   0

--- a/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatContainerTest.java
+++ b/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatContainerTest.java
@@ -176,6 +176,17 @@ public class FlatContainerTest
 			tabbedPane.setIconAt( i, icon );
 	}
 
+	private void iconPlacementChanged() {
+		Object iconPlacement = null;
+		switch( (String) iconPlacementField.getSelectedItem() ) {
+			case "leading":		iconPlacement = SwingConstants.LEADING; break;
+			case "trailing":	iconPlacement = SwingConstants.TRAILING; break;
+			case "top":			iconPlacement = SwingConstants.TOP; break;
+			case "bottom":		iconPlacement = SwingConstants.BOTTOM; break;
+		}
+		putTabbedPanesClientProperty( TABBED_PANE_TAB_ICON_PLACEMENT, iconPlacement );
+	}
+
 	private void customBorderChanged() {
 		Border border = customBorderCheckBox.isSelected()
 			? new MatteBorder( 10, 20, 25, 35, Color.green )
@@ -390,6 +401,7 @@ public class FlatContainerTest
 		tabPlacementField = new JComboBox<>();
 		tabIconsCheckBox = new JCheckBox();
 		tabIconSizeSpinner = new JSpinner();
+		iconPlacementField = new JComboBox<>();
 		JLabel tabAreaAlignmentLabel = new JLabel();
 		tabAreaAlignmentField = new JComboBox<>();
 		JLabel tabWidthModeLabel = new JLabel();
@@ -592,6 +604,16 @@ public class FlatContainerTest
 				tabIconSizeSpinner.addChangeListener(e -> tabIconsChanged());
 				tabbedPaneControlPanel.add(tabIconSizeSpinner, "cell 2 2");
 
+				//---- iconPlacementField ----
+				iconPlacementField.setModel(new DefaultComboBoxModel<>(new String[] {
+					"leading",
+					"trailing",
+					"top",
+					"bottom"
+				}));
+				iconPlacementField.addActionListener(e -> iconPlacementChanged());
+				tabbedPaneControlPanel.add(iconPlacementField, "cell 2 2");
+
 				//---- tabAreaAlignmentLabel ----
 				tabAreaAlignmentLabel.setText("Tab area alignment:");
 				tabbedPaneControlPanel.add(tabAreaAlignmentLabel, "cell 0 3");
@@ -710,6 +732,7 @@ public class FlatContainerTest
 	private JComboBox<String> tabPlacementField;
 	private JCheckBox tabIconsCheckBox;
 	private JSpinner tabIconSizeSpinner;
+	private JComboBox<String> iconPlacementField;
 	private JComboBox<String> tabAreaAlignmentField;
 	private JComboBox<String> tabWidthModeField;
 	private JCheckBox tabsClosableCheckBox;

--- a/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatContainerTest.java
+++ b/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatContainerTest.java
@@ -112,6 +112,8 @@ public class FlatContainerTest
 		}
 
 		customTabsChanged( tabbedPane );
+		tabBackForegroundChanged( tabbedPane );
+		setTabIcons( tabbedPane );
 	}
 
 	private void addTab( JTabbedPane tabbedPane ) {
@@ -154,24 +156,26 @@ public class FlatContainerTest
 	}
 
 	private void tabIconsChanged() {
-		boolean showTabIcons = tabIconsCheckBox.isSelected();
+		setTabIcons( tabbedPane1 );
+		setTabIcons( tabbedPane2 );
+		setTabIcons( tabbedPane3 );
+		setTabIcons( tabbedPane4 );
 
-		setTabIcons( tabbedPane1, showTabIcons );
-		setTabIcons( tabbedPane2, showTabIcons );
-		setTabIcons( tabbedPane3, showTabIcons );
-		setTabIcons( tabbedPane4, showTabIcons );
-
-		tabIconSizeSpinner.setEnabled( showTabIcons );
+		tabIconSizeSpinner.setEnabled( tabIconsCheckBox.isSelected() );
 	}
 
-	private void setTabIcons( JTabbedPane tabbedPane, boolean showTabIcons ) {
+	private void setTabIcons( JTabbedPane tabbedPane ) {
+		boolean showTabIcons = tabIconsCheckBox.isSelected();
 		Object iconSize = tabIconSizeSpinner.getValue();
 
 		Icon icon = showTabIcons
 			? new ScaledImageIcon( new ImageIcon( getClass().getResource( "/com/formdev/flatlaf/testing/test" + iconSize + ".png" ) ) )
 			: null;
-		tabbedPane.setIconAt( 0, icon );
-		tabbedPane.setIconAt( 1, icon );
+		int tabCount = tabbedPane.getTabCount();
+		if( tabCount > 0 )
+			tabbedPane.setIconAt( 0, icon );
+		if( tabCount > 1 )
+			tabbedPane.setIconAt( 1, icon );
 	}
 
 	private void customBorderChanged() {
@@ -195,11 +199,11 @@ public class FlatContainerTest
 	private void customTabsChanged( JTabbedPane tabbedPane ) {
 		boolean customTabs = customTabsCheckBox.isSelected();
 		int tabCount = tabbedPane.getTabCount();
-		if( tabCount >= 2 )
+		if( tabCount > 1 )
 			tabbedPane.setTabComponentAt( 1, customTabs ? new JButton( tabbedPane.getTitleAt( 1 ) ) : null );
-		if( tabCount >= 4 )
+		if( tabCount > 3 )
 			tabbedPane.setTabComponentAt( 3, customTabs ? createCustomTab( tabbedPane.getTitleAt( 3 ) ) : null );
-		if( tabCount >= 6 )
+		if( tabCount > 5 )
 			tabbedPane.setTabComponentAt( 5, customTabs ? new JCheckBox( tabbedPane.getTitleAt( 5 ) ) : null );
 	}
 
@@ -235,19 +239,33 @@ public class FlatContainerTest
 	}
 
 	private void hiddenTabsNavigationChanged() {
-		String value = null;
-		switch( (String) hiddenTabsNavigationField.getSelectedItem() ) {
-			case "moreTabsButton":	value = TABBED_PANE_HIDDEN_TABS_NAVIGATION_MORE_TABS_BUTTON; break;
-			case "arrowButtons":	value = TABBED_PANE_HIDDEN_TABS_NAVIGATION_ARROW_BUTTONS; break;
-		}
-
+		String value = (String) hiddenTabsNavigationField.getSelectedItem();
+		if( "default".equals( value ) )
+			value = null;
 		putTabbedPanesClientProperty( TABBED_PANE_HIDDEN_TABS_NAVIGATION, value );
 	}
 
+	private void tabAreaAlignmentChanged() {
+		String value = (String) tabAreaAlignmentField.getSelectedItem();
+		if( "default".equals( value ) )
+			value = null;
+		putTabbedPanesClientProperty( TABBED_PANE_TAB_AREA_ALIGNMENT, value );
+	}
+
 	private void tabBackForegroundChanged() {
+		tabBackForegroundChanged( tabbedPane1 );
+		tabBackForegroundChanged( tabbedPane2 );
+		tabBackForegroundChanged( tabbedPane3 );
+		tabBackForegroundChanged( tabbedPane4 );
+	}
+
+	private void tabBackForegroundChanged( JTabbedPane tabbedPane ) {
 		boolean enabled = tabBackForegroundCheckBox.isSelected();
-		tabbedPane1.setBackgroundAt( 0, enabled ? Color.red : null );
-		tabbedPane1.setForegroundAt( 1, enabled ? Color.red : null );
+		int tabCount = tabbedPane.getTabCount();
+		if( tabCount > 0 )
+			tabbedPane.setBackgroundAt( 0, enabled ? Color.red : null );
+		if( tabCount > 1 )
+			tabbedPane.setForegroundAt( 1, enabled ? Color.red : null );
 	}
 
 	private void leadingComponentChanged() {
@@ -293,13 +311,15 @@ public class FlatContainerTest
 
 		JTabbedPane[] tabbedPanes = new JTabbedPane[] { tabbedPane1, tabbedPane2, tabbedPane3, tabbedPane4 };
 		for( JTabbedPane tabbedPane : tabbedPanes ) {
-			Component c = tabbedPane.getComponentAt( 1 );
-			((JComponent)c).putClientProperty( TABBED_PANE_TAB_CLOSABLE, value );
+			if( tabbedPane.getTabCount() > 1 ) {
+				Component c = tabbedPane.getComponentAt( 1 );
+				((JComponent)c).putClientProperty( TABBED_PANE_TAB_CLOSABLE, value );
+			}
 		}
 	}
 
 	private void tabAreaInsetsChanged() {
-		UIManager.put( "TabbedPane.tabAreaInsets", tabAreaInsetsCheckBox.isSelected() ? new Insets( 10, 10, 25, 25 ) : null );
+		UIManager.put( "TabbedPane.tabAreaInsets", tabAreaInsetsCheckBox.isSelected() ? new Insets( 5, 5, 10, 10 ) : null );
 		FlatLaf.updateUI();
 	}
 
@@ -318,8 +338,10 @@ public class FlatContainerTest
 
 		JTabbedPane[] tabbedPanes = new JTabbedPane[] { tabbedPane1, tabbedPane2, tabbedPane3, tabbedPane4 };
 		for( JTabbedPane tabbedPane : tabbedPanes ) {
-			Component c = tabbedPane.getComponentAt( 1 );
-			((JComponent)c).putClientProperty( TABBED_PANE_TAB_INSETS, insets );
+			if( tabbedPane.getTabCount() > 1 ) {
+				Component c = tabbedPane.getComponentAt( 1 );
+				((JComponent)c).putClientProperty( TABBED_PANE_TAB_INSETS, insets );
+			}
 		}
 	}
 
@@ -363,6 +385,8 @@ public class FlatContainerTest
 		tabPlacementField = new JComboBox<>();
 		tabIconsCheckBox = new JCheckBox();
 		tabIconSizeSpinner = new JSpinner();
+		JLabel tabAreaAlignmentLabel = new JLabel();
+		tabAreaAlignmentField = new JComboBox<>();
 		tabsClosableCheckBox = new JCheckBox();
 		customBorderCheckBox = new JCheckBox();
 		tabAreaInsetsCheckBox = new JCheckBox();
@@ -488,6 +512,7 @@ public class FlatContainerTest
 					// rows
 					"[center]" +
 					"[]" +
+					"[]" +
 					"[]para" +
 					"[]" +
 					"[]para" +
@@ -560,75 +585,90 @@ public class FlatContainerTest
 				tabIconSizeSpinner.addChangeListener(e -> tabIconsChanged());
 				tabbedPaneControlPanel.add(tabIconSizeSpinner, "cell 2 2");
 
+				//---- tabAreaAlignmentLabel ----
+				tabAreaAlignmentLabel.setText("Tab area alignment:");
+				tabbedPaneControlPanel.add(tabAreaAlignmentLabel, "cell 0 3");
+
+				//---- tabAreaAlignmentField ----
+				tabAreaAlignmentField.setModel(new DefaultComboBoxModel<>(new String[] {
+					"default",
+					"leading",
+					"trailing",
+					"center",
+					"fill"
+				}));
+				tabAreaAlignmentField.addActionListener(e -> tabAreaAlignmentChanged());
+				tabbedPaneControlPanel.add(tabAreaAlignmentField, "cell 1 3");
+
 				//---- tabsClosableCheckBox ----
 				tabsClosableCheckBox.setText("Tabs closable");
 				tabsClosableCheckBox.addActionListener(e -> tabsClosableChanged());
-				tabbedPaneControlPanel.add(tabsClosableCheckBox, "cell 0 3");
+				tabbedPaneControlPanel.add(tabsClosableCheckBox, "cell 0 4");
 
 				//---- customBorderCheckBox ----
 				customBorderCheckBox.setText("Custom border");
 				customBorderCheckBox.addActionListener(e -> customBorderChanged());
-				tabbedPaneControlPanel.add(customBorderCheckBox, "cell 1 3");
+				tabbedPaneControlPanel.add(customBorderCheckBox, "cell 1 4");
 
 				//---- tabAreaInsetsCheckBox ----
-				tabAreaInsetsCheckBox.setText("Tab area insets (10,10,25,25)");
+				tabAreaInsetsCheckBox.setText("Tab area insets (5,5,10,10)");
 				tabAreaInsetsCheckBox.addActionListener(e -> tabAreaInsetsChanged());
-				tabbedPaneControlPanel.add(tabAreaInsetsCheckBox, "cell 2 3");
+				tabbedPaneControlPanel.add(tabAreaInsetsCheckBox, "cell 2 4");
 
 				//---- secondTabClosableCheckBox ----
 				secondTabClosableCheckBox.setText("Second Tab closable");
 				secondTabClosableCheckBox.addActionListener(e -> secondTabClosableChanged());
-				tabbedPaneControlPanel.add(secondTabClosableCheckBox, "cell 0 4");
+				tabbedPaneControlPanel.add(secondTabClosableCheckBox, "cell 0 5");
 
 				//---- hasFullBorderCheckBox ----
 				hasFullBorderCheckBox.setText("Show content border");
 				hasFullBorderCheckBox.addActionListener(e -> hasFullBorderChanged());
-				tabbedPaneControlPanel.add(hasFullBorderCheckBox, "cell 1 4,alignx left,growx 0");
+				tabbedPaneControlPanel.add(hasFullBorderCheckBox, "cell 1 5,alignx left,growx 0");
 
 				//---- smallerTabHeightCheckBox ----
 				smallerTabHeightCheckBox.setText("Smaller tab height (26)");
 				smallerTabHeightCheckBox.addActionListener(e -> smallerTabHeightChanged());
-				tabbedPaneControlPanel.add(smallerTabHeightCheckBox, "cell 2 4");
+				tabbedPaneControlPanel.add(smallerTabHeightCheckBox, "cell 2 5");
 
 				//---- leadingComponentCheckBox ----
 				leadingComponentCheckBox.setText("Leading component");
 				leadingComponentCheckBox.addActionListener(e -> leadingComponentChanged());
-				tabbedPaneControlPanel.add(leadingComponentCheckBox, "cell 0 5");
+				tabbedPaneControlPanel.add(leadingComponentCheckBox, "cell 0 6");
 
 				//---- hideContentSeparatorCheckBox ----
 				hideContentSeparatorCheckBox.setText("Hide content separator");
 				hideContentSeparatorCheckBox.addActionListener(e -> hideContentSeparatorChanged());
-				tabbedPaneControlPanel.add(hideContentSeparatorCheckBox, "cell 1 5");
+				tabbedPaneControlPanel.add(hideContentSeparatorCheckBox, "cell 1 6");
 
 				//---- smallerInsetsCheckBox ----
 				smallerInsetsCheckBox.setText("Smaller tab insets (2,2,2,2)");
 				smallerInsetsCheckBox.addActionListener(e -> smallerInsetsChanged());
-				tabbedPaneControlPanel.add(smallerInsetsCheckBox, "cell 2 5");
+				tabbedPaneControlPanel.add(smallerInsetsCheckBox, "cell 2 6");
 
 				//---- trailingComponentCheckBox ----
 				trailingComponentCheckBox.setText("Trailing component");
 				trailingComponentCheckBox.addActionListener(e -> trailingComponentChanged());
-				tabbedPaneControlPanel.add(trailingComponentCheckBox, "cell 0 6");
+				tabbedPaneControlPanel.add(trailingComponentCheckBox, "cell 0 7");
 
 				//---- showTabSeparatorsCheckBox ----
 				showTabSeparatorsCheckBox.setText("Show tab separators");
 				showTabSeparatorsCheckBox.addActionListener(e -> showTabSeparatorsChanged());
-				tabbedPaneControlPanel.add(showTabSeparatorsCheckBox, "cell 1 6");
+				tabbedPaneControlPanel.add(showTabSeparatorsCheckBox, "cell 1 7");
 
 				//---- secondTabWiderCheckBox ----
 				secondTabWiderCheckBox.setText("Second Tab insets wider (4,20,4,20)");
 				secondTabWiderCheckBox.addActionListener(e -> secondTabWiderChanged());
-				tabbedPaneControlPanel.add(secondTabWiderCheckBox, "cell 2 6");
+				tabbedPaneControlPanel.add(secondTabWiderCheckBox, "cell 2 7");
 
 				//---- minimumTabWidthCheckBox ----
 				minimumTabWidthCheckBox.setText("Minimum tab width (100)");
 				minimumTabWidthCheckBox.addActionListener(e -> minimumTabWidthChanged());
-				tabbedPaneControlPanel.add(minimumTabWidthCheckBox, "cell 2 7");
+				tabbedPaneControlPanel.add(minimumTabWidthCheckBox, "cell 2 8");
 
 				//---- maximumTabWidthCheckBox ----
 				maximumTabWidthCheckBox.setText("Maximum tab width (60)");
 				maximumTabWidthCheckBox.addActionListener(e -> maximumTabWidthChanged());
-				tabbedPaneControlPanel.add(maximumTabWidthCheckBox, "cell 2 8");
+				tabbedPaneControlPanel.add(maximumTabWidthCheckBox, "cell 2 9");
 			}
 			panel9.add(tabbedPaneControlPanel, cc.xywh(1, 11, 3, 1));
 		}
@@ -649,6 +689,7 @@ public class FlatContainerTest
 	private JComboBox<String> tabPlacementField;
 	private JCheckBox tabIconsCheckBox;
 	private JSpinner tabIconSizeSpinner;
+	private JComboBox<String> tabAreaAlignmentField;
 	private JCheckBox tabsClosableCheckBox;
 	private JCheckBox customBorderCheckBox;
 	private JCheckBox tabAreaInsetsCheckBox;

--- a/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatContainerTest.java
+++ b/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatContainerTest.java
@@ -323,6 +323,16 @@ public class FlatContainerTest
 		}
 	}
 
+	private void minimumTabWidthChanged() {
+		Integer minimumTabWidth = minimumTabWidthCheckBox.isSelected() ? 100 : null;
+		putTabbedPanesClientProperty( TABBED_PANE_MINIMUM_TAB_WIDTH, minimumTabWidth );
+	}
+
+	private void maximumTabWidthChanged() {
+		Integer maximumTabWidth = maximumTabWidthCheckBox.isSelected() ? 60 : null;
+		putTabbedPanesClientProperty( TABBED_PANE_MAXIMUM_TAB_WIDTH, maximumTabWidth );
+	}
+
 	private void initComponents() {
 		// JFormDesigner - Component initialization - DO NOT MODIFY  //GEN-BEGIN:initComponents
 		JPanel panel9 = new JPanel();
@@ -365,6 +375,8 @@ public class FlatContainerTest
 		trailingComponentCheckBox = new JCheckBox();
 		showTabSeparatorsCheckBox = new JCheckBox();
 		secondTabWiderCheckBox = new JCheckBox();
+		minimumTabWidthCheckBox = new JCheckBox();
+		maximumTabWidthCheckBox = new JCheckBox();
 		CellConstraints cc = new CellConstraints();
 
 		//======== this ========
@@ -475,6 +487,8 @@ public class FlatContainerTest
 					"[]",
 					// rows
 					"[center]" +
+					"[]" +
+					"[]para" +
 					"[]" +
 					"[]para" +
 					"[]" +
@@ -605,6 +619,16 @@ public class FlatContainerTest
 				secondTabWiderCheckBox.setText("Second Tab insets wider (4,20,4,20)");
 				secondTabWiderCheckBox.addActionListener(e -> secondTabWiderChanged());
 				tabbedPaneControlPanel.add(secondTabWiderCheckBox, "cell 2 6");
+
+				//---- minimumTabWidthCheckBox ----
+				minimumTabWidthCheckBox.setText("Minimum tab width (100)");
+				minimumTabWidthCheckBox.addActionListener(e -> minimumTabWidthChanged());
+				tabbedPaneControlPanel.add(minimumTabWidthCheckBox, "cell 2 7");
+
+				//---- maximumTabWidthCheckBox ----
+				maximumTabWidthCheckBox.setText("Maximum tab width (60)");
+				maximumTabWidthCheckBox.addActionListener(e -> maximumTabWidthChanged());
+				tabbedPaneControlPanel.add(maximumTabWidthCheckBox, "cell 2 8");
 			}
 			panel9.add(tabbedPaneControlPanel, cc.xywh(1, 11, 3, 1));
 		}
@@ -637,6 +661,8 @@ public class FlatContainerTest
 	private JCheckBox trailingComponentCheckBox;
 	private JCheckBox showTabSeparatorsCheckBox;
 	private JCheckBox secondTabWiderCheckBox;
+	private JCheckBox minimumTabWidthCheckBox;
+	private JCheckBox maximumTabWidthCheckBox;
 	// JFormDesigner - End of variables declaration  //GEN-END:variables
 
 	//---- class Tab1Panel ----------------------------------------------------

--- a/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatContainerTest.java
+++ b/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatContainerTest.java
@@ -168,12 +168,21 @@ public class FlatContainerTest
 		boolean showTabIcons = tabIconsCheckBox.isSelected();
 		Object iconSize = tabIconSizeSpinner.getValue();
 
-		Icon icon = showTabIcons
-			? new ScaledImageIcon( new ImageIcon( getClass().getResource( "/com/formdev/flatlaf/testing/test" + iconSize + ".png" ) ) )
-			: null;
+		Icon icon = null;
+		Icon disabledIcon = null;
+		if( showTabIcons ) {
+			ImageIcon imageIcon = new ImageIcon( getClass().getResource( "/com/formdev/flatlaf/testing/test" + iconSize + ".png" ) );
+			icon = new ScaledImageIcon( imageIcon );
+			disabledIcon = UIManager.getLookAndFeel().getDisabledIcon( tabbedPane, imageIcon );
+			if( disabledIcon instanceof ImageIcon )
+				disabledIcon = new ScaledImageIcon( (ImageIcon) disabledIcon );
+		}
+
 		int tabCount = tabbedPane.getTabCount();
-		for( int i = 0; i < tabCount; i++ )
+		for( int i = 0; i < tabCount; i++ ) {
 			tabbedPane.setIconAt( i, icon );
+			tabbedPane.setDisabledIconAt( i, disabledIcon );
+		}
 	}
 
 	private void iconPlacementChanged() {

--- a/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatContainerTest.java
+++ b/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatContainerTest.java
@@ -172,10 +172,8 @@ public class FlatContainerTest
 			? new ScaledImageIcon( new ImageIcon( getClass().getResource( "/com/formdev/flatlaf/testing/test" + iconSize + ".png" ) ) )
 			: null;
 		int tabCount = tabbedPane.getTabCount();
-		if( tabCount > 0 )
-			tabbedPane.setIconAt( 0, icon );
-		if( tabCount > 1 )
-			tabbedPane.setIconAt( 1, icon );
+		for( int i = 0; i < tabCount; i++ )
+			tabbedPane.setIconAt( i, icon );
 	}
 
 	private void customBorderChanged() {
@@ -250,6 +248,13 @@ public class FlatContainerTest
 		if( "default".equals( value ) )
 			value = null;
 		putTabbedPanesClientProperty( TABBED_PANE_TAB_AREA_ALIGNMENT, value );
+	}
+
+	private void tabWidthModeChanged() {
+		String value = (String) tabWidthModeField.getSelectedItem();
+		if( "default".equals( value ) )
+			value = null;
+		putTabbedPanesClientProperty( TABBED_PANE_TAB_WIDTH_MODE, value );
 	}
 
 	private void tabBackForegroundChanged() {
@@ -387,6 +392,8 @@ public class FlatContainerTest
 		tabIconSizeSpinner = new JSpinner();
 		JLabel tabAreaAlignmentLabel = new JLabel();
 		tabAreaAlignmentField = new JComboBox<>();
+		JLabel tabWidthModeLabel = new JLabel();
+		tabWidthModeField = new JComboBox<>();
 		tabsClosableCheckBox = new JCheckBox();
 		customBorderCheckBox = new JCheckBox();
 		tabAreaInsetsCheckBox = new JCheckBox();
@@ -600,6 +607,20 @@ public class FlatContainerTest
 				tabAreaAlignmentField.addActionListener(e -> tabAreaAlignmentChanged());
 				tabbedPaneControlPanel.add(tabAreaAlignmentField, "cell 1 3");
 
+				//---- tabWidthModeLabel ----
+				tabWidthModeLabel.setText("Tab width mode:");
+				tabbedPaneControlPanel.add(tabWidthModeLabel, "cell 2 3");
+
+				//---- tabWidthModeField ----
+				tabWidthModeField.setModel(new DefaultComboBoxModel<>(new String[] {
+					"default",
+					"preferred",
+					"equal",
+					"compact"
+				}));
+				tabWidthModeField.addActionListener(e -> tabWidthModeChanged());
+				tabbedPaneControlPanel.add(tabWidthModeField, "cell 2 3");
+
 				//---- tabsClosableCheckBox ----
 				tabsClosableCheckBox.setText("Tabs closable");
 				tabsClosableCheckBox.addActionListener(e -> tabsClosableChanged());
@@ -690,6 +711,7 @@ public class FlatContainerTest
 	private JCheckBox tabIconsCheckBox;
 	private JSpinner tabIconSizeSpinner;
 	private JComboBox<String> tabAreaAlignmentField;
+	private JComboBox<String> tabWidthModeField;
 	private JCheckBox tabsClosableCheckBox;
 	private JCheckBox customBorderCheckBox;
 	private JCheckBox tabAreaInsetsCheckBox;

--- a/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatContainerTest.java
+++ b/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatContainerTest.java
@@ -232,6 +232,26 @@ public class FlatContainerTest
 		return tab;
 	}
 
+	private void htmlTabsChanged() {
+		htmlTabsChanged( tabbedPane1 );
+		htmlTabsChanged( tabbedPane2 );
+		htmlTabsChanged( tabbedPane3 );
+		htmlTabsChanged( tabbedPane4 );
+	}
+
+	private void htmlTabsChanged( JTabbedPane tabbedPane ) {
+		boolean html = htmlTabsCheckBox.isSelected();
+		boolean multiLine = multiLineTabsCheckBox.isSelected();
+		String s = multiLine
+			? "<html><b>Bold</b> Tab<br>Second <i>Line</i> "
+			: (html ? "<html><b>Bold</b> Tab " : "Tab ");
+		int tabCount = tabbedPane.getTabCount();
+		if( tabCount > 0 )
+			tabbedPane.setTitleAt( 0, s + "1" );
+		if( tabCount > 3 )
+			tabbedPane.setTitleAt( 3, s + "4" );
+	}
+
 	private void tabPlacementChanged() {
 		int tabPlacement = -1;
 		switch( (String) tabPlacementField.getSelectedItem() ) {
@@ -394,6 +414,8 @@ public class FlatContainerTest
 		JLabel tabCountLabel = new JLabel();
 		tabCountSpinner = new JSpinner();
 		customTabsCheckBox = new JCheckBox();
+		htmlTabsCheckBox = new JCheckBox();
+		multiLineTabsCheckBox = new JCheckBox();
 		JLabel hiddenTabsNavigationLabel = new JLabel();
 		hiddenTabsNavigationField = new JComboBox<>();
 		tabBackForegroundCheckBox = new JCheckBox();
@@ -559,6 +581,16 @@ public class FlatContainerTest
 				customTabsCheckBox.setText("Custom tabs");
 				customTabsCheckBox.addActionListener(e -> customTabsChanged());
 				tabbedPaneControlPanel.add(customTabsCheckBox, "cell 2 0");
+
+				//---- htmlTabsCheckBox ----
+				htmlTabsCheckBox.setText("HTML");
+				htmlTabsCheckBox.addActionListener(e -> htmlTabsChanged());
+				tabbedPaneControlPanel.add(htmlTabsCheckBox, "cell 2 0");
+
+				//---- multiLineTabsCheckBox ----
+				multiLineTabsCheckBox.setText("multi-line");
+				multiLineTabsCheckBox.addActionListener(e -> htmlTabsChanged());
+				tabbedPaneControlPanel.add(multiLineTabsCheckBox, "cell 2 0");
 
 				//---- hiddenTabsNavigationLabel ----
 				hiddenTabsNavigationLabel.setText("Hidden tabs navigation:");
@@ -727,6 +759,8 @@ public class FlatContainerTest
 	private JCheckBox tabScrollCheckBox;
 	private JSpinner tabCountSpinner;
 	private JCheckBox customTabsCheckBox;
+	private JCheckBox htmlTabsCheckBox;
+	private JCheckBox multiLineTabsCheckBox;
 	private JComboBox<String> hiddenTabsNavigationField;
 	private JCheckBox tabBackForegroundCheckBox;
 	private JComboBox<String> tabPlacementField;

--- a/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatContainerTest.java
+++ b/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatContainerTest.java
@@ -324,8 +324,8 @@ public class FlatContainerTest
 	}
 
 	private void tabAreaInsetsChanged() {
-		UIManager.put( "TabbedPane.tabAreaInsets", tabAreaInsetsCheckBox.isSelected() ? new Insets( 5, 5, 10, 10 ) : null );
-		FlatLaf.updateUI();
+		Insets insets = tabAreaInsetsCheckBox.isSelected() ? new Insets( 5, 5, 10, 10 ) : null;
+		putTabbedPanesClientProperty( TABBED_PANE_TAB_AREA_INSETS, insets );
 	}
 
 	private void smallerTabHeightChanged() {

--- a/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatContainerTest.jfd
+++ b/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatContainerTest.jfd
@@ -132,7 +132,7 @@ new FormModel {
 				add( new FormContainer( "com.formdev.flatlaf.testing.FlatTestFrame$NoRightToLeftPanel", new FormLayoutManager( class net.miginfocom.swing.MigLayout ) {
 					"$layoutConstraints": "insets 0,hidemode 3"
 					"$columnConstraints": "[][fill][]"
-					"$rowConstraints": "[center][][]para[][]para[][]para[][]"
+					"$rowConstraints": "[center][][][]para[][]para[][]para[][]"
 				} ) {
 					name: "tabbedPaneControlPanel"
 					"opaque": false
@@ -261,6 +261,30 @@ new FormModel {
 					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
 						"value": "cell 2 2"
 					} )
+					add( new FormComponent( "javax.swing.JLabel" ) {
+						name: "tabAreaAlignmentLabel"
+						"text": "Tab area alignment:"
+					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+						"value": "cell 0 3"
+					} )
+					add( new FormComponent( "javax.swing.JComboBox" ) {
+						name: "tabAreaAlignmentField"
+						"model": new javax.swing.DefaultComboBoxModel {
+							selectedItem: "default"
+							addElement( "default" )
+							addElement( "leading" )
+							addElement( "trailing" )
+							addElement( "center" )
+							addElement( "fill" )
+						}
+						auxiliary() {
+							"JavaCodeGenerator.variableLocal": false
+							"JavaCodeGenerator.typeParameters": "String"
+						}
+						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "tabAreaAlignmentChanged", false ) )
+					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+						"value": "cell 1 3"
+					} )
 					add( new FormComponent( "javax.swing.JCheckBox" ) {
 						name: "tabsClosableCheckBox"
 						"text": "Tabs closable"
@@ -269,7 +293,7 @@ new FormModel {
 						}
 						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "tabsClosableChanged", false ) )
 					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-						"value": "cell 0 3"
+						"value": "cell 0 4"
 					} )
 					add( new FormComponent( "javax.swing.JCheckBox" ) {
 						name: "customBorderCheckBox"
@@ -279,17 +303,17 @@ new FormModel {
 						}
 						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "customBorderChanged", false ) )
 					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-						"value": "cell 1 3"
+						"value": "cell 1 4"
 					} )
 					add( new FormComponent( "javax.swing.JCheckBox" ) {
 						name: "tabAreaInsetsCheckBox"
-						"text": "Tab area insets (10,10,25,25)"
+						"text": "Tab area insets (5,5,10,10)"
 						auxiliary() {
 							"JavaCodeGenerator.variableLocal": false
 						}
 						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "tabAreaInsetsChanged", false ) )
 					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-						"value": "cell 2 3"
+						"value": "cell 2 4"
 					} )
 					add( new FormComponent( "com.formdev.flatlaf.extras.TriStateCheckBox" ) {
 						name: "secondTabClosableCheckBox"
@@ -299,7 +323,7 @@ new FormModel {
 						}
 						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "secondTabClosableChanged", false ) )
 					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-						"value": "cell 0 4"
+						"value": "cell 0 5"
 					} )
 					add( new FormComponent( "javax.swing.JCheckBox" ) {
 						name: "hasFullBorderCheckBox"
@@ -309,7 +333,7 @@ new FormModel {
 						}
 						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "hasFullBorderChanged", false ) )
 					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-						"value": "cell 1 4,alignx left,growx 0"
+						"value": "cell 1 5,alignx left,growx 0"
 					} )
 					add( new FormComponent( "javax.swing.JCheckBox" ) {
 						name: "smallerTabHeightCheckBox"
@@ -319,7 +343,7 @@ new FormModel {
 						}
 						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "smallerTabHeightChanged", false ) )
 					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-						"value": "cell 2 4"
+						"value": "cell 2 5"
 					} )
 					add( new FormComponent( "javax.swing.JCheckBox" ) {
 						name: "leadingComponentCheckBox"
@@ -329,7 +353,7 @@ new FormModel {
 						}
 						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "leadingComponentChanged", false ) )
 					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-						"value": "cell 0 5"
+						"value": "cell 0 6"
 					} )
 					add( new FormComponent( "javax.swing.JCheckBox" ) {
 						name: "hideContentSeparatorCheckBox"
@@ -339,7 +363,7 @@ new FormModel {
 						}
 						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "hideContentSeparatorChanged", false ) )
 					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-						"value": "cell 1 5"
+						"value": "cell 1 6"
 					} )
 					add( new FormComponent( "javax.swing.JCheckBox" ) {
 						name: "smallerInsetsCheckBox"
@@ -349,7 +373,7 @@ new FormModel {
 						}
 						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "smallerInsetsChanged", false ) )
 					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-						"value": "cell 2 5"
+						"value": "cell 2 6"
 					} )
 					add( new FormComponent( "javax.swing.JCheckBox" ) {
 						name: "trailingComponentCheckBox"
@@ -359,7 +383,7 @@ new FormModel {
 						}
 						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "trailingComponentChanged", false ) )
 					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-						"value": "cell 0 6"
+						"value": "cell 0 7"
 					} )
 					add( new FormComponent( "javax.swing.JCheckBox" ) {
 						name: "showTabSeparatorsCheckBox"
@@ -369,7 +393,7 @@ new FormModel {
 						}
 						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "showTabSeparatorsChanged", false ) )
 					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-						"value": "cell 1 6"
+						"value": "cell 1 7"
 					} )
 					add( new FormComponent( "javax.swing.JCheckBox" ) {
 						name: "secondTabWiderCheckBox"
@@ -379,7 +403,7 @@ new FormModel {
 						}
 						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "secondTabWiderChanged", false ) )
 					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-						"value": "cell 2 6"
+						"value": "cell 2 7"
 					} )
 					add( new FormComponent( "javax.swing.JCheckBox" ) {
 						name: "minimumTabWidthCheckBox"
@@ -389,7 +413,7 @@ new FormModel {
 						}
 						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "minimumTabWidthChanged", false ) )
 					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-						"value": "cell 2 7"
+						"value": "cell 2 8"
 					} )
 					add( new FormComponent( "javax.swing.JCheckBox" ) {
 						name: "maximumTabWidthCheckBox"
@@ -399,7 +423,7 @@ new FormModel {
 						}
 						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "maximumTabWidthChanged", false ) )
 					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-						"value": "cell 2 8"
+						"value": "cell 2 9"
 					} )
 				}, new FormLayoutConstraints( class com.jgoodies.forms.layout.CellConstraints ) {
 					"gridY": 11
@@ -410,7 +434,7 @@ new FormModel {
 			} )
 		}, new FormLayoutConstraints( null ) {
 			"location": new java.awt.Point( 0, 0 )
-			"size": new java.awt.Dimension( 810, 745 )
+			"size": new java.awt.Dimension( 810, 860 )
 		} )
 		add( new FormContainer( "javax.swing.JPanel", new FormLayoutManager( class net.miginfocom.swing.MigLayout ) {
 			"$layoutConstraints": "hidemode 3,align center center"
@@ -440,7 +464,7 @@ new FormModel {
 				"value": "cell 2 0"
 			} )
 		}, new FormLayoutConstraints( null ) {
-			"location": new java.awt.Point( 0, 790 )
+			"location": new java.awt.Point( 0, 890 )
 			"size": new java.awt.Dimension( 291, 118 )
 		} )
 		add( new FormContainer( "javax.swing.JPanel", new FormLayoutManager( class net.miginfocom.swing.MigLayout ) {
@@ -465,7 +489,7 @@ new FormModel {
 				"value": "cell 1 0"
 			} )
 		}, new FormLayoutConstraints( null ) {
-			"location": new java.awt.Point( 340, 790 )
+			"location": new java.awt.Point( 340, 890 )
 			"size": new java.awt.Dimension( 291, 118 )
 		} )
 	}

--- a/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatContainerTest.jfd
+++ b/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatContainerTest.jfd
@@ -176,6 +176,26 @@ new FormModel {
 					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
 						"value": "cell 2 0"
 					} )
+					add( new FormComponent( "javax.swing.JCheckBox" ) {
+						name: "htmlTabsCheckBox"
+						"text": "HTML"
+						auxiliary() {
+							"JavaCodeGenerator.variableLocal": false
+						}
+						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "htmlTabsChanged", false ) )
+					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+						"value": "cell 2 0"
+					} )
+					add( new FormComponent( "javax.swing.JCheckBox" ) {
+						name: "multiLineTabsCheckBox"
+						"text": "multi-line"
+						auxiliary() {
+							"JavaCodeGenerator.variableLocal": false
+						}
+						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "htmlTabsChanged", false ) )
+					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+						"value": "cell 2 0"
+					} )
 					add( new FormComponent( "javax.swing.JLabel" ) {
 						name: "hiddenTabsNavigationLabel"
 						"text": "Hidden tabs navigation:"

--- a/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatContainerTest.jfd
+++ b/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatContainerTest.jfd
@@ -261,6 +261,23 @@ new FormModel {
 					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
 						"value": "cell 2 2"
 					} )
+					add( new FormComponent( "javax.swing.JComboBox" ) {
+						name: "iconPlacementField"
+						"model": new javax.swing.DefaultComboBoxModel {
+							selectedItem: "leading"
+							addElement( "leading" )
+							addElement( "trailing" )
+							addElement( "top" )
+							addElement( "bottom" )
+						}
+						auxiliary() {
+							"JavaCodeGenerator.variableLocal": false
+							"JavaCodeGenerator.typeParameters": "String"
+						}
+						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "iconPlacementChanged", false ) )
+					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+						"value": "cell 2 2"
+					} )
 					add( new FormComponent( "javax.swing.JLabel" ) {
 						name: "tabAreaAlignmentLabel"
 						"text": "Tab area alignment:"

--- a/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatContainerTest.jfd
+++ b/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatContainerTest.jfd
@@ -132,7 +132,7 @@ new FormModel {
 				add( new FormContainer( "com.formdev.flatlaf.testing.FlatTestFrame$NoRightToLeftPanel", new FormLayoutManager( class net.miginfocom.swing.MigLayout ) {
 					"$layoutConstraints": "insets 0,hidemode 3"
 					"$columnConstraints": "[][fill][]"
-					"$rowConstraints": "[center][][]para[][]para[][]"
+					"$rowConstraints": "[center][][]para[][]para[][]para[][]"
 				} ) {
 					name: "tabbedPaneControlPanel"
 					"opaque": false
@@ -380,6 +380,26 @@ new FormModel {
 						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "secondTabWiderChanged", false ) )
 					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
 						"value": "cell 2 6"
+					} )
+					add( new FormComponent( "javax.swing.JCheckBox" ) {
+						name: "minimumTabWidthCheckBox"
+						"text": "Minimum tab width (100)"
+						auxiliary() {
+							"JavaCodeGenerator.variableLocal": false
+						}
+						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "minimumTabWidthChanged", false ) )
+					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+						"value": "cell 2 7"
+					} )
+					add( new FormComponent( "javax.swing.JCheckBox" ) {
+						name: "maximumTabWidthCheckBox"
+						"text": "Maximum tab width (60)"
+						auxiliary() {
+							"JavaCodeGenerator.variableLocal": false
+						}
+						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "maximumTabWidthChanged", false ) )
+					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+						"value": "cell 2 8"
 					} )
 				}, new FormLayoutConstraints( class com.jgoodies.forms.layout.CellConstraints ) {
 					"gridY": 11

--- a/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatContainerTest.jfd
+++ b/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatContainerTest.jfd
@@ -285,6 +285,29 @@ new FormModel {
 					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
 						"value": "cell 1 3"
 					} )
+					add( new FormComponent( "javax.swing.JLabel" ) {
+						name: "tabWidthModeLabel"
+						"text": "Tab width mode:"
+					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+						"value": "cell 2 3"
+					} )
+					add( new FormComponent( "javax.swing.JComboBox" ) {
+						name: "tabWidthModeField"
+						"model": new javax.swing.DefaultComboBoxModel {
+							selectedItem: "default"
+							addElement( "default" )
+							addElement( "preferred" )
+							addElement( "equal" )
+							addElement( "compact" )
+						}
+						auxiliary() {
+							"JavaCodeGenerator.variableLocal": false
+							"JavaCodeGenerator.typeParameters": "String"
+						}
+						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "tabWidthModeChanged", false ) )
+					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+						"value": "cell 2 3"
+					} )
 					add( new FormComponent( "javax.swing.JCheckBox" ) {
 						name: "tabsClosableCheckBox"
 						"text": "Tabs closable"

--- a/flatlaf-testing/src/main/resources/com/formdev/flatlaf/testing/FlatTestLaf.properties
+++ b/flatlaf-testing/src/main/resources/com/formdev/flatlaf/testing/FlatTestLaf.properties
@@ -277,12 +277,12 @@ SplitPaneDivider.oneTouchHoverArrowColor=#f00
 TabbedPane.disabledForeground=#777
 TabbedPane.selectedBackground=#0f0
 TabbedPane.selectedForeground=#00f
-TabbedPane.underlineColor=#4A88C7
+TabbedPane.underlineColor=#ff0
 TabbedPane.disabledUnderlineColor=#7a7a7a
 TabbedPane.hoverColor=#eee
 TabbedPane.focusColor=#ddd
 TabbedPane.tabSeparatorColor=#00f
-TabbedPane.contentAreaColor=#bbb
+TabbedPane.contentAreaColor=#f00
 
 TabbedPane.closeSize=16,16
 TabbedPane.closeArc=999

--- a/flatlaf-theme-editor/src/main/resources/com/formdev/flatlaf/themeeditor/FlatLafUIKeys.txt
+++ b/flatlaf-theme-editor/src/main/resources/com/formdev/flatlaf/themeeditor/FlatLafUIKeys.txt
@@ -667,6 +667,7 @@ TabbedPane.selectedTabPadInsets
 TabbedPane.selectionFollowsFocus
 TabbedPane.shadow
 TabbedPane.showTabSeparators
+TabbedPane.tabAreaAlignment
 TabbedPane.tabAreaInsets
 TabbedPane.tabHeight
 TabbedPane.tabInsets


### PR DESCRIPTION
## Tab area alignment

By default the tab area is aligned to the left edge. 
Now you can also align it to the right, center or fill.

![grafik](https://user-images.githubusercontent.com/5604048/97594816-54829480-1a03-11eb-89a4-7565974fff84.png)
![grafik](https://user-images.githubusercontent.com/5604048/97594852-5cdacf80-1a03-11eb-9e18-9d7c5971b999.png)
![grafik](https://user-images.githubusercontent.com/5604048/97594876-66643780-1a03-11eb-8e89-43c93922599a.png)
![grafik](https://user-images.githubusercontent.com/5604048/97594892-6c5a1880-1a03-11eb-958c-ab20be79ace1.png)

To use this for the whole application (allowed values are `leading`, `trailing`, `center` and `fill`:
~~~java
UIManager.put( "TabbedPane.tabAreaAlignment", "center" );
~~~

To use this for single tabbed pane:
~~~java
myTabbedPane.putClientProperty( "JTabbedPane.tabAreaAlignment", "center" );
~~~

## Minimum/maximum tab width

With this PR you can now specify minimum and maximum tab widths.
This is useful for IDE like applications where you e.g. use file names in tab titles.
With minimum tab width you can avoid small tabs for short file names.
With maximum tab width you can avoid too wide tabs for long file names.

Minimum tab width makes tabs wider:
![grafik](https://user-images.githubusercontent.com/5604048/97596265-d4f5c500-1a04-11eb-95a4-14b60d5391d2.png)

Maximum tab width makes tabs smaller:
![grafik](https://user-images.githubusercontent.com/5604048/97596187-c0193180-1a04-11eb-8001-5c217d3480a8.png)

~~~java
myTabbedPane.putClientProperty( "JTabbedPane.minimumTabWidth", 100 );
myTabbedPane.putClientProperty( "JTabbedPane.maximumTabWidth", 200 );
~~~

## Tab icon placement

You can now specify the tab icon placement (relative to tab title),
which makes it easy to create tabs in a style that you know from
your smartphone or tablet.

![grafik](https://user-images.githubusercontent.com/5604048/97805329-b8040080-1c55-11eb-85e5-22fe3b58c1cc.png)

~~~java
myTabbedPane.putClientProperty( "JTabbedPane.tabIconPlacement", SwingConstants.TOP );
myTabbedPane.putClientProperty( "JTabbedPane.tabIconPlacement", SwingConstants.BOTTOM );
myTabbedPane.putClientProperty( "JTabbedPane.tabIconPlacement", SwingConstants.LEADING ); // default
myTabbedPane.putClientProperty( "JTabbedPane.tabIconPlacement", SwingConstants.TRAILING );
~~~

## Tab width mode

With the "width mode" you can make all tabs equal width or hide tab title of unselected tabs. Available modes:

- `preferred`: tab width is adjusted to tab icon and title (the default) 
- `equal`: all tabs in a tabbed pane has same width
- `compact`: unselected tabs show only the tab icon, but no tab title; selected tabs show both; works only if tab has icon

![grafik](https://user-images.githubusercontent.com/5604048/97805507-e33b1f80-1c56-11eb-99f1-e8b4484a16f2.png)

![grafik](https://user-images.githubusercontent.com/5604048/97805613-7c6a3600-1c57-11eb-8eff-e5cd429eba0a.png)

~~~java
myTabbedPane.putClientProperty( "JTabbedPane.tabWidthMode", "preferred" ); // default
myTabbedPane.putClientProperty( "JTabbedPane.tabWidthMode", "equal" );
myTabbedPane.putClientProperty( "JTabbedPane.tabWidthMode", "compact" );
~~~
