### PR TITLE
Fix selected states for native window border related menu items

### DIFF
--- a/flatlaf-demo/src/main/java/com/formdev/flatlaf/demo/DemoFrame.java
+++ b/flatlaf-demo/src/main/java/com/formdev/flatlaf/demo/DemoFrame.java
@@ -750,8 +750,16 @@ class DemoFrame
 
 		boolean supportsWindowDecorations = UIManager.getLookAndFeel()
 			.getSupportsWindowDecorations() || FlatNativeWindowBorder.isSupported();
-		windowDecorationsCheckBoxMenuItem.setEnabled( supportsWindowDecorations && !JBRCustomDecorations.isSupported() );
-		menuBarEmbeddedCheckBoxMenuItem.setEnabled( supportsWindowDecorations );
+		if( !supportsWindowDecorations || JBRCustomDecorations.isSupported() ) {
+			windowDecorationsCheckBoxMenuItem.setEnabled( false );
+			windowDecorationsCheckBoxMenuItem.setSelected( false );
+			windowDecorationsCheckBoxMenuItem.setToolTipText( "Not supported on your system." );
+		}
+		if( !supportsWindowDecorations ) {
+			menuBarEmbeddedCheckBoxMenuItem.setEnabled( false );
+			menuBarEmbeddedCheckBoxMenuItem.setSelected( false );
+			menuBarEmbeddedCheckBoxMenuItem.setToolTipText( "Not supported on your system." );
+		}
 
 		// remove contentPanel bottom insets
 		MigLayout layout = (MigLayout) contentPanel.getLayout();

--- a/flatlaf-demo/src/main/java/com/formdev/flatlaf/demo/DemoFrame.java
+++ b/flatlaf-demo/src/main/java/com/formdev/flatlaf/demo/DemoFrame.java
@@ -750,6 +750,9 @@ class DemoFrame
 
 		boolean supportsWindowDecorations = UIManager.getLookAndFeel()
 			.getSupportsWindowDecorations() || FlatNativeWindowBorder.isSupported();
+
+		// If the JetBrainsRuntime is used, it forces the use of it's own custom
+		// window decoration, meaning we can't use our own.
 		if( !supportsWindowDecorations || JBRCustomDecorations.isSupported() ) {
 			windowDecorationsCheckBoxMenuItem.setEnabled( false );
 			windowDecorationsCheckBoxMenuItem.setSelected( false );


### PR DESCRIPTION
The menu items for custom window decorations and embeded menu bar aren't selected anymore if the feature isn't supported.
On top of that, there's now a tooltip indicating that these aren't supported.

Regarding the previous condition for enabling the item:

```java
supportsWindowDecorations && !JBRCustomDecorations.isSupported()
```

I deem it very confusing that we set the item to `enabled` if `JBRCustomDecorations` isn't supported.
Would you mind explaining this? I'd like to add an explanatory comment in the code here.