### PR TITLE
Added ButtonType.borderLess

### DIFF
--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/FlatClientProperties.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/FlatClientProperties.java
@@ -40,7 +40,8 @@ public interface FlatClientProperties
 	 *     {@link #BUTTON_TYPE_ROUND_RECT},
 	 *     {@link #BUTTON_TYPE_TAB},
 	 *     {@link #BUTTON_TYPE_HELP} or
-	 *     {@link BUTTON_TYPE_TOOLBAR_BUTTON}
+	 *     {@link #BUTTON_TYPE_TOOLBAR_BUTTON}
+	 *     {@link #BUTTON_TYPE_BORDER_LESS}
 	 */
 	String BUTTON_TYPE = "JButton.buttonType";
 
@@ -88,6 +89,15 @@ public interface FlatClientProperties
 	 * @see #BUTTON_TYPE
 	 */
 	String BUTTON_TYPE_TOOLBAR_BUTTON = "toolBarButton";
+
+	/**
+	 * Paint the button without a border in the unfocused state.
+	 * <p>
+	 * <strong>Components</strong> {@link javax.swing.JButton} and {@link javax.swing.JToggleButton}
+	 *
+	 * @see #BUTTON_TYPE
+	 */
+	String BUTTON_TYPE_BORDER_LESS = "borderLess";
 
 	/**
 	 * Specifies selected state of a checkbox.

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/FlatClientProperties.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/FlatClientProperties.java
@@ -41,7 +41,7 @@ public interface FlatClientProperties
 	 *     {@link #BUTTON_TYPE_TAB},
 	 *     {@link #BUTTON_TYPE_HELP} or
 	 *     {@link #BUTTON_TYPE_TOOLBAR_BUTTON}
-	 *     {@link #BUTTON_TYPE_BORDER_LESS}
+	 *     {@link #BUTTON_TYPE_BORDERLESS}
 	 */
 	String BUTTON_TYPE = "JButton.buttonType";
 
@@ -97,7 +97,7 @@ public interface FlatClientProperties
 	 *
 	 * @see #BUTTON_TYPE
 	 */
-	String BUTTON_TYPE_BORDER_LESS = "borderLess";
+	String BUTTON_TYPE_BORDERLESS = "borderless";
 
 	/**
 	 * Specifies selected state of a checkbox.

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatButtonBorder.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatButtonBorder.java
@@ -75,7 +75,7 @@ public class FlatButtonBorder
 	public void paintBorder( Component c, Graphics g, int x, int y, int width, int height ) {
 		if( FlatButtonUI.isContentAreaFilled( c ) &&
 			!FlatButtonUI.isToolBarButton( c ) &&
-			( !FlatButtonUI.isBorderLessButton( c ) || FlatUIUtils.isPermanentFocusOwner( c ) ) &&
+			( !FlatButtonUI.isBorderlessButton( c ) || FlatUIUtils.isPermanentFocusOwner( c ) ) &&
 			!FlatButtonUI.isHelpButton( c ) &&
 			!FlatToggleButtonUI.isTabButton( c ) )
 		  super.paintBorder( c, g, x, y, width, height );

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatButtonBorder.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatButtonBorder.java
@@ -75,6 +75,7 @@ public class FlatButtonBorder
 	public void paintBorder( Component c, Graphics g, int x, int y, int width, int height ) {
 		if( FlatButtonUI.isContentAreaFilled( c ) &&
 			!FlatButtonUI.isToolBarButton( c ) &&
+			( !FlatButtonUI.isBorderLessButton( c ) || FlatUIUtils.isPermanentFocusOwner( c ) ) &&
 			!FlatButtonUI.isHelpButton( c ) &&
 			!FlatToggleButtonUI.isTabButton( c ) )
 		  super.paintBorder( c, g, x, y, width, height );

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatButtonUI.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatButtonUI.java
@@ -285,8 +285,9 @@ public class FlatButtonUI
 			(c instanceof AbstractButton && clientPropertyEquals( (AbstractButton) c, BUTTON_TYPE, BUTTON_TYPE_TOOLBAR_BUTTON ));
 	}
 
-	static boolean isBorderLessButton( Component c ) {
-		return c instanceof AbstractButton && clientPropertyEquals( (AbstractButton) c, BUTTON_TYPE, BUTTON_TYPE_BORDER_LESS );
+	static boolean isBorderlessButton( Component c ) {
+		return c instanceof AbstractButton && clientPropertyEquals( (AbstractButton) c, BUTTON_TYPE,
+			BUTTON_TYPE_BORDERLESS );
 	}
 
 	@Override
@@ -336,7 +337,7 @@ public class FlatButtonUI
 
 			// paint shadow
 			Color shadowColor = def ? defaultShadowColor : this.shadowColor;
-			if( !isToolBarButton && !isBorderLessButton( c ) && shadowColor != null && shadowWidth > 0 && focusWidth > 0 &&
+			if( !isToolBarButton && !isBorderlessButton( c ) && shadowColor != null && shadowWidth > 0 && focusWidth > 0 &&
 				!(isFocusPainted( c ) && FlatUIUtils.isPermanentFocusOwner( c )) && c.isEnabled() )
 			{
 				g2.setColor( shadowColor );
@@ -395,7 +396,7 @@ public class FlatButtonUI
 		if( ((AbstractButton)c).isSelected() ) {
 			// in toolbar use same colors for disabled and enabled because
 			// we assume that toolbar icon is shown disabled
-			boolean toolBarButton = isToolBarButton( c ) || isBorderLessButton( c );
+			boolean toolBarButton = isToolBarButton( c ) || isBorderlessButton( c );
 			return buttonStateColor( c,
 				toolBarButton ? toolbarSelectedBackground : selectedBackground,
 				toolBarButton ? toolbarSelectedBackground : disabledSelectedBackground,
@@ -407,7 +408,7 @@ public class FlatButtonUI
 			return disabledBackground;
 
 		// toolbar button
-		if( isToolBarButton( c ) || isBorderLessButton( c ) ) {
+		if( isToolBarButton( c ) || isBorderlessButton( c ) ) {
 			ButtonModel model = ((AbstractButton)c).getModel();
 			if( model.isPressed() )
 				return toolbarPressedBackground;
@@ -469,7 +470,7 @@ public class FlatButtonUI
 		if( !c.isEnabled() )
 			return disabledText;
 
-		if( ((AbstractButton)c).isSelected() && !( isToolBarButton( c ) || isBorderLessButton( c ) ) )
+		if( ((AbstractButton)c).isSelected() && !( isToolBarButton( c ) || isBorderlessButton( c ) ) )
 			return selectedForeground;
 
 		// use component foreground if explicitly set

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatButtonUI.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatButtonUI.java
@@ -285,6 +285,10 @@ public class FlatButtonUI
 			(c instanceof AbstractButton && clientPropertyEquals( (AbstractButton) c, BUTTON_TYPE, BUTTON_TYPE_TOOLBAR_BUTTON ));
 	}
 
+	static boolean isBorderLessButton( Component c ) {
+		return c instanceof AbstractButton && clientPropertyEquals( (AbstractButton) c, BUTTON_TYPE, BUTTON_TYPE_BORDER_LESS );
+	}
+
 	@Override
 	public void update( Graphics g, JComponent c ) {
 		// fill background if opaque to avoid garbage if user sets opaque to true
@@ -332,7 +336,7 @@ public class FlatButtonUI
 
 			// paint shadow
 			Color shadowColor = def ? defaultShadowColor : this.shadowColor;
-			if( !isToolBarButton && shadowColor != null && shadowWidth > 0 && focusWidth > 0 &&
+			if( !isToolBarButton && !isBorderLessButton( c ) && shadowColor != null && shadowWidth > 0 && focusWidth > 0 &&
 				!(isFocusPainted( c ) && FlatUIUtils.isPermanentFocusOwner( c )) && c.isEnabled() )
 			{
 				g2.setColor( shadowColor );
@@ -391,7 +395,7 @@ public class FlatButtonUI
 		if( ((AbstractButton)c).isSelected() ) {
 			// in toolbar use same colors for disabled and enabled because
 			// we assume that toolbar icon is shown disabled
-			boolean toolBarButton = isToolBarButton( c );
+			boolean toolBarButton = isToolBarButton( c ) || isBorderLessButton( c );
 			return buttonStateColor( c,
 				toolBarButton ? toolbarSelectedBackground : selectedBackground,
 				toolBarButton ? toolbarSelectedBackground : disabledSelectedBackground,
@@ -403,7 +407,7 @@ public class FlatButtonUI
 			return disabledBackground;
 
 		// toolbar button
-		if( isToolBarButton( c ) ) {
+		if( isToolBarButton( c ) || isBorderLessButton( c ) ) {
 			ButtonModel model = ((AbstractButton)c).getModel();
 			if( model.isPressed() )
 				return toolbarPressedBackground;
@@ -465,7 +469,7 @@ public class FlatButtonUI
 		if( !c.isEnabled() )
 			return disabledText;
 
-		if( ((AbstractButton)c).isSelected() && !isToolBarButton( c ) )
+		if( ((AbstractButton)c).isSelected() && !( isToolBarButton( c ) || isBorderLessButton( c ) ) )
 			return selectedForeground;
 
 		// use component foreground if explicitly set

--- a/flatlaf-extras/src/main/java/com/formdev/flatlaf/extras/components/FlatButton.java
+++ b/flatlaf-extras/src/main/java/com/formdev/flatlaf/extras/components/FlatButton.java
@@ -30,7 +30,7 @@ public class FlatButton
 	implements FlatComponentExtension
 {
 	// NOTE: enum names must be equal to allowed strings
-	public enum ButtonType { none, square, roundRect, tab, help, toolBarButton };
+	public enum ButtonType { none, square, roundRect, tab, help, toolBarButton, borderLess }
 
 	/**
 	 * Returns type of a button.

--- a/flatlaf-extras/src/main/java/com/formdev/flatlaf/extras/components/FlatButton.java
+++ b/flatlaf-extras/src/main/java/com/formdev/flatlaf/extras/components/FlatButton.java
@@ -30,7 +30,7 @@ public class FlatButton
 	implements FlatComponentExtension
 {
 	// NOTE: enum names must be equal to allowed strings
-	public enum ButtonType { none, square, roundRect, tab, help, toolBarButton, borderLess }
+	public enum ButtonType { none, square, roundRect, tab, help, toolBarButton, borderless}
 
 	/**
 	 * Returns type of a button.

--- a/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatComponentsTest.java
+++ b/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatComponentsTest.java
@@ -253,6 +253,7 @@ public class FlatComponentsTest
 		JButton button16 = new JButton();
 		JButton button24 = new JButton();
 		JButton button20 = new JButton();
+		JButton button25 = new JButton();
 		JLabel toggleButtonLabel = new JLabel();
 		JToggleButton toggleButton1 = new JToggleButton();
 		FlatToggleButton toggleButton9 = new FlatToggleButton();
@@ -268,6 +269,7 @@ public class FlatComponentsTest
 		JToggleButton toggleButton14 = new JToggleButton();
 		JToggleButton toggleButton21 = new JToggleButton();
 		JToggleButton toggleButton18 = new JToggleButton();
+		JToggleButton toggleButton22 = new JToggleButton();
 		JLabel checkBoxLabel = new JLabel();
 		JCheckBox checkBox1 = new JCheckBox();
 		JCheckBox checkBox2 = new JCheckBox();
@@ -578,6 +580,11 @@ public class FlatComponentsTest
 		button20.setBorder(BorderFactory.createEmptyBorder());
 		add(button20, "cell 5 1 2 1");
 
+		//---- button25 ----
+		button25.setIcon(UIManager.getIcon("Tree.closedIcon"));
+		button25.putClientProperty("JButton.buttonType", "borderLess");
+		add(button25, "cell 5 1 2 1");
+
 		//---- toggleButtonLabel ----
 		toggleButtonLabel.setText("JToggleButton:");
 		add(toggleButtonLabel, "cell 0 2");
@@ -654,6 +661,12 @@ public class FlatComponentsTest
 		toggleButton18.setText("Empty border");
 		toggleButton18.setBorder(BorderFactory.createEmptyBorder());
 		add(toggleButton18, "cell 5 2 2 1");
+
+		//---- toggleButton22 ----
+		toggleButton22.setIcon(UIManager.getIcon("Tree.closedIcon"));
+		toggleButton22.setSelected(true);
+		toggleButton22.putClientProperty("JButton.buttonType", "borderLess");
+		add(toggleButton22, "cell 5 2 2 1");
 
 		//---- checkBoxLabel ----
 		checkBoxLabel.setText("JCheckBox");

--- a/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatComponentsTest.jfd
+++ b/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatComponentsTest.jfd
@@ -156,6 +156,13 @@ new FormModel {
 			}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
 				"value": "cell 5 1 2 1"
 			} )
+			add( new FormComponent( "javax.swing.JButton" ) {
+				name: "button25"
+				"icon": &SwingIcon0 new com.jformdesigner.model.SwingIcon( 2, "Tree.closedIcon" )
+				"$client.JButton.buttonType": "borderLess"
+			}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+				"value": "cell 5 1 2 1"
+			} )
 			add( new FormComponent( "javax.swing.JLabel" ) {
 				name: "toggleButtonLabel"
 				"text": "JToggleButton:"
@@ -260,6 +267,14 @@ new FormModel {
 				name: "toggleButton18"
 				"text": "Empty border"
 				"border": #EmptyBorder0
+			}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+				"value": "cell 5 2 2 1"
+			} )
+			add( new FormComponent( "javax.swing.JToggleButton" ) {
+				name: "toggleButton22"
+				"icon": &SwingIcon0 new com.jformdesigner.model.SwingIcon( 2, "Tree.closedIcon" )
+				"selected": true
+				"$client.JButton.buttonType": "borderLess"
 			}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
 				"value": "cell 5 2 2 1"
 			} )


### PR DESCRIPTION
To create buttons that look like toolbar buttons but have a focus indicator.

This behavior can be achieved with JideButton, but it would be preferable to use FlatButton instead.