### PR TITLE
Made paintColumnBorders protected to help with implementing derived table header UIs

### DIFF
--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatTableHeaderUI.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatTableHeaderUI.java
@@ -141,7 +141,7 @@ public class FlatTableHeaderUI
 			   rendererClassName.equals( "sun.swing.FilePane$AlignableTableHeaderRenderer" );
 	}
 
-	private void paintColumnBorders( Graphics g, JComponent c ) {
+	protected void paintColumnBorders( Graphics g, JComponent c ) {
 		int width = c.getWidth();
 		int height = c.getHeight();
 		float lineWidth = UIScale.scale( 1f );


### PR DESCRIPTION
To implement FlatLaf UIs for CellStyleTableHeaderUI and SortableTableHeaderUI from the Jide Grids library, access to the paintColumnBorders method is required.