### PR TITLE
JideTabbedPane improvements

### DIFF
--- a/flatlaf-jide-oss/src/main/java/com/formdev/flatlaf/jideoss/ui/FlatJidePainter.java
+++ b/flatlaf-jide-oss/src/main/java/com/formdev/flatlaf/jideoss/ui/FlatJidePainter.java
@@ -107,4 +107,22 @@ public class FlatJidePainter
 		} else
 			super.paintBackground( c, g, rect, borderColor, background, orientation );
 	}
+
+	@Override
+	public void paintGripper( JComponent c, Graphics g, Rectangle rect, int orientation, int state ) {
+		float userScaleFactor = UIScale.getUserScaleFactor();
+		if( userScaleFactor > 1 ) {
+			// scale gripper
+			Graphics2D g2 = (Graphics2D) g.create();
+			try {
+				g2.translate( rect.x, rect.y );
+				g2.scale( userScaleFactor, userScaleFactor );
+				Rectangle rect2 = new Rectangle( 0, 0, UIScale.unscale( rect.width ), UIScale.unscale( rect.height ) );
+				super.paintGripper( c, g2, rect2, orientation, state );
+			} finally {
+				g2.dispose();
+			}
+		} else
+			super.paintGripper( c, g, rect, orientation, state );
+	}
 }

--- a/flatlaf-jide-oss/src/main/java/com/formdev/flatlaf/jideoss/ui/FlatJideTabbedPaneUI.java
+++ b/flatlaf-jide-oss/src/main/java/com/formdev/flatlaf/jideoss/ui/FlatJideTabbedPaneUI.java
@@ -584,12 +584,15 @@ public class FlatJideTabbedPaneUI
 			if( !scrollableTabLayoutEnabled() || !isShowCloseButton() || !isShowCloseButtonOnTab() )
 				return;
 
+			Color background = _tabPane.getBackground();
+
 			for( int i = 0; i < _closeButtons.length; i++ ) {
 				JButton closeButton = _closeButtons[i];
 				if( closeButton.getWidth() == 0 || closeButton.getHeight() == 0 )
 					continue; // not visible
 
 				closeButton.setBounds( getTabCloseBounds( i ) );
+				closeButton.setBackground( background );
 			}
 		}
 

--- a/flatlaf-jide-oss/src/main/java/com/formdev/flatlaf/jideoss/ui/FlatJideTabbedPaneUI.java
+++ b/flatlaf-jide-oss/src/main/java/com/formdev/flatlaf/jideoss/ui/FlatJideTabbedPaneUI.java
@@ -709,7 +709,7 @@ public class FlatJideTabbedPaneUI
 		}
 
 		private void updateArrowButtons() {
-			if( !scrollableTabLayoutEnabled() )
+			if( !scrollableTabLayoutEnabled() || !_tabPane.isTabShown() )
 				return;
 
 			Insets insets = _tabPane.getInsets();
@@ -739,7 +739,8 @@ public class FlatJideTabbedPaneUI
 					y += tabAreaInsets.top;
 
 				// layout buttons
-				x = layoutButtonHorizontal( _tabScroller.closeButton, 16, x, y, h, leftToRight );
+				if( !isShowCloseButtonOnTab() )
+					x = layoutButtonHorizontal( _tabScroller.closeButton, 16, x, y, h, leftToRight );
 				x = layoutButtonHorizontal( _tabScroller.listButton, 24, x, y, h, leftToRight );
 				x = layoutButtonHorizontal( _tabScroller.scrollForwardButton, 16, x, y, h, leftToRight );
 				x = layoutButtonHorizontal( _tabScroller.scrollBackwardButton, 16, x, y, h, leftToRight );
@@ -770,7 +771,8 @@ public class FlatJideTabbedPaneUI
 					x += tabAreaInsets.left;
 
 				// layout buttons
-				y = layoutButtonVertical( _tabScroller.closeButton, 16, x, y, w );
+				if( !isShowCloseButtonOnTab() )
+					y = layoutButtonVertical( _tabScroller.closeButton, 16, x, y, w );
 				y = layoutButtonVertical( _tabScroller.listButton, 24, x, y, w );
 				y = layoutButtonVertical( _tabScroller.scrollForwardButton, 16, x, y, w );
 				y = layoutButtonVertical( _tabScroller.scrollBackwardButton, 16, x, y, w );

--- a/flatlaf-jide-oss/src/main/java/com/formdev/flatlaf/jideoss/ui/FlatJideTabbedPaneUI.java
+++ b/flatlaf-jide-oss/src/main/java/com/formdev/flatlaf/jideoss/ui/FlatJideTabbedPaneUI.java
@@ -415,6 +415,9 @@ public class FlatJideTabbedPaneUI
 	}
 
 	protected void paintTabSelection( Graphics g, int tabPlacement,  int x, int y, int w, int h ) {
+		if( !_tabPane.isTabShown() )
+			return;
+
 		// increase clip bounds in scroll-tab-layout to paint over the separator line
 		Rectangle clipBounds = scrollableTabLayoutEnabled() ? g.getClipBounds() : null;
 		if( clipBounds != null ) {
@@ -480,7 +483,7 @@ public class FlatJideTabbedPaneUI
 	 */
 	@Override
 	protected void paintContentBorder( Graphics g, int tabPlacement, int selectedIndex ) {
-		if( _tabPane.getTabCount() <= 0 )
+		if( !_tabPane.isTabShown() )
 			return;
 
 		Insets insets = _tabPane.getInsets();

--- a/flatlaf-jide-oss/src/main/java/com/formdev/flatlaf/jideoss/ui/FlatJideTabbedPaneUI.java
+++ b/flatlaf-jide-oss/src/main/java/com/formdev/flatlaf/jideoss/ui/FlatJideTabbedPaneUI.java
@@ -508,6 +508,29 @@ public class FlatJideTabbedPaneUI
 	}
 
 	@Override
+	protected void ensureCurrentRects( int leftMargin, int tabCount ) {
+		int oldFitStyleBoundSize = _fitStyleBoundSize;
+		int oldFitStyleFirstTabMargin = _fitStyleFirstTabMargin;
+		int oldCompressedStyleNoIconRectSize = _compressedStyleNoIconRectSize;
+		int oldCompressedStyleIconMargin = _compressedStyleIconMargin;
+		int oldFixedStyleRectSize = _fixedStyleRectSize;
+
+		_fitStyleBoundSize = scale( _fitStyleBoundSize );
+		_fitStyleFirstTabMargin = scale( _fitStyleFirstTabMargin );
+		_compressedStyleNoIconRectSize = scale( _compressedStyleNoIconRectSize );
+		_compressedStyleIconMargin = scale( _compressedStyleIconMargin );
+		_fixedStyleRectSize = scale( _fixedStyleRectSize );
+
+		super.ensureCurrentRects( leftMargin, tabCount );
+
+		_fitStyleBoundSize = oldFitStyleBoundSize;
+		_fitStyleFirstTabMargin = oldFitStyleFirstTabMargin;
+		_compressedStyleNoIconRectSize = oldCompressedStyleNoIconRectSize;
+		_compressedStyleIconMargin = oldCompressedStyleIconMargin;
+		_fixedStyleRectSize = oldFixedStyleRectSize;
+	}
+
+	@Override
 	public void ensureCloseButtonCreated() {
 		super.ensureCloseButtonCreated();
 

--- a/flatlaf-jide-oss/src/main/java/com/formdev/flatlaf/jideoss/ui/FlatJideTabbedPaneUI.java
+++ b/flatlaf-jide-oss/src/main/java/com/formdev/flatlaf/jideoss/ui/FlatJideTabbedPaneUI.java
@@ -475,6 +475,33 @@ public class FlatJideTabbedPaneUI
 	{
 	}
 
+	@Override
+	protected void layoutLabel( int tabPlacement, FontMetrics metrics, int tabIndex, String title, Icon icon,
+		Rectangle tabRect, Rectangle iconRect, Rectangle textRect, boolean isSelected )
+	{
+		if( tabPlacement == LEFT || tabPlacement == RIGHT ) {
+			Rectangle tabRect2 = new Rectangle( 0, 0, tabRect.height, tabRect.width );
+			Rectangle iconRect2 = new Rectangle();
+			Rectangle textRect2 = new Rectangle();
+
+			super.layoutLabel( TOP, metrics, tabIndex, title, icon, tabRect2, iconRect2, textRect2, isSelected );
+
+			textRect.x = tabRect.x + textRect2.y;
+			textRect.y = tabRect.y + textRect2.x;
+			textRect.width = textRect2.height;
+			textRect.height = textRect2.width;
+
+			if( tabPlacement == LEFT )
+				textRect.y += metrics.getHeight() / 2;
+
+			iconRect.x = tabRect.x + iconRect2.y;
+			iconRect.y = tabRect.y + iconRect2.x;
+			iconRect.width = iconRect2.height;
+			iconRect.height = iconRect2.width;
+		} else
+			super.layoutLabel( tabPlacement, metrics, tabIndex, title, icon, tabRect, iconRect, textRect, isSelected );
+	}
+
 	private boolean isLastInRun( int tabIndex ) {
 		int run = getRunForTab( _tabPane.getTabCount(), tabIndex );
 		return lastTabInRun( _tabPane.getTabCount(), run ) == tabIndex;

--- a/flatlaf-jide-oss/src/main/java/com/formdev/flatlaf/jideoss/ui/FlatJideTabbedPaneUI.java
+++ b/flatlaf-jide-oss/src/main/java/com/formdev/flatlaf/jideoss/ui/FlatJideTabbedPaneUI.java
@@ -151,6 +151,7 @@ public class FlatJideTabbedPaneUI
 
 				case JideTabbedPane.PROPERTY_TAB_AREA_INSETS:
 				case JideTabbedPane.PROPERTY_TAB_INSETS:
+				case JideTabbedPane.GRIPPER_PROPERTY:
 				case TABBED_PANE_SHOW_TAB_SEPARATORS:
 				case TABBED_PANE_HAS_FULL_BORDER:
 					_tabPane.revalidate();

--- a/flatlaf-jide-oss/src/main/java/com/formdev/flatlaf/jideoss/ui/FlatJideTabbedPaneUI.java
+++ b/flatlaf-jide-oss/src/main/java/com/formdev/flatlaf/jideoss/ui/FlatJideTabbedPaneUI.java
@@ -149,6 +149,8 @@ public class FlatJideTabbedPaneUI
 					repaintTab( (Integer) e.getNewValue() );
 					break;
 
+				case JideTabbedPane.PROPERTY_TAB_AREA_INSETS:
+				case JideTabbedPane.PROPERTY_TAB_INSETS:
 				case TABBED_PANE_SHOW_TAB_SEPARATORS:
 				case TABBED_PANE_HAS_FULL_BORDER:
 					_tabPane.revalidate();

--- a/flatlaf-jide-oss/src/main/java/com/formdev/flatlaf/jideoss/ui/FlatJideTabbedPaneUI.java
+++ b/flatlaf-jide-oss/src/main/java/com/formdev/flatlaf/jideoss/ui/FlatJideTabbedPaneUI.java
@@ -503,6 +503,13 @@ public class FlatJideTabbedPaneUI
 			super.layoutLabel( tabPlacement, metrics, tabIndex, title, icon, tabRect, iconRect, textRect, isSelected );
 	}
 
+	@Override
+	protected Rectangle getTabsTextBoundsAt( int tabIndex ) {
+		Rectangle rect = super.getTabsTextBoundsAt( tabIndex );
+		rect.x += getTabInsets( _tabPane.getTabPlacement(), tabIndex ).left;
+		return rect;
+	}
+
 	private boolean isLastInRun( int tabIndex ) {
 		int run = getRunForTab( _tabPane.getTabCount(), tabIndex );
 		return lastTabInRun( _tabPane.getTabCount(), run ) == tabIndex;

--- a/flatlaf-jide-oss/src/main/java/com/formdev/flatlaf/jideoss/ui/FlatJideTabbedPaneUI.java
+++ b/flatlaf-jide-oss/src/main/java/com/formdev/flatlaf/jideoss/ui/FlatJideTabbedPaneUI.java
@@ -168,10 +168,12 @@ public class FlatJideTabbedPaneUI
 			_tabScroller.scrollForwardButton.setIcon( arrowIcon );
 			_tabScroller.scrollBackwardButton.setIcon( arrowIcon );
 			_tabScroller.listButton.setIcon( arrowIcon );
+			_tabScroller.closeButton.setIcon( closeIcon );
 
 			_tabScroller.scrollForwardButton.setContentAreaFilled( false );
 			_tabScroller.scrollBackwardButton.setContentAreaFilled( false );
 			_tabScroller.listButton.setContentAreaFilled( false );
+			_tabScroller.closeButton.setContentAreaFilled( false );
 		}
 	}
 
@@ -737,6 +739,7 @@ public class FlatJideTabbedPaneUI
 					y += tabAreaInsets.top;
 
 				// layout buttons
+				x = layoutButtonHorizontal( _tabScroller.closeButton, 16, x, y, h, leftToRight );
 				x = layoutButtonHorizontal( _tabScroller.listButton, 24, x, y, h, leftToRight );
 				x = layoutButtonHorizontal( _tabScroller.scrollForwardButton, 16, x, y, h, leftToRight );
 				x = layoutButtonHorizontal( _tabScroller.scrollBackwardButton, 16, x, y, h, leftToRight );
@@ -767,6 +770,7 @@ public class FlatJideTabbedPaneUI
 					x += tabAreaInsets.left;
 
 				// layout buttons
+				y = layoutButtonVertical( _tabScroller.closeButton, 16, x, y, w );
 				y = layoutButtonVertical( _tabScroller.listButton, 24, x, y, w );
 				y = layoutButtonVertical( _tabScroller.scrollForwardButton, 16, x, y, w );
 				y = layoutButtonVertical( _tabScroller.scrollBackwardButton, 16, x, y, w );

--- a/flatlaf-jide-oss/src/main/resources/com/formdev/flatlaf/jideoss/FlatLaf.properties
+++ b/flatlaf-jide-oss/src/main/resources/com/formdev/flatlaf/jideoss/FlatLaf.properties
@@ -81,3 +81,6 @@ JideTabbedPane.tabAreaInsets = $TabbedPane.tabAreaInsets
 JideTabbedPane.contentBorderInsets = 0,0,0,0
 JideTabbedPane.tabRunOverlay = $TabbedPane.tabRunOverlay
 JideTabbedPane.shadow = $TabbedPane.shadow
+
+JideTabbedPane.closeButtonLeftMargin = 0
+JideTabbedPane.closeButtonRightMargin = 0

--- a/flatlaf-jide-oss/src/main/resources/com/formdev/flatlaf/jideoss/FlatLaf.properties
+++ b/flatlaf-jide-oss/src/main/resources/com/formdev/flatlaf/jideoss/FlatLaf.properties
@@ -84,3 +84,5 @@ JideTabbedPane.shadow = $TabbedPane.shadow
 
 JideTabbedPane.closeButtonLeftMargin = 0
 JideTabbedPane.closeButtonRightMargin = 0
+JideTabbedPane.fitStyleBoundSize = {integer}0
+JideTabbedPane.fitStyleFirstTabMargin = 0

--- a/flatlaf-testing/dumps/uidefaults/FlatDarkLaf_1.8.0_202.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatDarkLaf_1.8.0_202.txt
@@ -489,6 +489,8 @@ JideSplitButtonUI              com.formdev.flatlaf.jideoss.ui.FlatJideSplitButto
 #---- JideTabbedPane ----
 
 JideTabbedPane.background      #3c3f41    javax.swing.plaf.ColorUIResource [UI]
+JideTabbedPane.closeButtonLeftMargin 0
+JideTabbedPane.closeButtonRightMargin 0
 JideTabbedPane.contentBorderInsets 0,0,0,0    javax.swing.plaf.InsetsUIResource [UI]
 JideTabbedPane.foreground      #bbbbbb    javax.swing.plaf.ColorUIResource [UI]
 JideTabbedPane.shadow          #3c3f41    javax.swing.plaf.ColorUIResource [UI]

--- a/flatlaf-testing/dumps/uidefaults/FlatDarkLaf_1.8.0_202.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatDarkLaf_1.8.0_202.txt
@@ -492,6 +492,8 @@ JideTabbedPane.background      #3c3f41    javax.swing.plaf.ColorUIResource [UI]
 JideTabbedPane.closeButtonLeftMargin 0
 JideTabbedPane.closeButtonRightMargin 0
 JideTabbedPane.contentBorderInsets 0,0,0,0    javax.swing.plaf.InsetsUIResource [UI]
+JideTabbedPane.fitStyleBoundSize 0
+JideTabbedPane.fitStyleFirstTabMargin 0
 JideTabbedPane.foreground      #bbbbbb    javax.swing.plaf.ColorUIResource [UI]
 JideTabbedPane.shadow          #3c3f41    javax.swing.plaf.ColorUIResource [UI]
 JideTabbedPane.tabAreaBackground #3c3f41    javax.swing.plaf.ColorUIResource [UI]

--- a/flatlaf-testing/dumps/uidefaults/FlatLightLaf_1.8.0_202.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatLightLaf_1.8.0_202.txt
@@ -494,6 +494,8 @@ JideSplitButtonUI              com.formdev.flatlaf.jideoss.ui.FlatJideSplitButto
 #---- JideTabbedPane ----
 
 JideTabbedPane.background      #f2f2f2    javax.swing.plaf.ColorUIResource [UI]
+JideTabbedPane.closeButtonLeftMargin 0
+JideTabbedPane.closeButtonRightMargin 0
 JideTabbedPane.contentBorderInsets 0,0,0,0    javax.swing.plaf.InsetsUIResource [UI]
 JideTabbedPane.foreground      #000000    javax.swing.plaf.ColorUIResource [UI]
 JideTabbedPane.shadow          #f2f2f2    javax.swing.plaf.ColorUIResource [UI]

--- a/flatlaf-testing/dumps/uidefaults/FlatLightLaf_1.8.0_202.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatLightLaf_1.8.0_202.txt
@@ -497,6 +497,8 @@ JideTabbedPane.background      #f2f2f2    javax.swing.plaf.ColorUIResource [UI]
 JideTabbedPane.closeButtonLeftMargin 0
 JideTabbedPane.closeButtonRightMargin 0
 JideTabbedPane.contentBorderInsets 0,0,0,0    javax.swing.plaf.InsetsUIResource [UI]
+JideTabbedPane.fitStyleBoundSize 0
+JideTabbedPane.fitStyleFirstTabMargin 0
 JideTabbedPane.foreground      #000000    javax.swing.plaf.ColorUIResource [UI]
 JideTabbedPane.shadow          #f2f2f2    javax.swing.plaf.ColorUIResource [UI]
 JideTabbedPane.tabAreaBackground #f2f2f2    javax.swing.plaf.ColorUIResource [UI]

--- a/flatlaf-testing/dumps/uidefaults/FlatTestLaf_1.8.0_202.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatTestLaf_1.8.0_202.txt
@@ -485,6 +485,8 @@ JideSplitButtonUI              com.formdev.flatlaf.jideoss.ui.FlatJideSplitButto
 #---- JideTabbedPane ----
 
 JideTabbedPane.background      #ccffcc    javax.swing.plaf.ColorUIResource [UI]
+JideTabbedPane.closeButtonLeftMargin 0
+JideTabbedPane.closeButtonRightMargin 0
 JideTabbedPane.contentBorderInsets 0,0,0,0    javax.swing.plaf.InsetsUIResource [UI]
 JideTabbedPane.foreground      #ff0000    javax.swing.plaf.ColorUIResource [UI]
 JideTabbedPane.shadow          #ccffcc    javax.swing.plaf.ColorUIResource [UI]

--- a/flatlaf-testing/dumps/uidefaults/FlatTestLaf_1.8.0_202.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatTestLaf_1.8.0_202.txt
@@ -488,6 +488,8 @@ JideTabbedPane.background      #ccffcc    javax.swing.plaf.ColorUIResource [UI]
 JideTabbedPane.closeButtonLeftMargin 0
 JideTabbedPane.closeButtonRightMargin 0
 JideTabbedPane.contentBorderInsets 0,0,0,0    javax.swing.plaf.InsetsUIResource [UI]
+JideTabbedPane.fitStyleBoundSize 0
+JideTabbedPane.fitStyleFirstTabMargin 0
 JideTabbedPane.foreground      #ff0000    javax.swing.plaf.ColorUIResource [UI]
 JideTabbedPane.shadow          #ccffcc    javax.swing.plaf.ColorUIResource [UI]
 JideTabbedPane.tabAreaBackground #ccffcc    javax.swing.plaf.ColorUIResource [UI]

--- a/flatlaf-testing/dumps/uidefaults/JIDE-FlatDarkLaf_1.8.0_202.txt
+++ b/flatlaf-testing/dumps/uidefaults/JIDE-FlatDarkLaf_1.8.0_202.txt
@@ -121,8 +121,6 @@
 + JideTabbedPane.defaultTabBorderShadowColor #736d63    javax.swing.plaf.ColorUIResource [UI]
 + JideTabbedPane.defaultTabColorTheme 3
 + JideTabbedPane.defaultTabShape 2
-+ JideTabbedPane.fitStyleBoundSize 8
-+ JideTabbedPane.fitStyleFirstTabMargin 4
 + JideTabbedPane.fitStyleIconMinWidth 24
 + JideTabbedPane.fitStyleTextMinWidth 16
 + JideTabbedPane.fixedStyleRectSize 60

--- a/flatlaf-testing/dumps/uidefaults/JIDE-FlatDarkLaf_1.8.0_202.txt
+++ b/flatlaf-testing/dumps/uidefaults/JIDE-FlatDarkLaf_1.8.0_202.txt
@@ -108,12 +108,10 @@
 + JideTabbedPane.buttonMargin    5
 + JideTabbedPane.buttonSize      18
 + JideTabbedPane.closeButtonAlignment 11
-+ JideTabbedPane.closeButtonLeftMargin 2
 + JideTabbedPane.closeButtonMargin 2
 + JideTabbedPane.closeButtonMarginHorizonal 3
 + JideTabbedPane.closeButtonMarginSize 6
 + JideTabbedPane.closeButtonMarginVertical 3
-+ JideTabbedPane.closeButtonRightMargin 2
 + JideTabbedPane.compressedStyleCloseButtonMarginHorizontal 0
 + JideTabbedPane.compressedStyleCloseButtonMarginVertical 0
 + JideTabbedPane.compressedStyleIconMargin 12

--- a/flatlaf-testing/dumps/uidefaults/JIDE-FlatLightLaf_1.8.0_202.txt
+++ b/flatlaf-testing/dumps/uidefaults/JIDE-FlatLightLaf_1.8.0_202.txt
@@ -121,8 +121,6 @@
 + JideTabbedPane.defaultTabBorderShadowColor #736d63    javax.swing.plaf.ColorUIResource [UI]
 + JideTabbedPane.defaultTabColorTheme 3
 + JideTabbedPane.defaultTabShape 2
-+ JideTabbedPane.fitStyleBoundSize 8
-+ JideTabbedPane.fitStyleFirstTabMargin 4
 + JideTabbedPane.fitStyleIconMinWidth 24
 + JideTabbedPane.fitStyleTextMinWidth 16
 + JideTabbedPane.fixedStyleRectSize 60

--- a/flatlaf-testing/dumps/uidefaults/JIDE-FlatLightLaf_1.8.0_202.txt
+++ b/flatlaf-testing/dumps/uidefaults/JIDE-FlatLightLaf_1.8.0_202.txt
@@ -108,12 +108,10 @@
 + JideTabbedPane.buttonMargin    5
 + JideTabbedPane.buttonSize      18
 + JideTabbedPane.closeButtonAlignment 11
-+ JideTabbedPane.closeButtonLeftMargin 2
 + JideTabbedPane.closeButtonMargin 2
 + JideTabbedPane.closeButtonMarginHorizonal 3
 + JideTabbedPane.closeButtonMarginSize 6
 + JideTabbedPane.closeButtonMarginVertical 3
-+ JideTabbedPane.closeButtonRightMargin 2
 + JideTabbedPane.compressedStyleCloseButtonMarginHorizontal 0
 + JideTabbedPane.compressedStyleCloseButtonMarginVertical 0
 + JideTabbedPane.compressedStyleIconMargin 12

--- a/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/jideoss/FlatJideOssContainerTest.java
+++ b/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/jideoss/FlatJideOssContainerTest.java
@@ -16,12 +16,15 @@
 
 package com.formdev.flatlaf.testing.jideoss;
 
-import static com.formdev.flatlaf.FlatClientProperties.TABBED_PANE_HAS_FULL_BORDER;
 import java.awt.*;
 import javax.swing.*;
 import javax.swing.border.*;
+import com.formdev.flatlaf.FlatClientProperties;
+import com.formdev.flatlaf.FlatLaf;
+import com.formdev.flatlaf.icons.FlatInternalFrameCloseIcon;
 import com.formdev.flatlaf.testing.*;
 import com.formdev.flatlaf.testing.FlatTestFrame;
+import com.formdev.flatlaf.util.ScaledImageIcon;
 import com.jgoodies.forms.layout.*;
 import com.jidesoft.swing.*;
 import net.miginfocom.swing.*;
@@ -35,49 +38,335 @@ public class FlatJideOssContainerTest
 	public static void main( String[] args ) {
 		SwingUtilities.invokeLater( () -> {
 			FlatTestFrame frame = FlatTestFrame.create( args, "FlatJideOssContainerTest" );
+			frame.useApplyComponentOrientation = true;
 			frame.showFrame( FlatJideOssContainerTest::new );
 		} );
 	}
 
 	FlatJideOssContainerTest() {
 		initComponents();
+
+		tabPlacementField.init( TabPlacement.class, true );
+		tabAlignmentField.init( JideTabAlignment.class, false );
+		tabResizeModeField.init( JideTabResizeMode.class, true );
+
+		tabCountChanged();
+
+		tabsClosableCheckBox.setSelected( true );
+		tabsClosableChanged();
+
+		tabScrollCheckBox.setSelected( true );
+		tabScrollChanged();
 	}
 
 	private void tabScrollChanged() {
+		// JideTabbedPane supports tab closing only in scroll layout
+		// --> turn of if necessary to avoid exceptions in BasicJideTabbedPaneUI
+		tabsClosableChanged();
+
 		int tabLayoutPolicy = tabScrollCheckBox.isSelected() ? JTabbedPane.SCROLL_TAB_LAYOUT : JTabbedPane.WRAP_TAB_LAYOUT;
-		tabbedPane1.setTabLayoutPolicy( tabLayoutPolicy );
-		tabbedPane2.setTabLayoutPolicy( tabLayoutPolicy );
-		tabbedPane3.setTabLayoutPolicy( tabLayoutPolicy );
-		tabbedPane4.setTabLayoutPolicy( tabLayoutPolicy );
+		for( JTabbedPane tabbedPane : allTabbedPanes )
+			tabbedPane.setTabLayoutPolicy( tabLayoutPolicy );
+
+		int tabCount = (Integer) tabCountSpinner.getValue();
+		if( tabLayoutPolicy == JTabbedPane.SCROLL_TAB_LAYOUT && tabCount == 4 )
+			tabCountSpinner.setValue( 8 );
+		else if( tabLayoutPolicy == JTabbedPane.WRAP_TAB_LAYOUT && tabCount == 8 )
+			tabCountSpinner.setValue( 4 );
+	}
+
+	private void showTabSeparatorsChanged() {
+		Boolean showTabSeparators = showTabSeparatorsCheckBox.isSelected() ? true : null;
+		putTabbedPanesClientProperty( FlatClientProperties.TABBED_PANE_SHOW_TAB_SEPARATORS, showTabSeparators );
+	}
+
+	private void hideTabAreaWithOneTabChanged() {
+		boolean hideTabAreaWithOneTab = hideTabAreaWithOneTabCheckBox.isSelected();
+		for( JideTabbedPane tabbedPane : allTabbedPanes )
+			tabbedPane.setHideOneTab( hideTabAreaWithOneTab );
 	}
 
 	private void hasFullBorderChanged() {
 		Boolean hasFullBorder = hasFullBorderCheckBox.isSelected() ? true : null;
-		tabbedPane1.putClientProperty( TABBED_PANE_HAS_FULL_BORDER, hasFullBorder );
-		tabbedPane2.putClientProperty( TABBED_PANE_HAS_FULL_BORDER, hasFullBorder );
-		tabbedPane3.putClientProperty( TABBED_PANE_HAS_FULL_BORDER, hasFullBorder );
-		tabbedPane4.putClientProperty( TABBED_PANE_HAS_FULL_BORDER, hasFullBorder );
+		putTabbedPanesClientProperty( FlatClientProperties.TABBED_PANE_HAS_FULL_BORDER, hasFullBorder );
 	}
 
-	private void moreTabsChanged() {
-		boolean moreTabs = moreTabsCheckBox.isSelected();
-		addRemoveMoreTabs( tabbedPane1, moreTabs );
-		addRemoveMoreTabs( tabbedPane2, moreTabs );
-		addRemoveMoreTabs( tabbedPane3, moreTabs );
-		addRemoveMoreTabs( tabbedPane4, moreTabs );
+	private void putTabbedPanesClientProperty( String key, Object value ) {
+		for( JTabbedPane tabbedPane : allTabbedPanes )
+			tabbedPane.putClientProperty( key, value );
 	}
 
-	private void addRemoveMoreTabs( JTabbedPane tabbedPane, boolean add ) {
-		if( add ) {
-			tabbedPane.addTab( "Tab 4", new JLabel( "tab 4" ) );
-			tabbedPane.addTab( "Tab 5", new JLabel( "tab 5" ) );
-		} else {
-			int tabCount = tabbedPane.getTabCount();
-			if( tabCount > 3 ) {
-				for( int i = 0; i < 2; i++ )
-					tabbedPane.removeTabAt( tabbedPane.getTabCount() - 1 );
-			}
+	private void tabCountChanged() {
+		for( JideTabbedPane tabbedPane : allTabbedPanes )
+			tabCountChanged( tabbedPane );
+	}
+
+	private void tabCountChanged( JideTabbedPane tabbedPane ) {
+		int oldTabCount = tabbedPane.getTabCount();
+		int newTabCount = (Integer) tabCountSpinner.getValue();
+
+		if( newTabCount > oldTabCount ) {
+			for( int i = oldTabCount + 1; i <= newTabCount; i++ )
+				addTab( tabbedPane );
+		} else if( newTabCount < oldTabCount ) {
+			while( tabbedPane.getTabCount() > newTabCount )
+				tabbedPane.removeTabAt( tabbedPane.getTabCount() - 1 );
 		}
+
+		customTabsChanged( tabbedPane );
+		tabBackForegroundChanged( tabbedPane );
+		setTabIcons( tabbedPane );
+	}
+
+	private void addTab( JideTabbedPane tabbedPane ) {
+		switch( tabbedPane.getTabCount() ) {
+			case 0:
+				tabbedPane.addTab( "Tab 1", null, new Panel1(), "First tab." );
+				break;
+
+			case 1:
+				JComponent tab2 = new Panel2();
+				tab2.setBorder( new LineBorder( Color.magenta ) );
+				tabbedPane.addTab( "Second Tab", null, tab2, "This is the second tab." );
+				break;
+
+			case 2:
+				tabbedPane.addTab( "Disabled", createTab( "tab content 3" ) );
+				tabbedPane.setEnabledAt( 2, false );
+				tabbedPane.setToolTipTextAt( 2, "Disabled tab." );
+				break;
+
+			case 3:
+				tabbedPane.addTab( "Tab 4", new JLabel( "non-opaque content", SwingConstants.CENTER ) );
+				break;
+
+			default:
+				int index = tabbedPane.getTabCount() + 1;
+				tabbedPane.addTab( "Tab " + index, createTab( "tab content " + index ) );
+				break;
+		}
+	}
+
+	private JComponent createTab( String text ) {
+		JLabel label = new JLabel( text );
+		label.setHorizontalAlignment( SwingConstants.CENTER );
+
+		JPanel tab = new JPanel( new BorderLayout() );
+		tab.add( label, BorderLayout.CENTER );
+		return tab;
+	}
+
+	private void tabIconsChanged() {
+		for( JTabbedPane tabbedPane : allTabbedPanes )
+			setTabIcons( tabbedPane );
+
+		tabIconSizeSpinner.setEnabled( tabIconsCheckBox.isSelected() );
+	}
+
+	private void setTabIcons( JTabbedPane tabbedPane ) {
+		boolean showTabIcons = tabIconsCheckBox.isSelected();
+		Object iconSize = tabIconSizeSpinner.getValue();
+
+		Icon icon = null;
+		Icon disabledIcon = null;
+		if( showTabIcons ) {
+			ImageIcon imageIcon = new ImageIcon( getClass().getResource( "/com/formdev/flatlaf/testing/test" + iconSize + ".png" ) );
+			icon = new ScaledImageIcon( imageIcon );
+			disabledIcon = UIManager.getLookAndFeel().getDisabledIcon( tabbedPane, imageIcon );
+			if( disabledIcon instanceof ImageIcon )
+				disabledIcon = new ScaledImageIcon( (ImageIcon) disabledIcon );
+		}
+
+		int tabCount = tabbedPane.getTabCount();
+		for( int i = 0; i < tabCount; i++ ) {
+			tabbedPane.setIconAt( i, icon );
+			tabbedPane.setDisabledIconAt( i, disabledIcon );
+		}
+	}
+
+	private void customBorderChanged() {
+		Border border = customBorderCheckBox.isSelected()
+			? new MatteBorder( 10, 20, 25, 35, Color.green )
+			: null;
+
+		for( JTabbedPane tabbedPane : allTabbedPanes )
+			tabbedPane.setBorder( border );
+	}
+
+	private void customTabsChanged() {
+		for( JTabbedPane tabbedPane : allTabbedPanes )
+			customTabsChanged( tabbedPane );
+	}
+
+	private void customTabsChanged( JTabbedPane tabbedPane ) {
+		boolean customTabs = customTabsCheckBox.isSelected();
+		int tabCount = tabbedPane.getTabCount();
+		if( tabCount > 1 )
+			tabbedPane.setTabComponentAt( 1, customTabs ? new JButton( tabbedPane.getTitleAt( 1 ) ) : null );
+		if( tabCount > 3 )
+			tabbedPane.setTabComponentAt( 3, customTabs ? createCustomTab( tabbedPane.getTitleAt( 3 ) ) : null );
+		if( tabCount > 5 )
+			tabbedPane.setTabComponentAt( 5, customTabs ? new JCheckBox( tabbedPane.getTitleAt( 5 ) ) : null );
+	}
+
+	private Component createCustomTab( String tabTitle ) {
+		JButton closeButton;
+		if( UIManager.getLookAndFeel() instanceof FlatLaf ) {
+			closeButton = new JButton( new FlatInternalFrameCloseIcon() );
+			closeButton.setContentAreaFilled( false );
+			closeButton.setBorder( null );
+		} else
+			closeButton = new JButton( "x" );
+
+		JPanel tab = new JPanel( new BorderLayout( 5, 0 ) );
+		tab.setOpaque( false );
+		tab.add( closeButton, BorderLayout.EAST );
+		tab.add( new JLabel( tabTitle ), BorderLayout.CENTER );
+		return tab;
+	}
+
+	private void htmlTabsChanged() {
+		for( JTabbedPane tabbedPane : allTabbedPanes )
+			htmlTabsChanged( tabbedPane );
+	}
+
+	private void htmlTabsChanged( JTabbedPane tabbedPane ) {
+		boolean html = htmlTabsCheckBox.isSelected();
+		boolean multiLine = multiLineTabsCheckBox.isSelected();
+		String s = multiLine
+			? "<html><b>Bold</b> Tab<br>Second <i>Line</i> "
+			: (html ? "<html><b>Bold</b> Tab " : "Tab ");
+		int tabCount = tabbedPane.getTabCount();
+		if( tabCount > 0 )
+			tabbedPane.setTitleAt( 0, s + "1" );
+		if( tabCount > 3 )
+			tabbedPane.setTitleAt( 3, s + "4" );
+	}
+
+	private void tabPlacementChanged() {
+		TabPlacement value = tabPlacementField.getSelectedValue();
+		int tabPlacement = (value != null) ? value.value : -1;
+
+		tabbedPane1.setTabPlacement( (tabPlacement >= 0) ? tabPlacement : SwingConstants.TOP );
+		tabbedPane2.setTabPlacement( (tabPlacement >= 0) ? tabPlacement : SwingConstants.BOTTOM );
+		tabbedPane3.setTabPlacement( (tabPlacement >= 0) ? tabPlacement : SwingConstants.LEFT );
+		tabbedPane4.setTabPlacement( (tabPlacement >= 0) ? tabPlacement : SwingConstants.RIGHT );
+	}
+
+	private void tabAlignmentChanged() {
+		JideTabAlignment value = tabAlignmentField.getSelectedValue();
+		for( JideTabbedPane tabbedPane : allTabbedPanes )
+			tabbedPane.setTabAlignment( value.value );
+	}
+
+	private void tabResizeModeChanged() {
+		JideTabResizeMode value = tabResizeModeField.getSelectedValue();
+		int resizeMode = (value != null) ? value.value : JideTabbedPane.RESIZE_MODE_DEFAULT;
+		for( JideTabbedPane tabbedPane : allTabbedPanes )
+			tabbedPane.setTabResizeMode( resizeMode );
+	}
+
+	private void tabBackForegroundChanged() {
+		for( JTabbedPane tabbedPane : allTabbedPanes )
+			tabBackForegroundChanged( tabbedPane );
+	}
+
+	private void tabBackForegroundChanged( JTabbedPane tabbedPane ) {
+		boolean enabled = tabBackForegroundCheckBox.isSelected();
+		int tabCount = tabbedPane.getTabCount();
+		if( tabCount > 0 )
+			tabbedPane.setBackgroundAt( 0, enabled ? Color.red : null );
+		if( tabCount > 1 )
+			tabbedPane.setForegroundAt( 1, enabled ? Color.red : null );
+	}
+
+	private void leadingComponentChanged() {
+		leadingTrailingComponentChanged( leadingComponentCheckBox.isSelected(), true, "L", 4 );
+	}
+
+	private void trailingComponentChanged() {
+		leadingTrailingComponentChanged( trailingComponentCheckBox.isSelected(), false, "Trailing", 12 );
+	}
+
+	private void leadingTrailingComponentChanged( boolean enabled, boolean leading, String text, int gap ) {
+		for( JideTabbedPane tabbedPane : allTabbedPanes ) {
+			JComponent c = null;
+			if( enabled ) {
+				c = new JLabel( text );
+				c.setOpaque( true );
+				c.setBackground( leading ? Color.cyan : Color.orange );
+				c.setBorder( new EmptyBorder( gap, gap, gap, gap ) );
+			}
+			if( leading )
+				tabbedPane.setTabLeadingComponent( c );
+			else
+				tabbedPane.setTabTrailingComponent( c );
+		}
+	}
+
+	private void tabsClosableChanged() {
+		boolean closable = tabsClosableCheckBox.isSelected() && tabScrollCheckBox.isSelected();
+		for( JideTabbedPane tabbedPane : allTabbedPanes ) {
+			tabbedPane.setShowCloseButton( closable );
+			tabbedPane.setShowCloseButtonOnTab( closable );
+		}
+	}
+
+	private void secondTabClosableChanged() {
+		boolean closable = secondTabClosableCheckBox.isSelected();
+
+		for( JideTabbedPane tabbedPane : allTabbedPanes ) {
+			if( tabbedPane.getTabCount() > 1 )
+				tabbedPane.setTabClosableAt( 1, closable );
+		}
+	}
+
+	private void showCloseButtonOnSelectedTabChanged() {
+		boolean onSelected = showCloseButtonOnSelectedTabCheckBox.isSelected();
+
+		for( JideTabbedPane tabbedPane : allTabbedPanes ) {
+			tabbedPane.setShowCloseButtonOnSelectedTab( onSelected );
+			tabbedPane.revalidate();
+			tabbedPane.repaint();
+		}
+	}
+
+	private void showCloseButtonOnMouseOverChanged() {
+		boolean onMouseOver = showCloseButtonOnMouseOverCheckBox.isSelected();
+
+		for( JideTabbedPane tabbedPane : allTabbedPanes ) {
+			tabbedPane.setShowCloseButtonOnMouseOver( onMouseOver );
+			tabbedPane.revalidate();
+			tabbedPane.repaint();
+		}
+	}
+
+	private void tabAreaInsetsChanged() {
+		Insets insets = tabAreaInsetsCheckBox.isSelected() ? new Insets( 5, 5, 10, 10 ) : null;
+		for( JideTabbedPane tabbedPane : allTabbedPanes )
+			tabbedPane.setTabAreaInsets( insets );
+	}
+
+	private void smallerInsetsChanged() {
+		Insets insets = smallerInsetsCheckBox.isSelected()
+			? new Insets( 2, 2, 2, 2 )
+			: UIManager.getInsets( "JideTabbedPane.tabInsets" );
+		for( JideTabbedPane tabbedPane : allTabbedPanes )
+			tabbedPane.setTabInsets( insets );
+	}
+
+	private void boldActiveTabChanged() {
+		boolean boldActiveTab = boldActiveTabCheckBox.isSelected();
+
+		for( JideTabbedPane tabbedPane : allTabbedPanes )
+			tabbedPane.setBoldActiveTab( boldActiveTab );
+	}
+
+	private void showTabButtonsChanged() {
+		boolean showTabButtons = showTabButtonsCheckBox.isSelected();
+
+		for( JideTabbedPane tabbedPane : allTabbedPanes )
+			tabbedPane.setShowTabButtons( showTabButtons );
 	}
 
 	private void initComponents() {
@@ -85,29 +374,39 @@ public class FlatJideOssContainerTest
 		JPanel panel9 = new JPanel();
 		JLabel tabbedPaneLabel = new JLabel();
 		tabbedPane1 = new JideTabbedPane();
-		JPanel panel1 = new JPanel();
-		JLabel label1 = new JLabel();
-		JPanel panel2 = new JPanel();
-		JLabel label2 = new JLabel();
 		tabbedPane3 = new JideTabbedPane();
-		JPanel panel5 = new JPanel();
-		JLabel label5 = new JLabel();
-		JPanel panel6 = new JPanel();
-		JLabel label6 = new JLabel();
 		tabbedPane2 = new JideTabbedPane();
-		JPanel panel3 = new JPanel();
-		JLabel label3 = new JLabel();
-		JPanel panel4 = new JPanel();
-		JLabel label4 = new JLabel();
 		tabbedPane4 = new JideTabbedPane();
-		JPanel panel7 = new JPanel();
-		JLabel label7 = new JLabel();
-		JPanel panel8 = new JPanel();
-		JLabel label8 = new JLabel();
-		JPanel panel14 = new JPanel();
-		moreTabsCheckBox = new JCheckBox();
+		FlatTestFrame.NoRightToLeftPanel tabbedPaneControlPanel = new FlatTestFrame.NoRightToLeftPanel();
 		tabScrollCheckBox = new JCheckBox();
+		JLabel tabCountLabel = new JLabel();
+		tabCountSpinner = new JSpinner();
+		customTabsCheckBox = new JCheckBox();
+		htmlTabsCheckBox = new JCheckBox();
+		multiLineTabsCheckBox = new JCheckBox();
+		tabBackForegroundCheckBox = new JCheckBox();
+		tabIconsCheckBox = new JCheckBox();
+		tabIconSizeSpinner = new JSpinner();
+		tabsClosableCheckBox = new JCheckBox();
+		showCloseButtonOnSelectedTabCheckBox = new JCheckBox();
+		JLabel tabPlacementLabel = new JLabel();
+		tabPlacementField = new FlatTestEnumComboBox<>();
+		secondTabClosableCheckBox = new JCheckBox();
+		showCloseButtonOnMouseOverCheckBox = new JCheckBox();
+		JLabel tabAreaAlignmentLabel = new JLabel();
+		tabAlignmentField = new FlatTestEnumComboBox<>();
+		JLabel tabResizeModeLabel = new JLabel();
+		tabResizeModeField = new FlatTestEnumComboBox<>();
+		leadingComponentCheckBox = new JCheckBox();
+		customBorderCheckBox = new JCheckBox();
+		tabAreaInsetsCheckBox = new JCheckBox();
+		trailingComponentCheckBox = new JCheckBox();
 		hasFullBorderCheckBox = new JCheckBox();
+		boldActiveTabCheckBox = new JCheckBox();
+		showTabButtonsCheckBox = new JCheckBox();
+		smallerInsetsCheckBox = new JCheckBox();
+		showTabSeparatorsCheckBox = new JCheckBox();
+		hideTabAreaWithOneTabCheckBox = new JCheckBox();
 		CellConstraints cc = new CellConstraints();
 
 		//======== this ========
@@ -122,156 +421,201 @@ public class FlatJideOssContainerTest
 		{
 			panel9.setOpaque(false);
 			panel9.setLayout(new FormLayout(
-				"70dlu:grow, $lcgap, 70dlu:grow",
-				"pref, 2*($lgap, fill:70dlu:grow), $lgap, pref"));
+				"70dlu:grow, $ugap, 70dlu:grow",
+				"pref, $lgap, fill:80dlu:grow, $ugap, fill:80dlu:grow, $pgap, pref"));
 
 			//---- tabbedPaneLabel ----
 			tabbedPaneLabel.setText("JideTabbedPane:");
 			panel9.add(tabbedPaneLabel, cc.xy(1, 1));
-
-			//======== tabbedPane1 ========
-			{
-
-				//======== panel1 ========
-				{
-					panel1.setLayout(new FlowLayout());
-
-					//---- label1 ----
-					label1.setText("TOP");
-					panel1.add(label1);
-				}
-				tabbedPane1.addTab("Tab 1", panel1);
-
-				//======== panel2 ========
-				{
-					panel2.setBorder(new LineBorder(Color.magenta));
-					panel2.setLayout(new FlowLayout());
-				}
-				tabbedPane1.addTab("Tab 2", panel2);
-
-				//---- label2 ----
-				label2.setText("text");
-				tabbedPane1.addTab("Tab 3", label2);
-			}
 			panel9.add(tabbedPane1, cc.xy(1, 3));
 
 			//======== tabbedPane3 ========
 			{
 				tabbedPane3.setTabPlacement(SwingConstants.LEFT);
-
-				//======== panel5 ========
-				{
-					panel5.setLayout(new FlowLayout());
-
-					//---- label5 ----
-					label5.setText("LEFT");
-					panel5.add(label5);
-				}
-				tabbedPane3.addTab("Tab 1", panel5);
-
-				//======== panel6 ========
-				{
-					panel6.setBorder(new LineBorder(Color.magenta));
-					panel6.setLayout(new FlowLayout());
-				}
-				tabbedPane3.addTab("Tab 2", panel6);
-
-				//---- label6 ----
-				label6.setText("text");
-				tabbedPane3.addTab("Tab 3", label6);
 			}
 			panel9.add(tabbedPane3, cc.xy(3, 3));
 
 			//======== tabbedPane2 ========
 			{
 				tabbedPane2.setTabPlacement(SwingConstants.BOTTOM);
-
-				//======== panel3 ========
-				{
-					panel3.setLayout(new FlowLayout());
-
-					//---- label3 ----
-					label3.setText("BOTTOM");
-					panel3.add(label3);
-				}
-				tabbedPane2.addTab("Tab 1", panel3);
-
-				//======== panel4 ========
-				{
-					panel4.setBorder(new LineBorder(Color.magenta));
-					panel4.setLayout(new FlowLayout());
-				}
-				tabbedPane2.addTab("Tab 2", panel4);
-				tabbedPane2.setEnabledAt(1, false);
-
-				//---- label4 ----
-				label4.setText("text");
-				tabbedPane2.addTab("Tab 3", label4);
 			}
 			panel9.add(tabbedPane2, cc.xy(1, 5));
 
 			//======== tabbedPane4 ========
 			{
 				tabbedPane4.setTabPlacement(SwingConstants.RIGHT);
-
-				//======== panel7 ========
-				{
-					panel7.setLayout(new FlowLayout());
-
-					//---- label7 ----
-					label7.setText("RIGHT");
-					panel7.add(label7);
-				}
-				tabbedPane4.addTab("Tab 1", panel7);
-
-				//======== panel8 ========
-				{
-					panel8.setBorder(new LineBorder(Color.magenta));
-					panel8.setLayout(new FlowLayout());
-				}
-				tabbedPane4.addTab("Tab 2", panel8);
-
-				//---- label8 ----
-				label8.setText("text");
-				tabbedPane4.addTab("Tab 3", label8);
 			}
 			panel9.add(tabbedPane4, cc.xy(3, 5));
 
-			//======== panel14 ========
+			//======== tabbedPaneControlPanel ========
 			{
-				panel14.setOpaque(false);
-				panel14.setLayout(new MigLayout(
+				tabbedPaneControlPanel.setOpaque(false);
+				tabbedPaneControlPanel.setLayout(new MigLayout(
 					"insets 0,hidemode 3",
 					// columns
 					"[]" +
-					"[]" +
+					"[fill]" +
 					"[]",
 					// rows
-					"[center]"));
-
-				//---- moreTabsCheckBox ----
-				moreTabsCheckBox.setText("more tabs");
-				moreTabsCheckBox.setMnemonic('M');
-				moreTabsCheckBox.addActionListener(e -> moreTabsChanged());
-				panel14.add(moreTabsCheckBox, "cell 0 0");
+					"[center]" +
+					"[]" +
+					"[]" +
+					"[]" +
+					"[]" +
+					"[]para" +
+					"[]" +
+					"[]para" +
+					"[]" +
+					"[]" +
+					"[]"));
 
 				//---- tabScrollCheckBox ----
-				tabScrollCheckBox.setText("tabLayoutPolicy = SCROLL");
+				tabScrollCheckBox.setText("Use scroll layout");
 				tabScrollCheckBox.setMnemonic('S');
-				tabScrollCheckBox.setSelected(true);
 				tabScrollCheckBox.addActionListener(e -> tabScrollChanged());
-				panel14.add(tabScrollCheckBox, "cell 1 0,alignx left,growx 0");
+				tabbedPaneControlPanel.add(tabScrollCheckBox, "cell 0 0,alignx left,growx 0");
+
+				//---- tabCountLabel ----
+				tabCountLabel.setText("Tab count:");
+				tabbedPaneControlPanel.add(tabCountLabel, "cell 1 0");
+
+				//---- tabCountSpinner ----
+				tabCountSpinner.setModel(new SpinnerNumberModel(4, 0, null, 1));
+				tabCountSpinner.addChangeListener(e -> tabCountChanged());
+				tabbedPaneControlPanel.add(tabCountSpinner, "cell 1 0");
+
+				//---- customTabsCheckBox ----
+				customTabsCheckBox.setText("Custom tabs");
+				customTabsCheckBox.addActionListener(e -> customTabsChanged());
+				tabbedPaneControlPanel.add(customTabsCheckBox, "cell 2 0");
+
+				//---- htmlTabsCheckBox ----
+				htmlTabsCheckBox.setText("HTML");
+				htmlTabsCheckBox.addActionListener(e -> htmlTabsChanged());
+				tabbedPaneControlPanel.add(htmlTabsCheckBox, "cell 2 0");
+
+				//---- multiLineTabsCheckBox ----
+				multiLineTabsCheckBox.setText("multi-line");
+				multiLineTabsCheckBox.addActionListener(e -> htmlTabsChanged());
+				tabbedPaneControlPanel.add(multiLineTabsCheckBox, "cell 2 0");
+
+				//---- tabBackForegroundCheckBox ----
+				tabBackForegroundCheckBox.setText("Tab back/foreground");
+				tabBackForegroundCheckBox.addActionListener(e -> tabBackForegroundChanged());
+				tabbedPaneControlPanel.add(tabBackForegroundCheckBox, "cell 2 1");
+
+				//---- tabIconsCheckBox ----
+				tabIconsCheckBox.setText("Tab icons");
+				tabIconsCheckBox.addActionListener(e -> tabIconsChanged());
+				tabbedPaneControlPanel.add(tabIconsCheckBox, "cell 2 2");
+
+				//---- tabIconSizeSpinner ----
+				tabIconSizeSpinner.setModel(new SpinnerListModel(new String[] {"16", "24", "32", "48", "64"}));
+				tabIconSizeSpinner.setEnabled(false);
+				tabIconSizeSpinner.addChangeListener(e -> tabIconsChanged());
+				tabbedPaneControlPanel.add(tabIconSizeSpinner, "cell 2 2");
+
+				//---- tabsClosableCheckBox ----
+				tabsClosableCheckBox.setText("Tabs closable");
+				tabsClosableCheckBox.addActionListener(e -> tabsClosableChanged());
+				tabbedPaneControlPanel.add(tabsClosableCheckBox, "cell 2 3");
+
+				//---- showCloseButtonOnSelectedTabCheckBox ----
+				showCloseButtonOnSelectedTabCheckBox.setText("show on selected");
+				showCloseButtonOnSelectedTabCheckBox.addActionListener(e -> showCloseButtonOnSelectedTabChanged());
+				tabbedPaneControlPanel.add(showCloseButtonOnSelectedTabCheckBox, "cell 2 3");
+
+				//---- tabPlacementLabel ----
+				tabPlacementLabel.setText("Tab placement:");
+				tabbedPaneControlPanel.add(tabPlacementLabel, "cell 0 4");
+
+				//---- tabPlacementField ----
+				tabPlacementField.addActionListener(e -> tabPlacementChanged());
+				tabbedPaneControlPanel.add(tabPlacementField, "cell 1 4");
+
+				//---- secondTabClosableCheckBox ----
+				secondTabClosableCheckBox.setText("Second Tab closable");
+				secondTabClosableCheckBox.setSelected(true);
+				secondTabClosableCheckBox.addActionListener(e -> secondTabClosableChanged());
+				tabbedPaneControlPanel.add(secondTabClosableCheckBox, "cell 2 4");
+
+				//---- showCloseButtonOnMouseOverCheckBox ----
+				showCloseButtonOnMouseOverCheckBox.setText("show on hover");
+				showCloseButtonOnMouseOverCheckBox.addActionListener(e -> showCloseButtonOnMouseOverChanged());
+				tabbedPaneControlPanel.add(showCloseButtonOnMouseOverCheckBox, "cell 2 4");
+
+				//---- tabAreaAlignmentLabel ----
+				tabAreaAlignmentLabel.setText("Tab alignment:");
+				tabbedPaneControlPanel.add(tabAreaAlignmentLabel, "cell 0 5");
+
+				//---- tabAlignmentField ----
+				tabAlignmentField.addActionListener(e -> tabAlignmentChanged());
+				tabbedPaneControlPanel.add(tabAlignmentField, "cell 1 5");
+
+				//---- tabResizeModeLabel ----
+				tabResizeModeLabel.setText("Tab resize mode:");
+				tabbedPaneControlPanel.add(tabResizeModeLabel, "cell 2 5");
+
+				//---- tabResizeModeField ----
+				tabResizeModeField.addActionListener(e -> tabResizeModeChanged());
+				tabbedPaneControlPanel.add(tabResizeModeField, "cell 2 5");
+
+				//---- leadingComponentCheckBox ----
+				leadingComponentCheckBox.setText("Leading component");
+				leadingComponentCheckBox.addActionListener(e -> leadingComponentChanged());
+				tabbedPaneControlPanel.add(leadingComponentCheckBox, "cell 0 6");
+
+				//---- customBorderCheckBox ----
+				customBorderCheckBox.setText("Custom border");
+				customBorderCheckBox.addActionListener(e -> customBorderChanged());
+				tabbedPaneControlPanel.add(customBorderCheckBox, "cell 1 6");
+
+				//---- tabAreaInsetsCheckBox ----
+				tabAreaInsetsCheckBox.setText("Tab area insets (5,5,10,10)");
+				tabAreaInsetsCheckBox.addActionListener(e -> tabAreaInsetsChanged());
+				tabbedPaneControlPanel.add(tabAreaInsetsCheckBox, "cell 2 6");
+
+				//---- trailingComponentCheckBox ----
+				trailingComponentCheckBox.setText("Trailing component");
+				trailingComponentCheckBox.addActionListener(e -> trailingComponentChanged());
+				tabbedPaneControlPanel.add(trailingComponentCheckBox, "cell 0 7");
 
 				//---- hasFullBorderCheckBox ----
-				hasFullBorderCheckBox.setText("JTabbedPane.hasFullBorder");
-				hasFullBorderCheckBox.setMnemonic('F');
+				hasFullBorderCheckBox.setText("Show content border");
 				hasFullBorderCheckBox.addActionListener(e -> hasFullBorderChanged());
-				panel14.add(hasFullBorderCheckBox, "cell 2 0,alignx left,growx 0");
+				tabbedPaneControlPanel.add(hasFullBorderCheckBox, "cell 1 7,alignx left,growx 0");
+
+				//---- boldActiveTabCheckBox ----
+				boldActiveTabCheckBox.setText("Bold active tab");
+				boldActiveTabCheckBox.addActionListener(e -> boldActiveTabChanged());
+				tabbedPaneControlPanel.add(boldActiveTabCheckBox, "cell 0 8");
+
+				//---- showTabButtonsCheckBox ----
+				showTabButtonsCheckBox.setText("Show tab buttons always");
+				showTabButtonsCheckBox.addActionListener(e -> showTabButtonsChanged());
+				tabbedPaneControlPanel.add(showTabButtonsCheckBox, "cell 1 8");
+
+				//---- smallerInsetsCheckBox ----
+				smallerInsetsCheckBox.setText("Smaller tab insets (2,2,2,2)");
+				smallerInsetsCheckBox.addActionListener(e -> smallerInsetsChanged());
+				tabbedPaneControlPanel.add(smallerInsetsCheckBox, "cell 2 8");
+
+				//---- showTabSeparatorsCheckBox ----
+				showTabSeparatorsCheckBox.setText("Show tab separators");
+				showTabSeparatorsCheckBox.addActionListener(e -> showTabSeparatorsChanged());
+				tabbedPaneControlPanel.add(showTabSeparatorsCheckBox, "cell 1 9");
+
+				//---- hideTabAreaWithOneTabCheckBox ----
+				hideTabAreaWithOneTabCheckBox.setText("Hide tab area with one tab");
+				hideTabAreaWithOneTabCheckBox.addActionListener(e -> hideTabAreaWithOneTabChanged());
+				tabbedPaneControlPanel.add(hideTabAreaWithOneTabCheckBox, "cell 1 10");
 			}
-			panel9.add(panel14, cc.xywh(1, 7, 3, 1));
+			panel9.add(tabbedPaneControlPanel, cc.xywh(1, 7, 3, 1));
 		}
 		add(panel9, "cell 0 0");
 		// JFormDesigner - End of component initialization  //GEN-END:initComponents
+
+		allTabbedPanes = new JideTabbedPane[] { tabbedPane1, tabbedPane2, tabbedPane3, tabbedPane4 };
 	}
 
 	// JFormDesigner - Variables declaration - DO NOT MODIFY  //GEN-BEGIN:variables
@@ -279,8 +623,155 @@ public class FlatJideOssContainerTest
 	private JideTabbedPane tabbedPane3;
 	private JideTabbedPane tabbedPane2;
 	private JideTabbedPane tabbedPane4;
-	private JCheckBox moreTabsCheckBox;
 	private JCheckBox tabScrollCheckBox;
+	private JSpinner tabCountSpinner;
+	private JCheckBox customTabsCheckBox;
+	private JCheckBox htmlTabsCheckBox;
+	private JCheckBox multiLineTabsCheckBox;
+	private JCheckBox tabBackForegroundCheckBox;
+	private JCheckBox tabIconsCheckBox;
+	private JSpinner tabIconSizeSpinner;
+	private JCheckBox tabsClosableCheckBox;
+	private JCheckBox showCloseButtonOnSelectedTabCheckBox;
+	private FlatTestEnumComboBox<TabPlacement> tabPlacementField;
+	private JCheckBox secondTabClosableCheckBox;
+	private JCheckBox showCloseButtonOnMouseOverCheckBox;
+	private FlatTestEnumComboBox<JideTabAlignment> tabAlignmentField;
+	private FlatTestEnumComboBox<JideTabResizeMode> tabResizeModeField;
+	private JCheckBox leadingComponentCheckBox;
+	private JCheckBox customBorderCheckBox;
+	private JCheckBox tabAreaInsetsCheckBox;
+	private JCheckBox trailingComponentCheckBox;
 	private JCheckBox hasFullBorderCheckBox;
+	private JCheckBox boldActiveTabCheckBox;
+	private JCheckBox showTabButtonsCheckBox;
+	private JCheckBox smallerInsetsCheckBox;
+	private JCheckBox showTabSeparatorsCheckBox;
+	private JCheckBox hideTabAreaWithOneTabCheckBox;
 	// JFormDesigner - End of variables declaration  //GEN-END:variables
+
+	private JideTabbedPane[] allTabbedPanes;
+
+	//---- enum TabPlacement --------------------------------------------------
+
+	enum TabPlacement {
+		top( SwingConstants.TOP ),
+		bottom( SwingConstants.BOTTOM ),
+		left( SwingConstants.LEFT ),
+		right( SwingConstants.RIGHT );
+
+		public final int value;
+
+		TabPlacement( int value ) {
+			this.value = value;
+		}
+	};
+
+	//---- enum JideTabAlignment ----------------------------------------------
+
+	enum JideTabAlignment {
+		leading( SwingConstants.LEADING ),
+		center( SwingConstants.CENTER );
+
+		public final int value;
+
+		JideTabAlignment( int value ) {
+			this.value = value;
+		}
+	};
+
+	//---- enum JideTabResizeMode ---------------------------------------------
+
+	enum JideTabResizeMode {
+		none( JideTabbedPane.RESIZE_MODE_NONE ),
+		fit( JideTabbedPane.RESIZE_MODE_FIT ),
+		fixed( JideTabbedPane.RESIZE_MODE_FIXED ),
+		compressed( JideTabbedPane.RESIZE_MODE_COMPRESSED );
+
+		public final int value;
+
+		JideTabResizeMode( int value ) {
+			this.value = value;
+		}
+	};
+
+	//---- class Tab1Panel ----------------------------------------------------
+
+	private static class Panel1
+		extends JPanel
+	{
+		private Panel1() {
+			initComponents();
+		}
+
+		private void initComponents() {
+			// JFormDesigner - Component initialization - DO NOT MODIFY  //GEN-BEGIN:initComponents
+			JLabel label1 = new JLabel();
+			JTextField textField4 = new JTextField();
+			JButton button3 = new JButton();
+
+			//======== this ========
+			setLayout(new MigLayout(
+				"hidemode 3,align center center",
+				// columns
+				"[fill]" +
+				"[fill]" +
+				"[fill]",
+				// rows
+				"[fill]"));
+
+			//---- label1 ----
+			label1.setText("text");
+			add(label1, "cell 0 0");
+
+			//---- textField4 ----
+			textField4.setText("some text");
+			add(textField4, "cell 1 0");
+
+			//---- button3 ----
+			button3.setText("...");
+			add(button3, "cell 2 0");
+			// JFormDesigner - End of component initialization  //GEN-END:initComponents
+		}
+
+		// JFormDesigner - Variables declaration - DO NOT MODIFY  //GEN-BEGIN:variables
+		// JFormDesigner - End of variables declaration  //GEN-END:variables
+	}
+
+	//---- class Tab2Panel ----------------------------------------------------
+
+	private static class Panel2
+		extends JPanel
+	{
+		private Panel2() {
+			initComponents();
+		}
+
+		private void initComponents() {
+			// JFormDesigner - Component initialization - DO NOT MODIFY  //GEN-BEGIN:initComponents
+			JTextField textField5 = new JTextField();
+			JButton button4 = new JButton();
+
+			//======== this ========
+			setLayout(new MigLayout(
+				"insets 0,hidemode 3,align center center",
+				// columns
+				"[fill]" +
+				"[fill]",
+				// rows
+				"[fill]"));
+
+			//---- textField5 ----
+			textField5.setText("more text");
+			add(textField5, "cell 0 0");
+
+			//---- button4 ----
+			button4.setText("...");
+			add(button4, "cell 1 0");
+			// JFormDesigner - End of component initialization  //GEN-END:initComponents
+		}
+
+		// JFormDesigner - Variables declaration - DO NOT MODIFY  //GEN-BEGIN:variables
+		// JFormDesigner - End of variables declaration  //GEN-END:variables
+	}
 }

--- a/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/jideoss/FlatJideOssContainerTest.java
+++ b/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/jideoss/FlatJideOssContainerTest.java
@@ -369,6 +369,13 @@ public class FlatJideOssContainerTest
 			tabbedPane.setShowTabButtons( showTabButtons );
 	}
 
+	private void showGripperChanged() {
+		boolean showGripper = showGripperCheckBox.isSelected();
+
+		for( JideTabbedPane tabbedPane : allTabbedPanes )
+			tabbedPane.setShowGripper( showGripper );
+	}
+
 	private void initComponents() {
 		// JFormDesigner - Component initialization - DO NOT MODIFY  //GEN-BEGIN:initComponents
 		JPanel panel9 = new JPanel();
@@ -405,6 +412,7 @@ public class FlatJideOssContainerTest
 		boldActiveTabCheckBox = new JCheckBox();
 		showTabButtonsCheckBox = new JCheckBox();
 		smallerInsetsCheckBox = new JCheckBox();
+		showGripperCheckBox = new JCheckBox();
 		showTabSeparatorsCheckBox = new JCheckBox();
 		hideTabAreaWithOneTabCheckBox = new JCheckBox();
 		CellConstraints cc = new CellConstraints();
@@ -600,6 +608,11 @@ public class FlatJideOssContainerTest
 				smallerInsetsCheckBox.addActionListener(e -> smallerInsetsChanged());
 				tabbedPaneControlPanel.add(smallerInsetsCheckBox, "cell 2 8");
 
+				//---- showGripperCheckBox ----
+				showGripperCheckBox.setText("Show gripper");
+				showGripperCheckBox.addActionListener(e -> showGripperChanged());
+				tabbedPaneControlPanel.add(showGripperCheckBox, "cell 0 9");
+
 				//---- showTabSeparatorsCheckBox ----
 				showTabSeparatorsCheckBox.setText("Show tab separators");
 				showTabSeparatorsCheckBox.addActionListener(e -> showTabSeparatorsChanged());
@@ -646,6 +659,7 @@ public class FlatJideOssContainerTest
 	private JCheckBox boldActiveTabCheckBox;
 	private JCheckBox showTabButtonsCheckBox;
 	private JCheckBox smallerInsetsCheckBox;
+	private JCheckBox showGripperCheckBox;
 	private JCheckBox showTabSeparatorsCheckBox;
 	private JCheckBox hideTabAreaWithOneTabCheckBox;
 	// JFormDesigner - End of variables declaration  //GEN-END:variables

--- a/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/jideoss/FlatJideOssContainerTest.java
+++ b/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/jideoss/FlatJideOssContainerTest.java
@@ -376,6 +376,13 @@ public class FlatJideOssContainerTest
 			tabbedPane.setShowGripper( showGripper );
 	}
 
+	private void tabEditingAllowedChanged() {
+		boolean tabEditingAllowed = tabEditingAllowedCheckBox.isSelected();
+
+		for( JideTabbedPane tabbedPane : allTabbedPanes )
+			tabbedPane.setTabEditingAllowed( tabEditingAllowed );
+	}
+
 	private void initComponents() {
 		// JFormDesigner - Component initialization - DO NOT MODIFY  //GEN-BEGIN:initComponents
 		JPanel panel9 = new JPanel();
@@ -414,6 +421,7 @@ public class FlatJideOssContainerTest
 		smallerInsetsCheckBox = new JCheckBox();
 		showGripperCheckBox = new JCheckBox();
 		showTabSeparatorsCheckBox = new JCheckBox();
+		tabEditingAllowedCheckBox = new JCheckBox();
 		hideTabAreaWithOneTabCheckBox = new JCheckBox();
 		CellConstraints cc = new CellConstraints();
 
@@ -618,6 +626,11 @@ public class FlatJideOssContainerTest
 				showTabSeparatorsCheckBox.addActionListener(e -> showTabSeparatorsChanged());
 				tabbedPaneControlPanel.add(showTabSeparatorsCheckBox, "cell 1 9");
 
+				//---- tabEditingAllowedCheckBox ----
+				tabEditingAllowedCheckBox.setText("Tab editing allowed");
+				tabEditingAllowedCheckBox.addActionListener(e -> tabEditingAllowedChanged());
+				tabbedPaneControlPanel.add(tabEditingAllowedCheckBox, "cell 0 10");
+
 				//---- hideTabAreaWithOneTabCheckBox ----
 				hideTabAreaWithOneTabCheckBox.setText("Hide tab area with one tab");
 				hideTabAreaWithOneTabCheckBox.addActionListener(e -> hideTabAreaWithOneTabChanged());
@@ -661,6 +674,7 @@ public class FlatJideOssContainerTest
 	private JCheckBox smallerInsetsCheckBox;
 	private JCheckBox showGripperCheckBox;
 	private JCheckBox showTabSeparatorsCheckBox;
+	private JCheckBox tabEditingAllowedCheckBox;
 	private JCheckBox hideTabAreaWithOneTabCheckBox;
 	// JFormDesigner - End of variables declaration  //GEN-END:variables
 

--- a/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/jideoss/FlatJideOssContainerTest.java
+++ b/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/jideoss/FlatJideOssContainerTest.java
@@ -296,6 +296,8 @@ public class FlatJideOssContainerTest
 				c.setOpaque( true );
 				c.setBackground( leading ? Color.cyan : Color.orange );
 				c.setBorder( new EmptyBorder( gap, gap, gap, gap ) );
+				if( leading && (tabbedPane.getTabPlacement() == SwingConstants.TOP || tabbedPane.getTabPlacement() == SwingConstants.BOTTOM) )
+					c.setPreferredSize( new Dimension( 20, 80 ) );
 			}
 			if( leading )
 				tabbedPane.setTabLeadingComponent( c );
@@ -343,8 +345,11 @@ public class FlatJideOssContainerTest
 
 	private void tabAreaInsetsChanged() {
 		Insets insets = tabAreaInsetsCheckBox.isSelected() ? new Insets( 5, 5, 10, 10 ) : null;
-		for( JideTabbedPane tabbedPane : allTabbedPanes )
+		for( JideTabbedPane tabbedPane : allTabbedPanes ) {
 			tabbedPane.setTabAreaInsets( insets );
+			tabbedPane.revalidate();
+			tabbedPane.repaint();
+		}
 	}
 
 	private void smallerInsetsChanged() {

--- a/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/jideoss/FlatJideOssContainerTest.java
+++ b/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/jideoss/FlatJideOssContainerTest.java
@@ -308,11 +308,11 @@ public class FlatJideOssContainerTest
 
 	private void tabsClosableChanged() {
 		boolean closable = tabsClosableCheckBox.isSelected() && tabScrollCheckBox.isSelected();
-		boolean onTab = showCloseButtonOnTabCheckBox.isSelected();
+		boolean onTab = closable && showCloseButtonOnTabCheckBox.isSelected();
 
 		for( JideTabbedPane tabbedPane : allTabbedPanes ) {
-			tabbedPane.setShowCloseButton( closable );
 			tabbedPane.setShowCloseButtonOnTab( onTab );
+			tabbedPane.setShowCloseButton( closable );
 		}
 	}
 
@@ -323,13 +323,6 @@ public class FlatJideOssContainerTest
 			if( tabbedPane.getTabCount() > 1 )
 				tabbedPane.setTabClosableAt( 1, closable );
 		}
-	}
-
-	private void showCloseButtonOnTabChanged() {
-		boolean onTab = showCloseButtonOnTabCheckBox.isSelected();
-
-		for( JideTabbedPane tabbedPane : allTabbedPanes )
-			tabbedPane.setShowCloseButtonOnTab( onTab );
 	}
 
 	private void showCloseButtonOnSelectedTabChanged() {
@@ -554,7 +547,7 @@ public class FlatJideOssContainerTest
 				//---- showCloseButtonOnTabCheckBox ----
 				showCloseButtonOnTabCheckBox.setText("on tab");
 				showCloseButtonOnTabCheckBox.setSelected(true);
-				showCloseButtonOnTabCheckBox.addActionListener(e -> showCloseButtonOnTabChanged());
+				showCloseButtonOnTabCheckBox.addActionListener(e -> tabsClosableChanged());
 				tabbedPaneControlPanel.add(showCloseButtonOnTabCheckBox, "cell 2 3");
 
 				//---- showCloseButtonOnSelectedTabCheckBox ----

--- a/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/jideoss/FlatJideOssContainerTest.java
+++ b/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/jideoss/FlatJideOssContainerTest.java
@@ -308,9 +308,11 @@ public class FlatJideOssContainerTest
 
 	private void tabsClosableChanged() {
 		boolean closable = tabsClosableCheckBox.isSelected() && tabScrollCheckBox.isSelected();
+		boolean onTab = showCloseButtonOnTabCheckBox.isSelected();
+
 		for( JideTabbedPane tabbedPane : allTabbedPanes ) {
 			tabbedPane.setShowCloseButton( closable );
-			tabbedPane.setShowCloseButtonOnTab( closable );
+			tabbedPane.setShowCloseButtonOnTab( onTab );
 		}
 	}
 
@@ -321,6 +323,13 @@ public class FlatJideOssContainerTest
 			if( tabbedPane.getTabCount() > 1 )
 				tabbedPane.setTabClosableAt( 1, closable );
 		}
+	}
+
+	private void showCloseButtonOnTabChanged() {
+		boolean onTab = showCloseButtonOnTabCheckBox.isSelected();
+
+		for( JideTabbedPane tabbedPane : allTabbedPanes )
+			tabbedPane.setShowCloseButtonOnTab( onTab );
 	}
 
 	private void showCloseButtonOnSelectedTabChanged() {
@@ -407,6 +416,7 @@ public class FlatJideOssContainerTest
 		tabIconsCheckBox = new JCheckBox();
 		tabIconSizeSpinner = new JSpinner();
 		tabsClosableCheckBox = new JCheckBox();
+		showCloseButtonOnTabCheckBox = new JCheckBox();
 		showCloseButtonOnSelectedTabCheckBox = new JCheckBox();
 		JLabel tabPlacementLabel = new JLabel();
 		tabPlacementField = new FlatTestEnumComboBox<>();
@@ -541,6 +551,12 @@ public class FlatJideOssContainerTest
 				tabsClosableCheckBox.addActionListener(e -> tabsClosableChanged());
 				tabbedPaneControlPanel.add(tabsClosableCheckBox, "cell 2 3");
 
+				//---- showCloseButtonOnTabCheckBox ----
+				showCloseButtonOnTabCheckBox.setText("on tab");
+				showCloseButtonOnTabCheckBox.setSelected(true);
+				showCloseButtonOnTabCheckBox.addActionListener(e -> showCloseButtonOnTabChanged());
+				tabbedPaneControlPanel.add(showCloseButtonOnTabCheckBox, "cell 2 3");
+
 				//---- showCloseButtonOnSelectedTabCheckBox ----
 				showCloseButtonOnSelectedTabCheckBox.setText("show on selected");
 				showCloseButtonOnSelectedTabCheckBox.addActionListener(e -> showCloseButtonOnSelectedTabChanged());
@@ -663,6 +679,7 @@ public class FlatJideOssContainerTest
 	private JCheckBox tabIconsCheckBox;
 	private JSpinner tabIconSizeSpinner;
 	private JCheckBox tabsClosableCheckBox;
+	private JCheckBox showCloseButtonOnTabCheckBox;
 	private JCheckBox showCloseButtonOnSelectedTabCheckBox;
 	private FlatTestEnumComboBox<TabPlacement> tabPlacementField;
 	private JCheckBox secondTabClosableCheckBox;

--- a/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/jideoss/FlatJideOssContainerTest.jfd
+++ b/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/jideoss/FlatJideOssContainerTest.jfd
@@ -185,7 +185,7 @@ new FormModel {
 						auxiliary() {
 							"JavaCodeGenerator.variableLocal": false
 						}
-						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "showCloseButtonOnTabChanged", false ) )
+						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "tabsClosableChanged", false ) )
 					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
 						"value": "cell 2 3"
 					} )

--- a/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/jideoss/FlatJideOssContainerTest.jfd
+++ b/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/jideoss/FlatJideOssContainerTest.jfd
@@ -13,8 +13,8 @@ new FormModel {
 		} ) {
 			name: "this"
 			add( new FormContainer( "javax.swing.JPanel", new FormLayoutManager( class com.jgoodies.forms.layout.FormLayout ) {
-				"$columnSpecs": "70dlu:grow, labelcompgap, 70dlu:grow"
-				"$rowSpecs": "pref, linegap, fill:70dlu:grow, linegap, fill:70dlu:grow, linegap, pref"
+				"$columnSpecs": "70dlu:grow, unrelgap, 70dlu:grow"
+				"$rowSpecs": "pref, linegap, fill:80dlu:grow, unrelgap, fill:80dlu:grow, pargap, pref"
 			} ) {
 				name: "panel9"
 				"opaque": false
@@ -29,27 +29,6 @@ new FormModel {
 					auxiliary() {
 						"JavaCodeGenerator.variableLocal": false
 					}
-					add( new FormContainer( "javax.swing.JPanel", new FormLayoutManager( class java.awt.FlowLayout ) ) {
-						name: "panel1"
-						add( new FormComponent( "javax.swing.JLabel" ) {
-							name: "label1"
-							"text": "TOP"
-						} )
-					}, new FormLayoutConstraints( null ) {
-						"title": "Tab 1"
-					} )
-					add( new FormContainer( "javax.swing.JPanel", new FormLayoutManager( class java.awt.FlowLayout ) ) {
-						name: "panel2"
-						"border": &LineBorder0 new javax.swing.border.LineBorder( sfield java.awt.Color magenta, 1, false )
-					}, new FormLayoutConstraints( null ) {
-						"title": "Tab 2"
-					} )
-					add( new FormComponent( "javax.swing.JLabel" ) {
-						name: "label2"
-						"text": "text"
-					}, new FormLayoutConstraints( null ) {
-						"title": "Tab 3"
-					} )
 				}, new FormLayoutConstraints( class com.jgoodies.forms.layout.CellConstraints ) {
 					"gridX": 1
 					"gridY": 3
@@ -60,30 +39,9 @@ new FormModel {
 					auxiliary() {
 						"JavaCodeGenerator.variableLocal": false
 					}
-					add( new FormContainer( "javax.swing.JPanel", new FormLayoutManager( class java.awt.FlowLayout ) ) {
-						name: "panel5"
-						add( new FormComponent( "javax.swing.JLabel" ) {
-							name: "label5"
-							"text": "LEFT"
-						} )
-					}, new FormLayoutConstraints( null ) {
-						"title": "Tab 1"
-					} )
-					add( new FormContainer( "javax.swing.JPanel", new FormLayoutManager( class java.awt.FlowLayout ) ) {
-						name: "panel6"
-						"border": #LineBorder0
-					}, new FormLayoutConstraints( null ) {
-						"title": "Tab 2"
-					} )
-					add( new FormComponent( "javax.swing.JLabel" ) {
-						name: "label6"
-						"text": "text"
-					}, new FormLayoutConstraints( null ) {
-						"title": "Tab 3"
-					} )
 				}, new FormLayoutConstraints( class com.jgoodies.forms.layout.CellConstraints ) {
-					"gridX": 3
 					"gridY": 3
+					"gridX": 3
 				} )
 				add( new FormContainer( "com.jidesoft.swing.JideTabbedPane", new FormLayoutManager( class javax.swing.JTabbedPane ) ) {
 					name: "tabbedPane2"
@@ -91,28 +49,6 @@ new FormModel {
 					auxiliary() {
 						"JavaCodeGenerator.variableLocal": false
 					}
-					add( new FormContainer( "javax.swing.JPanel", new FormLayoutManager( class java.awt.FlowLayout ) ) {
-						name: "panel3"
-						add( new FormComponent( "javax.swing.JLabel" ) {
-							name: "label3"
-							"text": "BOTTOM"
-						} )
-					}, new FormLayoutConstraints( null ) {
-						"title": "Tab 1"
-					} )
-					add( new FormContainer( "javax.swing.JPanel", new FormLayoutManager( class java.awt.FlowLayout ) ) {
-						name: "panel4"
-						"border": #LineBorder0
-					}, new FormLayoutConstraints( null ) {
-						"title": "Tab 2"
-						"enabled": false
-					} )
-					add( new FormComponent( "javax.swing.JLabel" ) {
-						name: "label4"
-						"text": "text"
-					}, new FormLayoutConstraints( null ) {
-						"title": "Tab 3"
-					} )
 				}, new FormLayoutConstraints( class com.jgoodies.forms.layout.CellConstraints ) {
 					"gridY": 5
 				} )
@@ -122,71 +58,304 @@ new FormModel {
 					auxiliary() {
 						"JavaCodeGenerator.variableLocal": false
 					}
-					add( new FormContainer( "javax.swing.JPanel", new FormLayoutManager( class java.awt.FlowLayout ) ) {
-						name: "panel7"
-						add( new FormComponent( "javax.swing.JLabel" ) {
-							name: "label7"
-							"text": "RIGHT"
-						} )
-					}, new FormLayoutConstraints( null ) {
-						"title": "Tab 1"
-					} )
-					add( new FormContainer( "javax.swing.JPanel", new FormLayoutManager( class java.awt.FlowLayout ) ) {
-						name: "panel8"
-						"border": #LineBorder0
-					}, new FormLayoutConstraints( null ) {
-						"title": "Tab 2"
-					} )
-					add( new FormComponent( "javax.swing.JLabel" ) {
-						name: "label8"
-						"text": "text"
-					}, new FormLayoutConstraints( null ) {
-						"title": "Tab 3"
-					} )
 				}, new FormLayoutConstraints( class com.jgoodies.forms.layout.CellConstraints ) {
-					"gridX": 3
 					"gridY": 5
+					"gridX": 3
 				} )
-				add( new FormContainer( "javax.swing.JPanel", new FormLayoutManager( class net.miginfocom.swing.MigLayout ) {
+				add( new FormContainer( "com.formdev.flatlaf.testing.FlatTestFrame$NoRightToLeftPanel", new FormLayoutManager( class net.miginfocom.swing.MigLayout ) {
 					"$layoutConstraints": "insets 0,hidemode 3"
-					"$columnConstraints": "[][][]"
-					"$rowConstraints": "[center]"
+					"$columnConstraints": "[][fill][]"
+					"$rowConstraints": "[center][][][][][]para[][]para[][][]"
 				} ) {
-					name: "panel14"
+					name: "tabbedPaneControlPanel"
 					"opaque": false
 					add( new FormComponent( "javax.swing.JCheckBox" ) {
-						name: "moreTabsCheckBox"
-						"text": "more tabs"
-						"mnemonic": 77
-						auxiliary() {
-							"JavaCodeGenerator.variableLocal": false
-						}
-						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "moreTabsChanged", false ) )
-					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-						"value": "cell 0 0"
-					} )
-					add( new FormComponent( "javax.swing.JCheckBox" ) {
 						name: "tabScrollCheckBox"
-						"text": "tabLayoutPolicy = SCROLL"
+						"text": "Use scroll layout"
 						"mnemonic": 83
-						"selected": true
 						auxiliary() {
 							"JavaCodeGenerator.variableLocal": false
 						}
 						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "tabScrollChanged", false ) )
 					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-						"value": "cell 1 0,alignx left,growx 0"
+						"value": "cell 0 0,alignx left,growx 0"
+					} )
+					add( new FormComponent( "javax.swing.JLabel" ) {
+						name: "tabCountLabel"
+						"text": "Tab count:"
+					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+						"value": "cell 1 0"
+					} )
+					add( new FormComponent( "javax.swing.JSpinner" ) {
+						name: "tabCountSpinner"
+						"model": new javax.swing.SpinnerNumberModel {
+							minimum: 0
+							value: 4
+						}
+						auxiliary() {
+							"JavaCodeGenerator.variableLocal": false
+						}
+						addEvent( new FormEvent( "javax.swing.event.ChangeListener", "stateChanged", "tabCountChanged", false ) )
+					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+						"value": "cell 1 0"
+					} )
+					add( new FormComponent( "javax.swing.JCheckBox" ) {
+						name: "customTabsCheckBox"
+						"text": "Custom tabs"
+						auxiliary() {
+							"JavaCodeGenerator.variableLocal": false
+						}
+						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "customTabsChanged", false ) )
+					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+						"value": "cell 2 0"
+					} )
+					add( new FormComponent( "javax.swing.JCheckBox" ) {
+						name: "htmlTabsCheckBox"
+						"text": "HTML"
+						auxiliary() {
+							"JavaCodeGenerator.variableLocal": false
+						}
+						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "htmlTabsChanged", false ) )
+					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+						"value": "cell 2 0"
+					} )
+					add( new FormComponent( "javax.swing.JCheckBox" ) {
+						name: "multiLineTabsCheckBox"
+						"text": "multi-line"
+						auxiliary() {
+							"JavaCodeGenerator.variableLocal": false
+						}
+						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "htmlTabsChanged", false ) )
+					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+						"value": "cell 2 0"
+					} )
+					add( new FormComponent( "javax.swing.JCheckBox" ) {
+						name: "tabBackForegroundCheckBox"
+						"text": "Tab back/foreground"
+						auxiliary() {
+							"JavaCodeGenerator.variableLocal": false
+						}
+						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "tabBackForegroundChanged", false ) )
+					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+						"value": "cell 2 1"
+					} )
+					add( new FormComponent( "javax.swing.JCheckBox" ) {
+						name: "tabIconsCheckBox"
+						"text": "Tab icons"
+						auxiliary() {
+							"JavaCodeGenerator.variableLocal": false
+						}
+						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "tabIconsChanged", false ) )
+					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+						"value": "cell 2 2"
+					} )
+					add( new FormComponent( "javax.swing.JSpinner" ) {
+						name: "tabIconSizeSpinner"
+						"model": new javax.swing.SpinnerListModel {
+							list: new java.util.ArrayList {
+								add( "16" )
+								add( "24" )
+								add( "32" )
+								add( "48" )
+								add( "64" )
+							}
+						}
+						"enabled": false
+						auxiliary() {
+							"JavaCodeGenerator.variableLocal": false
+						}
+						addEvent( new FormEvent( "javax.swing.event.ChangeListener", "stateChanged", "tabIconsChanged", false ) )
+					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+						"value": "cell 2 2"
+					} )
+					add( new FormComponent( "javax.swing.JCheckBox" ) {
+						name: "tabsClosableCheckBox"
+						"text": "Tabs closable"
+						auxiliary() {
+							"JavaCodeGenerator.variableLocal": false
+						}
+						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "tabsClosableChanged", false ) )
+					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+						"value": "cell 2 3"
+					} )
+					add( new FormComponent( "javax.swing.JCheckBox" ) {
+						name: "showCloseButtonOnSelectedTabCheckBox"
+						"text": "show on selected"
+						auxiliary() {
+							"JavaCodeGenerator.variableLocal": false
+						}
+						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "showCloseButtonOnSelectedTabChanged", false ) )
+					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+						"value": "cell 2 3"
+					} )
+					add( new FormComponent( "javax.swing.JLabel" ) {
+						name: "tabPlacementLabel"
+						"text": "Tab placement:"
+					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+						"value": "cell 0 4"
+					} )
+					add( new FormComponent( "com.formdev.flatlaf.testing.FlatTestEnumComboBox" ) {
+						name: "tabPlacementField"
+						auxiliary() {
+							"JavaCodeGenerator.variableLocal": false
+							"JavaCodeGenerator.typeParameters": "TabPlacement"
+						}
+						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "tabPlacementChanged", false ) )
+					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+						"value": "cell 1 4"
+					} )
+					add( new FormComponent( "javax.swing.JCheckBox" ) {
+						name: "secondTabClosableCheckBox"
+						"text": "Second Tab closable"
+						"selected": true
+						auxiliary() {
+							"JavaCodeGenerator.variableLocal": false
+						}
+						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "secondTabClosableChanged", false ) )
+					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+						"value": "cell 2 4"
+					} )
+					add( new FormComponent( "javax.swing.JCheckBox" ) {
+						name: "showCloseButtonOnMouseOverCheckBox"
+						"text": "show on hover"
+						auxiliary() {
+							"JavaCodeGenerator.variableLocal": false
+						}
+						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "showCloseButtonOnMouseOverChanged", false ) )
+					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+						"value": "cell 2 4"
+					} )
+					add( new FormComponent( "javax.swing.JLabel" ) {
+						name: "tabAreaAlignmentLabel"
+						"text": "Tab alignment:"
+					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+						"value": "cell 0 5"
+					} )
+					add( new FormComponent( "com.formdev.flatlaf.testing.FlatTestEnumComboBox" ) {
+						name: "tabAlignmentField"
+						auxiliary() {
+							"JavaCodeGenerator.variableLocal": false
+							"JavaCodeGenerator.typeParameters": "JideTabAlignment"
+						}
+						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "tabAlignmentChanged", false ) )
+					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+						"value": "cell 1 5"
+					} )
+					add( new FormComponent( "javax.swing.JLabel" ) {
+						name: "tabResizeModeLabel"
+						"text": "Tab resize mode:"
+					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+						"value": "cell 2 5"
+					} )
+					add( new FormComponent( "com.formdev.flatlaf.testing.FlatTestEnumComboBox" ) {
+						name: "tabResizeModeField"
+						auxiliary() {
+							"JavaCodeGenerator.variableLocal": false
+							"JavaCodeGenerator.typeParameters": "JideTabResizeMode"
+						}
+						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "tabResizeModeChanged", false ) )
+					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+						"value": "cell 2 5"
+					} )
+					add( new FormComponent( "javax.swing.JCheckBox" ) {
+						name: "leadingComponentCheckBox"
+						"text": "Leading component"
+						auxiliary() {
+							"JavaCodeGenerator.variableLocal": false
+						}
+						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "leadingComponentChanged", false ) )
+					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+						"value": "cell 0 6"
+					} )
+					add( new FormComponent( "javax.swing.JCheckBox" ) {
+						name: "customBorderCheckBox"
+						"text": "Custom border"
+						auxiliary() {
+							"JavaCodeGenerator.variableLocal": false
+						}
+						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "customBorderChanged", false ) )
+					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+						"value": "cell 1 6"
+					} )
+					add( new FormComponent( "javax.swing.JCheckBox" ) {
+						name: "tabAreaInsetsCheckBox"
+						"text": "Tab area insets (5,5,10,10)"
+						auxiliary() {
+							"JavaCodeGenerator.variableLocal": false
+						}
+						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "tabAreaInsetsChanged", false ) )
+					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+						"value": "cell 2 6"
+					} )
+					add( new FormComponent( "javax.swing.JCheckBox" ) {
+						name: "trailingComponentCheckBox"
+						"text": "Trailing component"
+						auxiliary() {
+							"JavaCodeGenerator.variableLocal": false
+						}
+						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "trailingComponentChanged", false ) )
+					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+						"value": "cell 0 7"
 					} )
 					add( new FormComponent( "javax.swing.JCheckBox" ) {
 						name: "hasFullBorderCheckBox"
-						"text": "JTabbedPane.hasFullBorder"
-						"mnemonic": 70
+						"text": "Show content border"
 						auxiliary() {
 							"JavaCodeGenerator.variableLocal": false
 						}
 						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "hasFullBorderChanged", false ) )
 					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-						"value": "cell 2 0,alignx left,growx 0"
+						"value": "cell 1 7,alignx left,growx 0"
+					} )
+					add( new FormComponent( "javax.swing.JCheckBox" ) {
+						name: "boldActiveTabCheckBox"
+						"text": "Bold active tab"
+						auxiliary() {
+							"JavaCodeGenerator.variableLocal": false
+						}
+						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "boldActiveTabChanged", false ) )
+					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+						"value": "cell 0 8"
+					} )
+					add( new FormComponent( "javax.swing.JCheckBox" ) {
+						name: "showTabButtonsCheckBox"
+						"text": "Show tab buttons always"
+						auxiliary() {
+							"JavaCodeGenerator.variableLocal": false
+						}
+						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "showTabButtonsChanged", false ) )
+					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+						"value": "cell 1 8"
+					} )
+					add( new FormComponent( "javax.swing.JCheckBox" ) {
+						name: "smallerInsetsCheckBox"
+						"text": "Smaller tab insets (2,2,2,2)"
+						auxiliary() {
+							"JavaCodeGenerator.variableLocal": false
+						}
+						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "smallerInsetsChanged", false ) )
+					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+						"value": "cell 2 8"
+					} )
+					add( new FormComponent( "javax.swing.JCheckBox" ) {
+						name: "showTabSeparatorsCheckBox"
+						"text": "Show tab separators"
+						auxiliary() {
+							"JavaCodeGenerator.variableLocal": false
+						}
+						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "showTabSeparatorsChanged", false ) )
+					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+						"value": "cell 1 9"
+					} )
+					add( new FormComponent( "javax.swing.JCheckBox" ) {
+						name: "hideTabAreaWithOneTabCheckBox"
+						"text": "Hide tab area with one tab"
+						auxiliary() {
+							"JavaCodeGenerator.variableLocal": false
+						}
+						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "hideTabAreaWithOneTabChanged", false ) )
+					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+						"value": "cell 1 10"
 					} )
 				}, new FormLayoutConstraints( class com.jgoodies.forms.layout.CellConstraints ) {
 					"gridY": 7
@@ -197,7 +366,63 @@ new FormModel {
 			} )
 		}, new FormLayoutConstraints( null ) {
 			"location": new java.awt.Point( 0, 0 )
-			"size": new java.awt.Dimension( 500, 500 )
+			"size": new java.awt.Dimension( 695, 655 )
+		} )
+		add( new FormContainer( "javax.swing.JPanel", new FormLayoutManager( class net.miginfocom.swing.MigLayout ) {
+			"$layoutConstraints": "hidemode 3,align center center"
+			"$columnConstraints": "[fill][fill][fill]"
+			"$rowConstraints": "[fill]"
+		} ) {
+			name: "panel1"
+			auxiliary() {
+				"JavaCodeGenerator.className": "Panel1"
+			}
+			add( new FormComponent( "javax.swing.JLabel" ) {
+				name: "label1"
+				"text": "text"
+			}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+				"value": "cell 0 0"
+			} )
+			add( new FormComponent( "javax.swing.JTextField" ) {
+				name: "textField4"
+				"text": "some text"
+			}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+				"value": "cell 1 0"
+			} )
+			add( new FormComponent( "javax.swing.JButton" ) {
+				name: "button3"
+				"text": "..."
+			}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+				"value": "cell 2 0"
+			} )
+		}, new FormLayoutConstraints( null ) {
+			"location": new java.awt.Point( 0, 710 )
+			"size": new java.awt.Dimension( 291, 118 )
+		} )
+		add( new FormContainer( "javax.swing.JPanel", new FormLayoutManager( class net.miginfocom.swing.MigLayout ) {
+			"$layoutConstraints": "insets 0,hidemode 3,align center center"
+			"$columnConstraints": "[fill][fill]"
+			"$rowConstraints": "[fill]"
+		} ) {
+			name: "panel2"
+			auxiliary() {
+				"JavaCodeGenerator.className": "Panel2"
+			}
+			add( new FormComponent( "javax.swing.JTextField" ) {
+				name: "textField5"
+				"text": "more text"
+			}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+				"value": "cell 0 0"
+			} )
+			add( new FormComponent( "javax.swing.JButton" ) {
+				name: "button4"
+				"text": "..."
+			}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+				"value": "cell 1 0"
+			} )
+		}, new FormLayoutConstraints( null ) {
+			"location": new java.awt.Point( 340, 710 )
+			"size": new java.awt.Dimension( 291, 118 )
 		} )
 	}
 }

--- a/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/jideoss/FlatJideOssContainerTest.jfd
+++ b/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/jideoss/FlatJideOssContainerTest.jfd
@@ -338,6 +338,16 @@ new FormModel {
 						"value": "cell 2 8"
 					} )
 					add( new FormComponent( "javax.swing.JCheckBox" ) {
+						name: "showGripperCheckBox"
+						"text": "Show gripper"
+						auxiliary() {
+							"JavaCodeGenerator.variableLocal": false
+						}
+						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "showGripperChanged", false ) )
+					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+						"value": "cell 0 9"
+					} )
+					add( new FormComponent( "javax.swing.JCheckBox" ) {
 						name: "showTabSeparatorsCheckBox"
 						"text": "Show tab separators"
 						auxiliary() {

--- a/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/jideoss/FlatJideOssContainerTest.jfd
+++ b/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/jideoss/FlatJideOssContainerTest.jfd
@@ -1,4 +1,4 @@
-JFDML JFormDesigner: "7.0.3.1.342" Java: "15" encoding: "UTF-8"
+JFDML JFormDesigner: "7.0.3.1.342" Java: "16" encoding: "UTF-8"
 
 new FormModel {
 	contentType: "form/swing"
@@ -175,6 +175,17 @@ new FormModel {
 							"JavaCodeGenerator.variableLocal": false
 						}
 						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "tabsClosableChanged", false ) )
+					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+						"value": "cell 2 3"
+					} )
+					add( new FormComponent( "javax.swing.JCheckBox" ) {
+						name: "showCloseButtonOnTabCheckBox"
+						"text": "on tab"
+						"selected": true
+						auxiliary() {
+							"JavaCodeGenerator.variableLocal": false
+						}
+						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "showCloseButtonOnTabChanged", false ) )
 					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
 						"value": "cell 2 3"
 					} )

--- a/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/jideoss/FlatJideOssContainerTest.jfd
+++ b/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/jideoss/FlatJideOssContainerTest.jfd
@@ -358,6 +358,16 @@ new FormModel {
 						"value": "cell 1 9"
 					} )
 					add( new FormComponent( "javax.swing.JCheckBox" ) {
+						name: "tabEditingAllowedCheckBox"
+						"text": "Tab editing allowed"
+						auxiliary() {
+							"JavaCodeGenerator.variableLocal": false
+						}
+						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "tabEditingAllowedChanged", false ) )
+					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+						"value": "cell 0 10"
+					} )
+					add( new FormComponent( "javax.swing.JCheckBox" ) {
 						name: "hideTabAreaWithOneTabCheckBox"
 						"text": "Hide tab area with one tab"
 						auxiliary() {

--- a/flatlaf-theme-editor/src/main/resources/com/formdev/flatlaf/themeeditor/FlatLafUIKeys.txt
+++ b/flatlaf-theme-editor/src/main/resources/com/formdev/flatlaf/themeeditor/FlatLafUIKeys.txt
@@ -343,6 +343,8 @@ JideSplitButton.selectionForeground
 JideSplitButton.textIconGap
 JideSplitButtonUI
 JideTabbedPane.background
+JideTabbedPane.closeButtonLeftMargin
+JideTabbedPane.closeButtonRightMargin
 JideTabbedPane.contentBorderInsets
 JideTabbedPane.foreground
 JideTabbedPane.shadow

--- a/flatlaf-theme-editor/src/main/resources/com/formdev/flatlaf/themeeditor/FlatLafUIKeys.txt
+++ b/flatlaf-theme-editor/src/main/resources/com/formdev/flatlaf/themeeditor/FlatLafUIKeys.txt
@@ -346,6 +346,8 @@ JideTabbedPane.background
 JideTabbedPane.closeButtonLeftMargin
 JideTabbedPane.closeButtonRightMargin
 JideTabbedPane.contentBorderInsets
+JideTabbedPane.fitStyleBoundSize
+JideTabbedPane.fitStyleFirstTabMargin
 JideTabbedPane.foreground
 JideTabbedPane.shadow
 JideTabbedPane.tabAreaBackground


### PR DESCRIPTION
This PR updates the look of `JideTabbedPane` to match `JTabbedPane`, adds tab separators and fixes some issues.

![image](https://user-images.githubusercontent.com/5604048/114555622-2d91e500-9c68-11eb-9b24-bb0f8302bbc3.png)

List of improvements:
- new scroll and list buttons
- new tab close buttons
- support tab separators
- support selected tab background
- scale tab gripper
- fixed disabled tab text, which was unreadable in dark themes
- fixed tab icon and title locations in vertical tabs
- tab layout fixes for compact resize mode
- fixed location of tab title editing box
- hide tab selection and tab area separator for `tabbedPane.setHideOneTab(true)` if tabbed pane contains only one tab

## Tab Separators

![image](https://user-images.githubusercontent.com/5604048/114559680-47352b80-9c6c-11eb-8686-fe3081f8cabc.png)

Enable for all tabbed panes in application (`JideTabbedPane` and `JTabbedPane`) with:
~~~java
UIManager.put( "TabbedPane.showTabSeparators", true );
~~~

Or for single tabbed pane with:
~~~java
tabbedPane.putClientProperty( "JTabbedPane.showTabSeparators", true );
~~~

## Selected Tab Background

![image](https://user-images.githubusercontent.com/5604048/114561117-9465cd00-9c6d-11eb-90e6-36186c35db66.png)

Enable for all tabbed panes in application (`JideTabbedPane` and `JTabbedPane`) with:
~~~java
UIManager.put( "TabbedPane.selectedBackground", Color.white );
~~~
