### PR TITLE
Switched from sub-pixel to greyscale text anti-aliasing on macOS when running with a JetBrains JRE

### DIFF
--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/FlatLaf.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/FlatLaf.java
@@ -546,7 +546,12 @@ public abstract class FlatLaf
 	}
 
 	private void putAATextInfo( UIDefaults defaults ) {
-		if( SystemInfo.isJava_9_orLater ) {
+		if ( SystemInfo.isJetBrainsJVM ) {
+			// The awt.font.desktophints property suggests sub-pixel anti-aliasing
+			// which renders text with too much weight on macOS in the JetBrains JRE.
+			// Use greyscale anti-aliasing instead.
+			defaults.put( RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON );
+		} else if( SystemInfo.isJava_9_orLater ) {
 			Object desktopHints = Toolkit.getDefaultToolkit().getDesktopProperty( DESKTOPFONTHINTS );
 			if( desktopHints instanceof Map ) {
 				@SuppressWarnings( "unchecked" )


### PR DESCRIPTION
Sub-pixel anti-aliasing (VALUE_TEXT_ANTIALIAS_LCD_HRGB) causes font rendering with too much weight with a JetBrains JREs (both 8 and 11). This can be seen when comparing the text rendering of UI elements between IntelliJ IDEA and FlatLaf.

This commits aligns FlatLaf's behavior with IntelliJ IDEA which disables sub-pixel anti-aliasing on macOS for its IDE anti-aliasing setting and uses greyscale anti-aliasing by default (see com.intellij.ide.ui.AntialiasingType.canUseSubpixelAAForIDE).

Before:

<img width="1334" alt="JetBrains11_before" src="https://user-images.githubusercontent.com/1199475/104630271-df863900-569a-11eb-930c-935f88e277fa.png">

After:

<img width="1334" alt="JetBrains11_after" src="https://user-images.githubusercontent.com/1199475/104630357-f2007280-569a-11eb-893c-26becf2673a9.png">