### PR TITLE
Add a setter for the native provider

### DIFF
--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatNativeWindowBorder.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatNativeWindowBorder.java
@@ -247,14 +247,17 @@ public class FlatNativeWindowBorder
 /*
 			Class<?> cls = Class.forName( "com.formdev.flatlaf.natives.jna.windows.FlatWindowsNativeWindowBorder" );
 			Method m = cls.getMethod( "getInstance" );
-			nativeProvider = (Provider) m.invoke( null );
+			setNativeProvider( (Provider) m.invoke( null ) );
 */
-			nativeProvider = FlatWindowsNativeWindowBorder.getInstance();
-
-			supported = (nativeProvider != null);
+			setNativeProvider( FlatWindowsNativeWindowBorder.getInstance() );
 		} catch( Exception ex ) {
 			// ignore
 		}
+	}
+
+	public static void setNativeProvider( Provider nativeProvider ) {
+		FlatNativeWindowBorder.nativeProvider = nativeProvider;
+		supported = nativeProvider != null;
 	}
 
 	//---- interface Provider -------------------------------------------------


### PR DESCRIPTION
This makes it possible to support situations where the extraction of a DLL at runtime is not possible.

Rationale:

Extracting DLLs to the temporary directory will trigger some anti-virus tools and can lead to quarantined binaries.
This is why in install4j we use the RegisterNatives JNI function to provide native code from the installer executable without loading an additional library. For the native code in FlatLaf, we would like to do the same.