### PR TITLE
JetBrains Runtime 11 has support for displaying the .AppleSystemUIFont font.

### DIFF
--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/FlatLaf.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/FlatLaf.java
@@ -467,8 +467,13 @@ public abstract class FlatLaf
 		} else if( SystemInfo.isMacOS ) {
 			String fontName;
 			if( SystemInfo.isMacOS_10_15_Catalina_orLater ) {
-				// use Helvetica Neue font
-				fontName = "Helvetica Neue";
+				if (SystemInfo.isJetBrainsJVM_11_orLater) {
+					// See https://youtrack.jetbrains.com/issue/JBR-1915
+					fontName = ".AppleSystemUIFont";
+				} else {
+					// use Helvetica Neue font
+					fontName = "Helvetica Neue";
+				}
 			} else if( SystemInfo.isMacOS_10_11_ElCapitan_orLater ) {
 				// use San Francisco Text font
 				fontName = ".SF NS Text";


### PR DESCRIPTION
This font should be used for UI elements since macOS 10.15.

See https://youtrack.jetbrains.com/issue/JBR-1915 for more information.

Other JREs, including JetBrains Runtime 8 do not handle kerning for that font correctly.