### PR TITLE
TextField Placeholder now honors the right inset

### DIFF
--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatTextFieldUI.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatTextFieldUI.java
@@ -39,6 +39,7 @@ import javax.swing.text.Caret;
 import javax.swing.text.JTextComponent;
 import com.formdev.flatlaf.FlatClientProperties;
 import com.formdev.flatlaf.util.HiDPIUtils;
+import com.formdev.flatlaf.util.JavaCompatibility;
 
 /**
  * Provides the Flat LaF UI delegate for {@link javax.swing.JTextField}.
@@ -213,7 +214,9 @@ public class FlatTextFieldUI
 
 		// paint placeholder
 		g.setColor( placeholderForeground );
-		FlatUIUtils.drawString( c, g, (String) placeholder, x, y );
+		String clippedPlaceholder = JavaCompatibility.getClippedString( jc, fm,
+				(String) placeholder, c.getWidth() - insets.left - insets.right );
+		FlatUIUtils.drawString( c, g, clippedPlaceholder, x, y );
 	}
 
 	@Override


### PR DESCRIPTION
Hey,

we added a custom icon to a textfield and used additional inset to do so. Since left and top inset is already being honored, we thought it'd make sense to do the same with the right inset.

However, there's two questions:

1. How do correctly format the source code (We used IDEA which should use .editorconfig, right?)
2. Should we clip the placeholder or use an ellipsis (Currently we are clipping it)