### PR TITLE
Added a per-tree wide selection setting

### DIFF
--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/FlatClientProperties.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/FlatClientProperties.java
@@ -670,6 +670,14 @@ public interface FlatClientProperties
 	 */
 	String TAB_BUTTON_SELECTED_BACKGROUND = "JToggleButton.tab.selectedBackground";
 
+	/**
+	 * Override if a tree shows a wide selection.
+	 * <p>
+	 * <strong>Component</strong> {@link javax.swing.JTree}<br>
+	 * <strong>Value type</strong> {@link java.lang.Boolean}
+	 */
+	String TREE_WIDE_SELECTION = "JTree.wideSelection";
+
 	//---- helper methods -----------------------------------------------------
 
 	/**

--- a/flatlaf-extras/src/main/java/com/formdev/flatlaf/extras/components/FlatTree.java
+++ b/flatlaf-extras/src/main/java/com/formdev/flatlaf/extras/components/FlatTree.java
@@ -1,0 +1,28 @@
+package com.formdev.flatlaf.extras.components;
+
+import javax.swing.*;
+import static com.formdev.flatlaf.FlatClientProperties.TREE_WIDE_SELECTION;
+import static com.formdev.flatlaf.FlatClientProperties.clientPropertyBoolean;
+
+/**
+ * Subclass of {@link JTree} that provides easy access to FlatLaf specific client properties.
+ *
+ */
+public class FlatTree
+	extends JTree
+	implements FlatComponentExtension
+{
+	/**
+	 * Returns if the tree shows a wide selection
+	 */
+	public boolean isWideSelection() {
+		return clientPropertyBoolean( this, TREE_WIDE_SELECTION, UIManager.getBoolean( "Tree.wideSelection" ));
+	}
+
+	/**
+	 * Sets if the tree shows a wide selection
+	 */
+	public void setWideSelection(boolean wideSelection) {
+		putClientProperty( TREE_WIDE_SELECTION, wideSelection);
+	}
+}


### PR DESCRIPTION
Even when using wide selection by default, there are use cases where no selection background is desired, for example if the renderer shows the selected node in bold text without any selection background.