### PR TITLE
Fixed JInternalFrame iconified content snapshot for already installed DesktopManager

### DIFF
--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatDesktopPaneUI.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatDesktopPaneUI.java
@@ -16,9 +16,7 @@
 
 package com.formdev.flatlaf.ui;
 
-import javax.swing.DefaultDesktopManager;
-import javax.swing.JComponent;
-import javax.swing.JInternalFrame;
+import javax.swing.*;
 import javax.swing.plaf.ComponentUI;
 import javax.swing.plaf.UIResource;
 import javax.swing.plaf.basic.BasicDesktopPaneUI;
@@ -42,15 +40,25 @@ public class FlatDesktopPaneUI
 
 	@Override
 	protected void installDesktopManager() {
-		desktopManager = desktop.getDesktopManager();
-		if( desktopManager == null ) {
+		// Check current installed desktop manager
+		// to avoid recursive call with property change event (will fire a stack overflow)
+		// Do not handle install if already installed
+		DesktopManager old = desktop.getDesktopManager();
+		if (old instanceof FlatDesktopManager) return;
+
+		if( old == null ) {
 			desktopManager = new FlatDesktopManager();
-			desktop.setDesktopManager( desktopManager );
+
+		} else {
+			// create the wrapper version of the desktop manager
+			desktopManager = new FlatWrapperDesktopManager(old);
+
 		}
+		desktop.setDesktopManager(desktopManager);
+
 	}
 
 	//---- class FlatDesktopManager -------------------------------------------
-
 	private class FlatDesktopManager
 		extends DefaultDesktopManager
 		implements UIResource
@@ -60,6 +68,96 @@ public class FlatDesktopPaneUI
 			super.iconifyFrame( f );
 
 			((FlatDesktopIconUI)f.getDesktopIcon().getUI()).updateDockIcon();
+		}
+	}
+
+	//---- class for already installed desktop manager to use the flat desktop manager features
+	private class FlatWrapperDesktopManager
+		extends FlatDesktopManager
+
+	{
+		private DesktopManager parent = null;
+
+		private FlatWrapperDesktopManager(DesktopManager parent) {
+			super();
+			this.parent = parent;
+
+		}
+
+		@Override
+		public void openFrame(JInternalFrame f) {
+			parent.openFrame( f );
+		}
+
+		@Override
+		public void closeFrame(JInternalFrame f) {
+			parent.closeFrame( f );
+		}
+
+		@Override
+		public void maximizeFrame(JInternalFrame f) {
+			parent.maximizeFrame( f );
+		}
+
+		@Override
+		public void minimizeFrame(JInternalFrame f) {
+			parent.minimizeFrame( f );
+		}
+
+		@Override
+		public void activateFrame(JInternalFrame f) {
+			parent.activateFrame( f );
+		}
+
+		@Override
+		public void deactivateFrame(JInternalFrame f) {
+			parent.deactivateFrame( f );
+		}
+
+		@Override
+		public void iconifyFrame( JInternalFrame f ) {
+			super.iconifyFrame( f );
+
+		}
+
+		@Override
+		public void deiconifyFrame( JInternalFrame f ) {
+			super.deiconifyFrame( f );
+		}
+
+		@Override
+		public void beginDraggingFrame(JComponent f) {
+			parent.beginDraggingFrame( f );
+		}
+
+		@Override
+		public void dragFrame(JComponent f, int newX, int newY) {
+			parent.dragFrame( f, newX, newY );
+		}
+
+		@Override
+		public void endDraggingFrame(JComponent f) {
+			parent.endDraggingFrame( f );
+		}
+
+		@Override
+		public void beginResizingFrame(JComponent f, int direction) {
+			parent.beginResizingFrame( f, direction );
+		}
+
+		@Override
+		public void resizeFrame(JComponent f, int newX, int newY, int newWidth, int newHeight) {
+			parent.resizeFrame( f, newX, newY, newWidth, newHeight );
+		}
+
+		@Override
+		public void endResizingFrame(JComponent f) {
+			parent.endResizingFrame( f );
+		}
+
+		@Override
+		public void setBoundsForFrame(JComponent f, int newX, int newY, int newWidth, int newHeight) {
+			parent.setBoundsForFrame( f, newX, newY, newWidth, newHeight );
 		}
 	}
 }

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatDesktopPaneUI.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatDesktopPaneUI.java
@@ -47,6 +47,7 @@ public class FlatDesktopPaneUI
 		if (old instanceof FlatDesktopManager) return;
 
 		if( old == null ) {
+			// default version
 			desktopManager = new FlatDesktopManager();
 
 		} else {


### PR DESCRIPTION
When a custom `DesktopManager` was installed, the FlatLaf one will not be used (so no small content snapshot for iconified frames will be present).
This patch allows a custom `DesktopManager` to keep the FlatLaf iconified feature.
My solution is to wrap the old `DesktopManager` in a container class so only the `iconifyFrame` methods is overriden.