### PR TITLE
Add issue template for reports in order to reduce communication overhead

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -1,0 +1,22 @@
+---
+name: Bug report
+about: Tell us what went wrong
+---
+
+## Environment information
+
+| Key | Value |
+| - | - |
+| OS | **TODO** <!-- Your operating system, for example "Windows 10 64-Bit". --> |
+| JRE | **TODO** <!-- Your Java Runtime Environment, for example "OpenJDK 11 64-Bit". --> |
+| FlatLaf version | **TODO** <!-- For example "FlatLaf 1.1.1 installed via maven" --> |
+
+<!-- If you have other information abour your environment that you deem useful, such
+as monitors, their arrangement or other details about your system, whether it's hardware
+or software, we'd like you to write them down here. -->
+
+## What happened
+
+<!-- Please describe the issue and if necessary tell us what you would've expected to happen instead. -->
+
+<!-- If an exception occurred or you have visual artifacts, please include the stacktraces or screenshots. -->


### PR DESCRIPTION
Thought it might be useful to avoid the basic ping pong question game at the start of each issue.