### PR TITLE
Fix #309

### DIFF
--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/LinuxFontPolicy.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/LinuxFontPolicy.java
@@ -261,9 +261,9 @@ class LinuxFontPolicy
 	 * <br>
 	 * Some fonts seem to use hyphens to declare their style
 	 * (e.g <i>NimbusSans-Bold</i>), while others include numbers within their name
-	 * (e.g <i>QumpellkaNo12</i>) or both (e.g <i>ZnikomitNo24-Bold</i>), if we query
+	 * (e.g <i>QumpellkaNo12</i>) or both (e.g <i>ZnikomitNo24-Bold</i>); If we query
 	 * {@code gnome.Gtk/FontName} we'll get a font name which won't be recognized by
-	 * {@code new Font()}; Trying to create a Font object using such name will produce
+	 * {@code new Font()}, so any Font object created using such name will produce
 	 * unexpected results.
 	 * <br>
 	 * <br>


### PR DESCRIPTION
Successfully fixes #309 by completely redesigning how FlatLaf should parse info from `Toolkit.getDefaultToolkit().getDesktopProperty("gnome.Gtk/FontName")`, while trying to interfere the least with already settled code.

I tried to conform to current FlatLaf's code style, so I hope there won't be any problem merging this PR of mine.

I've already tested it slightly, as already shown in #309.