### PR TITLE
New tabbed pane active tab border painting style

### DIFF
--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/FlatClientProperties.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/FlatClientProperties.java
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-
 package com.formdev.flatlaf;
+
 import java.awt.Color;
 import java.util.Objects;
 import javax.swing.JComponent;
@@ -325,21 +325,41 @@ public interface FlatClientProperties
 	//---- JTabbedPane --------------------------------------------------------
 
 	/**
+	 * Specifies type of the selected tab.
+	 * <p>
+	 * <strong>Component</strong> {@link javax.swing.JTabbedPane}<br>
+	 * <strong>Value type</strong> {@link java.lang.String}<br>
+	 * <strong>Allowed Values</strong>
+	 *     {@link #TABBED_PANE_TAB_TYPE_UNDERLINED} or
+	 *     {@link #TABBED_PANE_TAB_TYPE_CARD}
+	 *
+	 * @since 2
+	 */
+	String TABBED_PANE_TAB_TYPE = "JTabbedPane.tabType";
+
+	/**
+	 * Paint the selected tab underlined.
+	 *
+	 * @see #TABBED_PANE_TAB_TYPE
+	 * @since 2
+	 */
+	String TABBED_PANE_TAB_TYPE_UNDERLINED = "underlined";
+
+	/**
+	 * Paint the selected tab as card.
+	 *
+	 * @see #TABBED_PANE_TAB_TYPE
+	 * @since 2
+	 */
+	String TABBED_PANE_TAB_TYPE_CARD = "card";
+
+	/**
 	 * Specifies whether separators are shown between tabs.
 	 * <p>
 	 * <strong>Component</strong> {@link javax.swing.JTabbedPane}<br>
 	 * <strong>Value type</strong> {@link java.lang.Boolean}
 	 */
 	String TABBED_PANE_SHOW_TAB_SEPARATORS = "JTabbedPane.showTabSeparators";
-
-	/**
-	 * Specifies whether a border is painted around the active tab.
-	 * This also changes position of the active tab indicator.
-	 * <p>
-	 * <strong>Component</strong> {@link javax.swing.JTabbedPane}<br>
-	 * <strong>Value type</strong> {@link java.lang.Boolean}
-	 */
-	String TABBED_PANE_ACTIVE_TAB_BORDER = "JTabbedPane.activeTabBorder";
 
 	/**
 	 * Specifies whether the separator between tabs area and content area should be shown.

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/FlatClientProperties.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/FlatClientProperties.java
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-package com.formdev.flatlaf;
 
+package com.formdev.flatlaf;
 import java.awt.Color;
 import java.util.Objects;
 import javax.swing.JComponent;
@@ -331,6 +331,15 @@ public interface FlatClientProperties
 	 * <strong>Value type</strong> {@link java.lang.Boolean}
 	 */
 	String TABBED_PANE_SHOW_TAB_SEPARATORS = "JTabbedPane.showTabSeparators";
+
+	/**
+	 * Specifies whether a border is painted around the active tab.
+	 * This also changes position of the active tab indicator.
+	 * <p>
+	 * <strong>Component</strong> {@link javax.swing.JTabbedPane}<br>
+	 * <strong>Value type</strong> {@link java.lang.Boolean}
+	 */
+	String TABBED_PANE_ACTIVE_TAB_BORDER = "JTabbedPane.activeTabBorder";
 
 	/**
 	 * Specifies whether the separator between tabs area and content area should be shown.

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatTabbedPaneUI.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatTabbedPaneUI.java
@@ -98,6 +98,7 @@ import com.formdev.flatlaf.util.UIScale;
  *
  * @clientProperty JTabbedPane.showTabSeparators		boolean
  * @clientProperty JTabbedPane.hasFullBorder			boolean
+ * @clientProperty JTabbedPane.activeTabBorder			boolean
  *
  * <!-- BasicTabbedPaneUI -->
  *
@@ -135,6 +136,7 @@ import com.formdev.flatlaf.util.UIScale;
  * @uiDefault TabbedPane.showTabSeparators				boolean
  * @uiDefault TabbedPane.tabSeparatorsFullHeight		boolean
  * @uiDefault TabbedPane.hasFullBorder					boolean
+ * @uiDefault TabbedPane.activeTabBorder				boolean
  *
  * @uiDefault TabbedPane.tabLayoutPolicy				String	wrap (default) or scroll
  * @uiDefault TabbedPane.tabsPopupPolicy				String	never or asNeeded (default)
@@ -1014,10 +1016,19 @@ public class FlatTabbedPaneUI
 	{
 		// paint tab separators
 		if( clientPropertyBoolean( tabPane, TABBED_PANE_SHOW_TAB_SEPARATORS, showTabSeparators ) &&
-			!isLastInRun( tabIndex ) )
-			paintTabSeparator( g, tabPlacement, x, y, w, h );
+			!isLastInRun( tabIndex ) ) {
+			if( clientPropertyBoolean( tabPane, TABBED_PANE_ACTIVE_TAB_BORDER, activeTabBorder ) ) {
+				// Some separators need to be omitted when activeTabBorder is enabled
+				int selectedIndex = tabPane.getSelectedIndex();
+				if (tabIndex != selectedIndex - 1 && tabIndex != selectedIndex) {
+					paintTabSeparator( g, tabPlacement, x, y, w, h );
+				}
+			} else {
+				paintTabSeparator( g, tabPlacement, x, y, w, h );
+			}
+		}
 
-		// paint tab border
+		// paint active tab border
 		if ( clientPropertyBoolean( tabPane, TABBED_PANE_ACTIVE_TAB_BORDER, activeTabBorder ) && isSelected) {
 			paintActiveTabBorder(g, tabPlacement, tabIndex, x, y, w, h);
 		}
@@ -1101,7 +1112,7 @@ public class FlatTabbedPaneUI
 
 			case BOTTOM:
 				if ( clientPropertyBoolean( tabPane, TABBED_PANE_ACTIVE_TAB_BORDER, activeTabBorder )) {
-					g.fillRect( x, y + h + contentInsets.top - tabSelectionHeight, w, tabSelectionHeight );
+					g.fillRect( x, y + h - tabSelectionHeight, w, tabSelectionHeight );
 				} else {
 					g.fillRect( x, y - contentInsets.bottom, w, tabSelectionHeight );
 				}
@@ -1119,7 +1130,7 @@ public class FlatTabbedPaneUI
 
 			case RIGHT:
 				if ( clientPropertyBoolean( tabPane, TABBED_PANE_ACTIVE_TAB_BORDER, activeTabBorder )) {
-					g.fillRect( x + w + contentInsets.left - tabSelectionHeight, y, tabSelectionHeight, h );
+					g.fillRect( x + w - tabSelectionHeight, y, tabSelectionHeight, h );
 				} else {
 					g.fillRect( x - contentInsets.right, y, tabSelectionHeight, h );
 				}

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatTabbedPaneUI.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatTabbedPaneUI.java
@@ -640,21 +640,22 @@ public class FlatTabbedPaneUI
 		if ( clientPropertyBoolean( tabPane, TABBED_PANE_ACTIVE_TAB_BORDER, activeTabBorder ) &&
 			 clientPropertyBoolean( tabPane, TABBED_PANE_SHOW_CONTENT_SEPARATOR, true ))
 		{
+			int csh = scale(contentSeparatorHeight);
 			Rectangle bounds = getContentBorderBounds(tabPane.getTabPlacement());
 			Rectangle r;
 			switch (tabPane.getTabPlacement()) {
 				default:
 				case TOP:
-					r = new Rectangle( bounds.x, bounds.y, bounds.width, contentSeparatorHeight);
+					r = new Rectangle( bounds.x, bounds.y, bounds.width, csh);
 					break;
 				case BOTTOM:
-					r = new Rectangle( bounds.x, bounds.y + bounds.height - contentSeparatorHeight, bounds.width, contentSeparatorHeight);
+					r = new Rectangle( bounds.x, bounds.y + bounds.height - csh, bounds.width, csh);
 					break;
 				case LEFT:
-					r = new Rectangle( bounds.x, bounds.y, contentSeparatorHeight, bounds.height);
+					r = new Rectangle( bounds.x, bounds.y, csh, bounds.height);
 					break;
 				case RIGHT:
-					r = new Rectangle( bounds.x + bounds.width - contentSeparatorHeight, bounds.y, contentSeparatorHeight, bounds.height);
+					r = new Rectangle( bounds.x + bounds.width - csh, bounds.y, csh, bounds.height);
 					break;
 			}
 			tabPane.repaint(r);
@@ -1037,7 +1038,7 @@ public class FlatTabbedPaneUI
 	}
 
 	protected void paintActiveTabBorder( Graphics g, int tabPlacement, int tabIndex, int x, int y, int w, int h) {
-		float borderWidth = UIScale.scale( 1f );
+		float borderWidth = scale(contentSeparatorHeight);
 		g.setColor( (tabSeparatorColor != null) ? tabSeparatorColor : contentAreaColor );
 
 		switch( tabPlacement ) {
@@ -1052,6 +1053,25 @@ public class FlatTabbedPaneUI
 				((Graphics2D)g).fill( new Rectangle2D.Float( x, y, w, borderWidth) );
 				((Graphics2D)g).fill( new Rectangle2D.Float( x, y + h - borderWidth, w, borderWidth) );
 				break;
+		}
+
+		if (tabSelectionHeight <= 0) {
+			//If there is no tab selection indicator, paint a top border as well
+			switch( tabPlacement ) {
+				default:
+				case TOP:
+					((Graphics2D)g).fill( new Rectangle2D.Float( x, y, w, borderWidth) );
+					break;
+				case BOTTOM:
+					((Graphics2D)g).fill( new Rectangle2D.Float( x, y + h - borderWidth, w, borderWidth) );
+					break;
+				case LEFT:
+					((Graphics2D)g).fill( new Rectangle2D.Float( x, y, borderWidth, h) );
+					break;
+				case RIGHT:
+					((Graphics2D)g).fill( new Rectangle2D.Float( x + w - borderWidth, y, borderWidth, h) );
+					break;
+			}
 		}
 	}
 
@@ -1200,6 +1220,8 @@ public class FlatTabbedPaneUI
 		int w = contentBorderBounds.width;
 		int h = contentBorderBounds.height;
 
+		int csh = scale( contentSeparatorHeight );
+
 		// compute insets for separator or full border
 		boolean hasFullBorder = clientPropertyBoolean( tabPane, TABBED_PANE_HAS_FULL_BORDER, this.hasFullBorder );
 		int sh = scale( contentSeparatorHeight * 100 ); // multiply by 100 because rotateInsets() does not use floats
@@ -1234,28 +1256,28 @@ public class FlatTabbedPaneUI
 			switch( tabPlacement ) {
 				default:
 				case TOP:
-					gapX = x + ax + 1 + (-scrollOffsetX + tabViewportOffsetX);
+					gapX = x + ax + csh + (-scrollOffsetX + tabViewportOffsetX);
 					gapY = y;
-					gapW = aw - 2;
-					gapH = contentSeparatorHeight;
+					gapW = aw - csh*2;
+					gapH = csh;
 					break;
 				case BOTTOM:
-					gapX = x + ax + 1 + (-scrollOffsetX + tabViewportOffsetX);
-					gapY = h - contentSeparatorHeight;
-					gapW = aw - 2;
-					gapH = contentSeparatorHeight;
+					gapX = x + ax + csh + (-scrollOffsetX + tabViewportOffsetX);
+					gapY = h - csh;
+					gapW = aw - csh*2;
+					gapH = csh;
 					break;
 				case LEFT:
 					gapX = x;
-					gapY = y + ay + 1 + (-scrollOffsetY + tabViewportOffsetY);
-					gapW = contentSeparatorHeight;
-					gapH = ah - 2;
+					gapY = y + ay + csh + (-scrollOffsetY + tabViewportOffsetY);
+					gapW = csh;
+					gapH = ah - csh*2;
 					break;
 				case RIGHT:
-					gapX = w - contentSeparatorHeight;
-					gapY = y + ay + 1 + (-scrollOffsetY + tabViewportOffsetY);
-					gapW = contentSeparatorHeight;
-					gapH = ah - 2;
+					gapX = w - csh;
+					gapY = y + ay + csh + (-scrollOffsetY + tabViewportOffsetY);
+					gapW = csh;
+					gapH = ah - csh*2;
 					break;
 			}
 
@@ -1283,9 +1305,6 @@ public class FlatTabbedPaneUI
 						break;
 				}
 			}
-
-//			((Graphics2D)g).fill( new Rectangle2D.Float( x, y, tabViewport.getX() - x, contentSeparatorHeight) );
-
 		} else {
 			area.add( new Area( new Rectangle2D.Float(x, y, w, h) ) );
 		}

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatTabbedPaneUI.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatTabbedPaneUI.java
@@ -489,7 +489,9 @@ public class FlatTabbedPaneUI
 		contentBorderFocusListener = new FocusListener()
 		{
 			@Override
-			public void focusGained( FocusEvent e ) {}
+			public void focusGained( FocusEvent e ) {
+				repaintContentBorder();
+			}
 
 			@Override
 			public void focusLost( FocusEvent e ) {

--- a/flatlaf-core/src/main/resources/com/formdev/flatlaf/FlatLaf.properties
+++ b/flatlaf-core/src/main/resources/com/formdev/flatlaf/FlatLaf.properties
@@ -569,9 +569,9 @@ SplitPaneDivider.gripGap = 2
 
 TabbedPane.tabHeight = 32
 TabbedPane.tabSelectionHeight = 3
+TabbedPane.cardTabSelectionHeight = 2
 TabbedPane.contentSeparatorHeight = 1
 TabbedPane.showTabSeparators = false
-TabbedPane.activeTabBorder = false
 TabbedPane.tabSeparatorsFullHeight = false
 TabbedPane.hasFullBorder = false
 TabbedPane.tabInsets = 4,12,4,12
@@ -590,6 +590,9 @@ TabbedPane.tabAreaAlignment = leading
 TabbedPane.tabAlignment = center
 # allowed values: preferred, equal or compact
 TabbedPane.tabWidthMode = preferred
+
+# allowed values: underlined or card
+TabbedPane.tabType = underlined
 
 # allowed values: chevron or triangle
 TabbedPane.arrowType = chevron

--- a/flatlaf-core/src/main/resources/com/formdev/flatlaf/FlatLaf.properties
+++ b/flatlaf-core/src/main/resources/com/formdev/flatlaf/FlatLaf.properties
@@ -571,6 +571,7 @@ TabbedPane.tabHeight = 32
 TabbedPane.tabSelectionHeight = 3
 TabbedPane.contentSeparatorHeight = 1
 TabbedPane.showTabSeparators = false
+TabbedPane.activeTabBorder = false
 TabbedPane.tabSeparatorsFullHeight = false
 TabbedPane.hasFullBorder = false
 TabbedPane.tabInsets = 4,12,4,12

--- a/flatlaf-demo/src/main/java/com/formdev/flatlaf/demo/FlatLafDemo.java
+++ b/flatlaf-demo/src/main/java/com/formdev/flatlaf/demo/FlatLafDemo.java
@@ -17,13 +17,11 @@
 package com.formdev.flatlaf.demo;
 
 import java.awt.Dimension;
-import javax.swing.*;
+import javax.swing.SwingUtilities;
 import com.formdev.flatlaf.FlatLaf;
 import com.formdev.flatlaf.extras.FlatInspector;
 import com.formdev.flatlaf.extras.FlatUIDefaultsInspector;
 import com.formdev.flatlaf.util.SystemInfo;
-import static com.formdev.flatlaf.FlatClientProperties.TABBED_PANE_ACTIVE_TAB_BORDER;
-import static com.formdev.flatlaf.FlatClientProperties.TABBED_PANE_HAS_FULL_BORDER;
 
 /**
  * @author Karl Tauber

--- a/flatlaf-demo/src/main/java/com/formdev/flatlaf/demo/FlatLafDemo.java
+++ b/flatlaf-demo/src/main/java/com/formdev/flatlaf/demo/FlatLafDemo.java
@@ -17,11 +17,13 @@
 package com.formdev.flatlaf.demo;
 
 import java.awt.Dimension;
-import javax.swing.SwingUtilities;
+import javax.swing.*;
 import com.formdev.flatlaf.FlatLaf;
 import com.formdev.flatlaf.extras.FlatInspector;
 import com.formdev.flatlaf.extras.FlatUIDefaultsInspector;
 import com.formdev.flatlaf.util.SystemInfo;
+import static com.formdev.flatlaf.FlatClientProperties.TABBED_PANE_ACTIVE_TAB_BORDER;
+import static com.formdev.flatlaf.FlatClientProperties.TABBED_PANE_HAS_FULL_BORDER;
 
 /**
  * @author Karl Tauber

--- a/flatlaf-demo/src/main/java/com/formdev/flatlaf/demo/TabsPanel.java
+++ b/flatlaf-demo/src/main/java/com/formdev/flatlaf/demo/TabsPanel.java
@@ -983,7 +983,7 @@ class TabsPanel
 			panel4.add(showTabSeparatorsCheckBox, "cell 2 1");
 
 			//---- activeTabBorderCheckBox ----
-			activeTabBorderCheckBox.setText("Active tab border");
+			activeTabBorderCheckBox.setText("Paint border around active tab");
 			activeTabBorderCheckBox.setName("activeTabBorderCheckBox");
 			activeTabBorderCheckBox.addActionListener(e -> activeTabBorderChanged());
 			panel4.add(activeTabBorderCheckBox, "cell 3 1");

--- a/flatlaf-demo/src/main/java/com/formdev/flatlaf/demo/TabsPanel.java
+++ b/flatlaf-demo/src/main/java/com/formdev/flatlaf/demo/TabsPanel.java
@@ -303,15 +303,14 @@ class TabsPanel
 		putTabbedPanesClientProperty( TABBED_PANE_SCROLL_BUTTONS_PLACEMENT, scrollButtonsPlacement );
 	}
 
+	private void tabTypeChanged() {
+		String tabType = cardTabTypeButton.isSelected() ? TABBED_PANE_TAB_TYPE_CARD : null;
+		putTabbedPanesClientProperty( TABBED_PANE_TAB_TYPE, tabType );
+	}
+
 	private void showTabSeparatorsChanged() {
 		Boolean showTabSeparators = showTabSeparatorsCheckBox.isSelected() ? true : null;
 		putTabbedPanesClientProperty( TABBED_PANE_SHOW_TAB_SEPARATORS, showTabSeparators );
-	}
-
-	private void activeTabBorderChanged() {
-		Boolean activeBorderTab = activeTabBorderCheckBox.isSelected() ? true : false;
-		System.out.println(TABBED_PANE_ACTIVE_TAB_BORDER + ": " + activeBorderTab);
-		putTabbedPanesClientProperty( TABBED_PANE_ACTIVE_TAB_BORDER, activeBorderTab );
 	}
 
 	private void putTabbedPanesClientProperty( String key, Object value ) {
@@ -402,12 +401,15 @@ class TabsPanel
 		scrollButtonsPlacementToolBar = new JToolBar();
 		scrollBothButton = new JToggleButton();
 		scrollTrailingButton = new JToggleButton();
+		showTabSeparatorsCheckBox = new JCheckBox();
 		tabsPopupPolicyLabel = new JLabel();
 		tabsPopupPolicyToolBar = new JToolBar();
 		popupAsNeededButton = new JToggleButton();
 		popupNeverButton = new JToggleButton();
-		showTabSeparatorsCheckBox = new JCheckBox();
-		activeTabBorderCheckBox = new JCheckBox();
+		tabTypeLabel = new JLabel();
+		tabTypeToolBar = new JToolBar();
+		underlinedTabTypeButton = new JToggleButton();
+		cardTabTypeButton = new JToggleButton();
 
 		//======== this ========
 		setName("this");
@@ -502,7 +504,7 @@ class TabsPanel
 			{
 				tabPlacementTabbedPane.setName("tabPlacementTabbedPane");
 			}
-			panel1.add(tabPlacementTabbedPane, "cell 0 1, width 300:300, height 100:100");
+			panel1.add(tabPlacementTabbedPane, "cell 0 1,width 300:300,height 100:100");
 
 			//---- tabLayoutLabel ----
 			tabLayoutLabel.setText("Tab layout");
@@ -880,7 +882,8 @@ class TabsPanel
 				"[]" +
 				"[fill]para" +
 				"[fill]" +
-				"[fill]para",
+				"[fill]para" +
+				"[fill]",
 				// rows
 				"[]" +
 				"[center]"));
@@ -948,6 +951,12 @@ class TabsPanel
 			}
 			panel4.add(scrollButtonsPlacementToolBar, "cell 3 0");
 
+			//---- showTabSeparatorsCheckBox ----
+			showTabSeparatorsCheckBox.setText("Show tab separators");
+			showTabSeparatorsCheckBox.setName("showTabSeparatorsCheckBox");
+			showTabSeparatorsCheckBox.addActionListener(e -> showTabSeparatorsChanged());
+			panel4.add(showTabSeparatorsCheckBox, "cell 4 0");
+
 			//---- tabsPopupPolicyLabel ----
 			tabsPopupPolicyLabel.setText("Tabs popup policy:");
 			tabsPopupPolicyLabel.setName("tabsPopupPolicyLabel");
@@ -976,17 +985,32 @@ class TabsPanel
 			}
 			panel4.add(tabsPopupPolicyToolBar, "cell 1 1");
 
-			//---- showTabSeparatorsCheckBox ----
-			showTabSeparatorsCheckBox.setText("Show tab separators");
-			showTabSeparatorsCheckBox.setName("showTabSeparatorsCheckBox");
-			showTabSeparatorsCheckBox.addActionListener(e -> showTabSeparatorsChanged());
-			panel4.add(showTabSeparatorsCheckBox, "cell 2 1");
+			//---- tabTypeLabel ----
+			tabTypeLabel.setText("Tab type:");
+			tabTypeLabel.setName("tabTypeLabel");
+			panel4.add(tabTypeLabel, "cell 2 1");
 
-			//---- activeTabBorderCheckBox ----
-			activeTabBorderCheckBox.setText("Paint border around active tab");
-			activeTabBorderCheckBox.setName("activeTabBorderCheckBox");
-			activeTabBorderCheckBox.addActionListener(e -> activeTabBorderChanged());
-			panel4.add(activeTabBorderCheckBox, "cell 3 1");
+			//======== tabTypeToolBar ========
+			{
+				tabTypeToolBar.setFloatable(false);
+				tabTypeToolBar.setName("tabTypeToolBar");
+
+				//---- underlinedTabTypeButton ----
+				underlinedTabTypeButton.setText("underlined");
+				underlinedTabTypeButton.setFont(underlinedTabTypeButton.getFont().deriveFont(underlinedTabTypeButton.getFont().getSize() - 2f));
+				underlinedTabTypeButton.setSelected(true);
+				underlinedTabTypeButton.setName("underlinedTabTypeButton");
+				underlinedTabTypeButton.addActionListener(e -> tabTypeChanged());
+				tabTypeToolBar.add(underlinedTabTypeButton);
+
+				//---- cardTabTypeButton ----
+				cardTabTypeButton.setText("card");
+				cardTabTypeButton.setFont(cardTabTypeButton.getFont().deriveFont(cardTabTypeButton.getFont().getSize() - 2f));
+				cardTabTypeButton.setName("cardTabTypeButton");
+				cardTabTypeButton.addActionListener(e -> tabTypeChanged());
+				tabTypeToolBar.add(cardTabTypeButton);
+			}
+			panel4.add(tabTypeToolBar, "cell 3 1");
 		}
 		add(panel4, "cell 0 2 3 1");
 
@@ -1023,6 +1047,11 @@ class TabsPanel
 		ButtonGroup tabsPopupPolicyButtonGroup = new ButtonGroup();
 		tabsPopupPolicyButtonGroup.add(popupAsNeededButton);
 		tabsPopupPolicyButtonGroup.add(popupNeverButton);
+
+		//---- tabTypeButtonGroup ----
+		ButtonGroup tabTypeButtonGroup = new ButtonGroup();
+		tabTypeButtonGroup.add(underlinedTabTypeButton);
+		tabTypeButtonGroup.add(cardTabTypeButton);
 		// JFormDesigner - End of component initialization  //GEN-END:initComponents
 
 		if( FlatLafDemo.screenshotsMode ) {
@@ -1102,11 +1131,14 @@ class TabsPanel
 	private JToolBar scrollButtonsPlacementToolBar;
 	private JToggleButton scrollBothButton;
 	private JToggleButton scrollTrailingButton;
+	private JCheckBox showTabSeparatorsCheckBox;
 	private JLabel tabsPopupPolicyLabel;
 	private JToolBar tabsPopupPolicyToolBar;
 	private JToggleButton popupAsNeededButton;
 	private JToggleButton popupNeverButton;
-	private JCheckBox showTabSeparatorsCheckBox;
-	private JCheckBox activeTabBorderCheckBox;
+	private JLabel tabTypeLabel;
+	private JToolBar tabTypeToolBar;
+	private JToggleButton underlinedTabTypeButton;
+	private JToggleButton cardTabTypeButton;
 	// JFormDesigner - End of variables declaration  //GEN-END:variables
 }

--- a/flatlaf-demo/src/main/java/com/formdev/flatlaf/demo/TabsPanel.java
+++ b/flatlaf-demo/src/main/java/com/formdev/flatlaf/demo/TabsPanel.java
@@ -308,6 +308,12 @@ class TabsPanel
 		putTabbedPanesClientProperty( TABBED_PANE_SHOW_TAB_SEPARATORS, showTabSeparators );
 	}
 
+	private void activeTabBorderChanged() {
+		Boolean activeBorderTab = activeTabBorderCheckBox.isSelected() ? true : false;
+		System.out.println(TABBED_PANE_ACTIVE_TAB_BORDER + ": " + activeBorderTab);
+		putTabbedPanesClientProperty( TABBED_PANE_ACTIVE_TAB_BORDER, activeBorderTab );
+	}
+
 	private void putTabbedPanesClientProperty( String key, Object value ) {
 		updateTabbedPanesRecur( this, tabbedPane -> tabbedPane.putClientProperty( key, value ) );
 	}
@@ -401,6 +407,7 @@ class TabsPanel
 		popupAsNeededButton = new JToggleButton();
 		popupNeverButton = new JToggleButton();
 		showTabSeparatorsCheckBox = new JCheckBox();
+		activeTabBorderCheckBox = new JCheckBox();
 
 		//======== this ========
 		setName("this");
@@ -495,7 +502,7 @@ class TabsPanel
 			{
 				tabPlacementTabbedPane.setName("tabPlacementTabbedPane");
 			}
-			panel1.add(tabPlacementTabbedPane, "cell 0 1,width 300:300,height 100:100");
+			panel1.add(tabPlacementTabbedPane, "cell 0 1, width 300:300, height 100:100");
 
 			//---- tabLayoutLabel ----
 			tabLayoutLabel.setText("Tab layout");
@@ -973,7 +980,13 @@ class TabsPanel
 			showTabSeparatorsCheckBox.setText("Show tab separators");
 			showTabSeparatorsCheckBox.setName("showTabSeparatorsCheckBox");
 			showTabSeparatorsCheckBox.addActionListener(e -> showTabSeparatorsChanged());
-			panel4.add(showTabSeparatorsCheckBox, "cell 2 1 2 1");
+			panel4.add(showTabSeparatorsCheckBox, "cell 2 1");
+
+			//---- activeTabBorderCheckBox ----
+			activeTabBorderCheckBox.setText("Active tab border");
+			activeTabBorderCheckBox.setName("activeTabBorderCheckBox");
+			activeTabBorderCheckBox.addActionListener(e -> activeTabBorderChanged());
+			panel4.add(activeTabBorderCheckBox, "cell 3 1");
 		}
 		add(panel4, "cell 0 2 3 1");
 
@@ -1094,5 +1107,6 @@ class TabsPanel
 	private JToggleButton popupAsNeededButton;
 	private JToggleButton popupNeverButton;
 	private JCheckBox showTabSeparatorsCheckBox;
+	private JCheckBox activeTabBorderCheckBox;
 	// JFormDesigner - End of variables declaration  //GEN-END:variables
 }

--- a/flatlaf-demo/src/main/java/com/formdev/flatlaf/demo/TabsPanel.jfd
+++ b/flatlaf-demo/src/main/java/com/formdev/flatlaf/demo/TabsPanel.jfd
@@ -457,7 +457,7 @@ new FormModel {
 			} )
 			add( new FormContainer( "javax.swing.JPanel", new FormLayoutManager( class net.miginfocom.swing.MigLayout ) {
 				"$layoutConstraints": "insets 0,hidemode 3"
-				"$columnConstraints": "[][fill]para[fill][fill]para"
+				"$columnConstraints": "[][fill]para[fill][fill]para[fill]"
 				"$rowConstraints": "[][center]"
 			} ) {
 				name: "panel4"
@@ -527,6 +527,16 @@ new FormModel {
 				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
 					"value": "cell 3 0"
 				} )
+				add( new FormComponent( "javax.swing.JCheckBox" ) {
+					name: "showTabSeparatorsCheckBox"
+					"text": "Show tab separators"
+					auxiliary() {
+						"JavaCodeGenerator.variableLocal": false
+					}
+					addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "showTabSeparatorsChanged", false ) )
+				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+					"value": "cell 4 0"
+				} )
 				add( new FormComponent( "javax.swing.JLabel" ) {
 					name: "tabsPopupPolicyLabel"
 					"text": "Tabs popup policy:"
@@ -555,15 +565,32 @@ new FormModel {
 				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
 					"value": "cell 1 1"
 				} )
-				add( new FormComponent( "javax.swing.JCheckBox" ) {
-					name: "showTabSeparatorsCheckBox"
-					"text": "Show tab separators"
-					auxiliary() {
-						"JavaCodeGenerator.variableLocal": false
-					}
-					addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "showTabSeparatorsChanged", false ) )
+				add( new FormComponent( "javax.swing.JLabel" ) {
+					name: "tabTypeLabel"
+					"text": "Tab type:"
 				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-					"value": "cell 2 1 2 1"
+					"value": "cell 2 1"
+				} )
+				add( new FormContainer( "javax.swing.JToolBar", new FormLayoutManager( class javax.swing.JToolBar ) ) {
+					name: "tabTypeToolBar"
+					"floatable": false
+					add( new FormComponent( "javax.swing.JToggleButton" ) {
+						name: "underlinedTabTypeButton"
+						"text": "underlined"
+						"font": &SwingDerivedFont8 new com.jformdesigner.model.SwingDerivedFont( null, 0, -2, false )
+						"selected": true
+						"$buttonGroup": new FormReference( "tabTypeButtonGroup" )
+						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "tabTypeChanged", false ) )
+					} )
+					add( new FormComponent( "javax.swing.JToggleButton" ) {
+						name: "cardTabTypeButton"
+						"text": "card"
+						"font": #SwingDerivedFont8
+						"$buttonGroup": new FormReference( "tabTypeButtonGroup" )
+						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "tabTypeChanged", false ) )
+					} )
+				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+					"value": "cell 3 1"
 				} )
 			}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
 				"value": "cell 0 2 3 1"
@@ -601,6 +628,11 @@ new FormModel {
 			name: "scrollButtonsPlacementButtonGroup"
 		}, new FormLayoutConstraints( null ) {
 			"location": new java.awt.Point( 200, 1020 )
+		} )
+		add( new FormNonVisual( "javax.swing.ButtonGroup" ) {
+			name: "tabTypeButtonGroup"
+		}, new FormLayoutConstraints( null ) {
+			"location": new java.awt.Point( 0, 1072 )
 		} )
 	}
 }

--- a/flatlaf-extras/src/main/java/com/formdev/flatlaf/extras/components/FlatTabbedPane.java
+++ b/flatlaf-extras/src/main/java/com/formdev/flatlaf/extras/components/FlatTabbedPane.java
@@ -364,6 +364,29 @@ public class FlatTabbedPane
 
 
 	// NOTE: enum names must be equal to allowed strings
+	/** @since 2 */ public enum TabType { underlined, card };
+
+	/**
+	 * Returns type of selected tab.
+	 *
+	 * @since 2
+	 */
+	public TabType getTabType() {
+		return getClientPropertyEnumString( TABBED_PANE_TAB_TYPE, TabType.class,
+			"TabbedPane.tabType", TabType.underlined );
+	}
+
+	/**
+	 * Specifies type of selected tab.
+	 *
+	 * @since 2
+	 */
+	public void setTabType( TabType tabType ) {
+		putClientPropertyEnumString( TABBED_PANE_TAB_TYPE, tabType );
+	}
+
+
+	// NOTE: enum names must be equal to allowed strings
 	public enum TabsPopupPolicy { never, asNeeded };
 
 	/**

--- a/flatlaf-testing/dumps/uidefaults/FlatDarkLaf_1.8.0_202.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatDarkLaf_1.8.0_202.txt
@@ -980,6 +980,7 @@ TabbedPane.buttonArc           6
 TabbedPane.buttonHoverBackground #303234    com.formdev.flatlaf.util.DerivedColor [UI]    darken(5%)
 TabbedPane.buttonInsets        2,1,2,1    javax.swing.plaf.InsetsUIResource [UI]
 TabbedPane.buttonPressedBackground #282a2c    com.formdev.flatlaf.util.DerivedColor [UI]    darken(8%)
+TabbedPane.cardTabSelectionHeight 2
 TabbedPane.closeArc            4
 TabbedPane.closeCrossFilledSize 7.5
 TabbedPane.closeCrossLineWidth 1.0
@@ -1022,6 +1023,7 @@ TabbedPane.tabInsets           4,12,4,12    javax.swing.plaf.InsetsUIResource [U
 TabbedPane.tabRunOverlay       0
 TabbedPane.tabSelectionHeight  3
 TabbedPane.tabSeparatorsFullHeight false
+TabbedPane.tabType             underlined
 TabbedPane.tabWidthMode        preferred
 TabbedPane.tabsOpaque          true
 TabbedPane.tabsOverlapBorder   false

--- a/flatlaf-testing/dumps/uidefaults/FlatLightLaf_1.8.0_202.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatLightLaf_1.8.0_202.txt
@@ -985,6 +985,7 @@ TabbedPane.buttonArc           6
 TabbedPane.buttonHoverBackground #e0e0e0    com.formdev.flatlaf.util.DerivedColor [UI]    darken(7% autoInverse)
 TabbedPane.buttonInsets        2,1,2,1    javax.swing.plaf.InsetsUIResource [UI]
 TabbedPane.buttonPressedBackground #d9d9d9    com.formdev.flatlaf.util.DerivedColor [UI]    darken(10% autoInverse)
+TabbedPane.cardTabSelectionHeight 2
 TabbedPane.closeArc            4
 TabbedPane.closeCrossFilledSize 7.5
 TabbedPane.closeCrossLineWidth 1.0
@@ -1027,6 +1028,7 @@ TabbedPane.tabInsets           4,12,4,12    javax.swing.plaf.InsetsUIResource [U
 TabbedPane.tabRunOverlay       0
 TabbedPane.tabSelectionHeight  3
 TabbedPane.tabSeparatorsFullHeight false
+TabbedPane.tabType             underlined
 TabbedPane.tabWidthMode        preferred
 TabbedPane.tabsOpaque          true
 TabbedPane.tabsOverlapBorder   false

--- a/flatlaf-testing/dumps/uidefaults/FlatTestLaf_1.8.0_202.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatTestLaf_1.8.0_202.txt
@@ -980,6 +980,7 @@ TabbedPane.buttonArc           6
 TabbedPane.buttonHoverBackground #ffff00    javax.swing.plaf.ColorUIResource [UI]
 TabbedPane.buttonInsets        2,1,2,1    javax.swing.plaf.InsetsUIResource [UI]
 TabbedPane.buttonPressedBackground #ffc800    javax.swing.plaf.ColorUIResource [UI]
+TabbedPane.cardTabSelectionHeight 2
 TabbedPane.closeArc            999
 TabbedPane.closeCrossFilledSize 6.5
 TabbedPane.closeCrossLineWidth 2.0
@@ -1025,6 +1026,7 @@ TabbedPane.tabRunOverlay       0
 TabbedPane.tabSelectionHeight  3
 TabbedPane.tabSeparatorColor   #0000ff    javax.swing.plaf.ColorUIResource [UI]
 TabbedPane.tabSeparatorsFullHeight false
+TabbedPane.tabType             underlined
 TabbedPane.tabWidthMode        preferred
 TabbedPane.tabsOpaque          true
 TabbedPane.tabsOverlapBorder   false

--- a/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatContainerTest.java
+++ b/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatContainerTest.java
@@ -50,6 +50,8 @@ public class FlatContainerTest
 	public FlatContainerTest() {
 		initComponents();
 
+		tabTypeComboBox.init( TabType.class, true );
+
 		tabPlacementField.init( TabPlacement.class, true );
 		iconPlacementField.init( TabIconPlacement.class, true );
 		tabsPopupPolicyField.init( TabsPopupPolicy.class, true );
@@ -310,6 +312,12 @@ public class FlatContainerTest
 			tabbedPane.setTabWidthMode( value );
 	}
 
+	private void tabTypeChanged() {
+		TabType value = tabTypeComboBox.getSelectedValue();
+		for( FlatTabbedPane tabbedPane : allTabbedPanes )
+			tabbedPane.setTabType( value );
+	}
+
 	private void tabBackForegroundChanged() {
 		for( JTabbedPane tabbedPane : allTabbedPanes )
 			tabBackForegroundChanged( tabbedPane );
@@ -491,6 +499,8 @@ public class FlatContainerTest
 		tabAlignmentField = new FlatTestEnumComboBox<>();
 		JLabel tabWidthModeLabel = new JLabel();
 		tabWidthModeField = new FlatTestEnumComboBox<>();
+		JLabel tabTypeLabel = new JLabel();
+		tabTypeComboBox = new FlatTestEnumComboBox<>();
 		leadingComponentCheckBox = new JCheckBox();
 		customBorderCheckBox = new JCheckBox();
 		tabAreaInsetsCheckBox = new JCheckBox();
@@ -619,6 +629,7 @@ public class FlatContainerTest
 					"[]" +
 					"[]" +
 					"[]" +
+					"[]" +
 					"[]para" +
 					"[]" +
 					"[]para" +
@@ -739,75 +750,83 @@ public class FlatContainerTest
 				tabWidthModeField.addActionListener(e -> tabWidthModeChanged());
 				tabbedPaneControlPanel.add(tabWidthModeField, "cell 2 5");
 
+				//---- tabTypeLabel ----
+				tabTypeLabel.setText("Tab type:");
+				tabbedPaneControlPanel.add(tabTypeLabel, "cell 0 6");
+
+				//---- tabTypeComboBox ----
+				tabTypeComboBox.addActionListener(e -> tabTypeChanged());
+				tabbedPaneControlPanel.add(tabTypeComboBox, "cell 1 6");
+
 				//---- leadingComponentCheckBox ----
 				leadingComponentCheckBox.setText("Leading component");
 				leadingComponentCheckBox.addActionListener(e -> leadingComponentChanged());
-				tabbedPaneControlPanel.add(leadingComponentCheckBox, "cell 0 6");
+				tabbedPaneControlPanel.add(leadingComponentCheckBox, "cell 0 7");
 
 				//---- customBorderCheckBox ----
 				customBorderCheckBox.setText("Custom border");
 				customBorderCheckBox.addActionListener(e -> customBorderChanged());
-				tabbedPaneControlPanel.add(customBorderCheckBox, "cell 1 6");
+				tabbedPaneControlPanel.add(customBorderCheckBox, "cell 1 7");
 
 				//---- tabAreaInsetsCheckBox ----
 				tabAreaInsetsCheckBox.setText("Tab area insets (5,5,10,10)");
 				tabAreaInsetsCheckBox.addActionListener(e -> tabAreaInsetsChanged());
-				tabbedPaneControlPanel.add(tabAreaInsetsCheckBox, "cell 2 6");
+				tabbedPaneControlPanel.add(tabAreaInsetsCheckBox, "cell 2 7");
 
 				//---- trailingComponentCheckBox ----
 				trailingComponentCheckBox.setText("Trailing component");
 				trailingComponentCheckBox.addActionListener(e -> trailingComponentChanged());
-				tabbedPaneControlPanel.add(trailingComponentCheckBox, "cell 0 7");
+				tabbedPaneControlPanel.add(trailingComponentCheckBox, "cell 0 8");
 
 				//---- hasFullBorderCheckBox ----
 				hasFullBorderCheckBox.setText("Show content border");
 				hasFullBorderCheckBox.addActionListener(e -> hasFullBorderChanged());
-				tabbedPaneControlPanel.add(hasFullBorderCheckBox, "cell 1 7,alignx left,growx 0");
+				tabbedPaneControlPanel.add(hasFullBorderCheckBox, "cell 1 8,alignx left,growx 0");
 
 				//---- smallerTabHeightCheckBox ----
 				smallerTabHeightCheckBox.setText("Smaller tab height (26)");
 				smallerTabHeightCheckBox.addActionListener(e -> smallerTabHeightChanged());
-				tabbedPaneControlPanel.add(smallerTabHeightCheckBox, "cell 2 7");
+				tabbedPaneControlPanel.add(smallerTabHeightCheckBox, "cell 2 8");
 
 				//---- minimumTabWidthCheckBox ----
 				minimumTabWidthCheckBox.setText("Minimum tab width (100)");
 				minimumTabWidthCheckBox.addActionListener(e -> minimumTabWidthChanged());
-				tabbedPaneControlPanel.add(minimumTabWidthCheckBox, "cell 0 8");
+				tabbedPaneControlPanel.add(minimumTabWidthCheckBox, "cell 0 9");
 
 				//---- hideContentSeparatorCheckBox ----
 				hideContentSeparatorCheckBox.setText("Hide content separator");
 				hideContentSeparatorCheckBox.addActionListener(e -> hideContentSeparatorChanged());
-				tabbedPaneControlPanel.add(hideContentSeparatorCheckBox, "cell 1 8");
+				tabbedPaneControlPanel.add(hideContentSeparatorCheckBox, "cell 1 9");
 
 				//---- smallerInsetsCheckBox ----
 				smallerInsetsCheckBox.setText("Smaller tab insets (2,2,2,2)");
 				smallerInsetsCheckBox.addActionListener(e -> smallerInsetsChanged());
-				tabbedPaneControlPanel.add(smallerInsetsCheckBox, "cell 2 8");
+				tabbedPaneControlPanel.add(smallerInsetsCheckBox, "cell 2 9");
 
 				//---- maximumTabWidthCheckBox ----
 				maximumTabWidthCheckBox.setText("Maximum tab width (60)");
 				maximumTabWidthCheckBox.addActionListener(e -> maximumTabWidthChanged());
-				tabbedPaneControlPanel.add(maximumTabWidthCheckBox, "cell 0 9");
+				tabbedPaneControlPanel.add(maximumTabWidthCheckBox, "cell 0 10");
 
 				//---- showTabSeparatorsCheckBox ----
 				showTabSeparatorsCheckBox.setText("Show tab separators");
 				showTabSeparatorsCheckBox.addActionListener(e -> showTabSeparatorsChanged());
-				tabbedPaneControlPanel.add(showTabSeparatorsCheckBox, "cell 1 9");
+				tabbedPaneControlPanel.add(showTabSeparatorsCheckBox, "cell 1 10");
 
 				//---- secondTabWiderCheckBox ----
 				secondTabWiderCheckBox.setText("Second Tab insets wider (4,20,4,20)");
 				secondTabWiderCheckBox.addActionListener(e -> secondTabWiderChanged());
-				tabbedPaneControlPanel.add(secondTabWiderCheckBox, "cell 2 9");
+				tabbedPaneControlPanel.add(secondTabWiderCheckBox, "cell 2 10");
 
 				//---- hideTabAreaWithOneTabCheckBox ----
 				hideTabAreaWithOneTabCheckBox.setText("Hide tab area with one tab");
 				hideTabAreaWithOneTabCheckBox.addActionListener(e -> hideTabAreaWithOneTabChanged());
-				tabbedPaneControlPanel.add(hideTabAreaWithOneTabCheckBox, "cell 1 10");
+				tabbedPaneControlPanel.add(hideTabAreaWithOneTabCheckBox, "cell 1 11");
 
 				//---- customWheelScrollingCheckBox ----
 				customWheelScrollingCheckBox.setText("Custom wheel scrolling");
 				customWheelScrollingCheckBox.addActionListener(e -> customWheelScrollingChanged());
-				tabbedPaneControlPanel.add(customWheelScrollingCheckBox, "cell 2 10");
+				tabbedPaneControlPanel.add(customWheelScrollingCheckBox, "cell 2 11");
 			}
 			panel9.add(tabbedPaneControlPanel, cc.xywh(1, 11, 3, 1));
 		}
@@ -840,6 +859,7 @@ public class FlatContainerTest
 	private FlatTestEnumComboBox<TabAreaAlignment> tabAreaAlignmentField;
 	private FlatTestEnumComboBox<TabAlignment> tabAlignmentField;
 	private FlatTestEnumComboBox<TabWidthMode> tabWidthModeField;
+	private FlatTestEnumComboBox<TabType> tabTypeComboBox;
 	private JCheckBox leadingComponentCheckBox;
 	private JCheckBox customBorderCheckBox;
 	private JCheckBox tabAreaInsetsCheckBox;

--- a/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatContainerTest.jfd
+++ b/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatContainerTest.jfd
@@ -132,7 +132,7 @@ new FormModel {
 				add( new FormContainer( "com.formdev.flatlaf.testing.FlatTestFrame$NoRightToLeftPanel", new FormLayoutManager( class net.miginfocom.swing.MigLayout ) {
 					"$layoutConstraints": "insets 0,hidemode 3"
 					"$columnConstraints": "[][fill][]"
-					"$rowConstraints": "[center][][][][][]para[][]para[][][]"
+					"$rowConstraints": "[center][][][][][][]para[][]para[][][]"
 				} ) {
 					name: "tabbedPaneControlPanel"
 					"opaque": false
@@ -372,6 +372,22 @@ new FormModel {
 					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
 						"value": "cell 2 5"
 					} )
+					add( new FormComponent( "javax.swing.JLabel" ) {
+						name: "tabTypeLabel"
+						"text": "Tab type:"
+					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+						"value": "cell 0 6"
+					} )
+					add( new FormComponent( "com.formdev.flatlaf.testing.FlatTestEnumComboBox" ) {
+						name: "tabTypeComboBox"
+						auxiliary() {
+							"JavaCodeGenerator.typeParameters": "TabType"
+							"JavaCodeGenerator.variableLocal": false
+						}
+						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "tabTypeChanged", false ) )
+					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+						"value": "cell 1 6"
+					} )
 					add( new FormComponent( "javax.swing.JCheckBox" ) {
 						name: "leadingComponentCheckBox"
 						"text": "Leading component"
@@ -380,7 +396,7 @@ new FormModel {
 						}
 						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "leadingComponentChanged", false ) )
 					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-						"value": "cell 0 6"
+						"value": "cell 0 7"
 					} )
 					add( new FormComponent( "javax.swing.JCheckBox" ) {
 						name: "customBorderCheckBox"
@@ -390,7 +406,7 @@ new FormModel {
 						}
 						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "customBorderChanged", false ) )
 					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-						"value": "cell 1 6"
+						"value": "cell 1 7"
 					} )
 					add( new FormComponent( "javax.swing.JCheckBox" ) {
 						name: "tabAreaInsetsCheckBox"
@@ -400,7 +416,7 @@ new FormModel {
 						}
 						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "tabAreaInsetsChanged", false ) )
 					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-						"value": "cell 2 6"
+						"value": "cell 2 7"
 					} )
 					add( new FormComponent( "javax.swing.JCheckBox" ) {
 						name: "trailingComponentCheckBox"
@@ -410,7 +426,7 @@ new FormModel {
 						}
 						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "trailingComponentChanged", false ) )
 					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-						"value": "cell 0 7"
+						"value": "cell 0 8"
 					} )
 					add( new FormComponent( "javax.swing.JCheckBox" ) {
 						name: "hasFullBorderCheckBox"
@@ -420,7 +436,7 @@ new FormModel {
 						}
 						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "hasFullBorderChanged", false ) )
 					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-						"value": "cell 1 7,alignx left,growx 0"
+						"value": "cell 1 8,alignx left,growx 0"
 					} )
 					add( new FormComponent( "javax.swing.JCheckBox" ) {
 						name: "smallerTabHeightCheckBox"
@@ -430,7 +446,7 @@ new FormModel {
 						}
 						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "smallerTabHeightChanged", false ) )
 					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-						"value": "cell 2 7"
+						"value": "cell 2 8"
 					} )
 					add( new FormComponent( "javax.swing.JCheckBox" ) {
 						name: "minimumTabWidthCheckBox"
@@ -440,7 +456,7 @@ new FormModel {
 						}
 						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "minimumTabWidthChanged", false ) )
 					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-						"value": "cell 0 8"
+						"value": "cell 0 9"
 					} )
 					add( new FormComponent( "javax.swing.JCheckBox" ) {
 						name: "hideContentSeparatorCheckBox"
@@ -450,7 +466,7 @@ new FormModel {
 						}
 						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "hideContentSeparatorChanged", false ) )
 					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-						"value": "cell 1 8"
+						"value": "cell 1 9"
 					} )
 					add( new FormComponent( "javax.swing.JCheckBox" ) {
 						name: "smallerInsetsCheckBox"
@@ -460,7 +476,7 @@ new FormModel {
 						}
 						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "smallerInsetsChanged", false ) )
 					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-						"value": "cell 2 8"
+						"value": "cell 2 9"
 					} )
 					add( new FormComponent( "javax.swing.JCheckBox" ) {
 						name: "maximumTabWidthCheckBox"
@@ -470,7 +486,7 @@ new FormModel {
 						}
 						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "maximumTabWidthChanged", false ) )
 					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-						"value": "cell 0 9"
+						"value": "cell 0 10"
 					} )
 					add( new FormComponent( "javax.swing.JCheckBox" ) {
 						name: "showTabSeparatorsCheckBox"
@@ -480,7 +496,7 @@ new FormModel {
 						}
 						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "showTabSeparatorsChanged", false ) )
 					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-						"value": "cell 1 9"
+						"value": "cell 1 10"
 					} )
 					add( new FormComponent( "javax.swing.JCheckBox" ) {
 						name: "secondTabWiderCheckBox"
@@ -490,7 +506,7 @@ new FormModel {
 						}
 						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "secondTabWiderChanged", false ) )
 					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-						"value": "cell 2 9"
+						"value": "cell 2 10"
 					} )
 					add( new FormComponent( "javax.swing.JCheckBox" ) {
 						name: "hideTabAreaWithOneTabCheckBox"
@@ -500,7 +516,7 @@ new FormModel {
 						}
 						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "hideTabAreaWithOneTabChanged", false ) )
 					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-						"value": "cell 1 10"
+						"value": "cell 1 11"
 					} )
 					add( new FormComponent( "javax.swing.JCheckBox" ) {
 						name: "customWheelScrollingCheckBox"
@@ -510,7 +526,7 @@ new FormModel {
 						}
 						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "customWheelScrollingChanged", false ) )
 					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-						"value": "cell 2 10"
+						"value": "cell 2 11"
 					} )
 				}, new FormLayoutConstraints( class com.jgoodies.forms.layout.CellConstraints ) {
 					"gridY": 11

--- a/flatlaf-theme-editor/src/main/resources/com/formdev/flatlaf/themeeditor/FlatLafUIKeys.txt
+++ b/flatlaf-theme-editor/src/main/resources/com/formdev/flatlaf/themeeditor/FlatLafUIKeys.txt
@@ -709,6 +709,7 @@ TabbedPane.buttonArc
 TabbedPane.buttonHoverBackground
 TabbedPane.buttonInsets
 TabbedPane.buttonPressedBackground
+TabbedPane.cardTabSelectionHeight
 TabbedPane.closeArc
 TabbedPane.closeCrossFilledSize
 TabbedPane.closeCrossLineWidth
@@ -754,6 +755,7 @@ TabbedPane.tabInsets
 TabbedPane.tabRunOverlay
 TabbedPane.tabSelectionHeight
 TabbedPane.tabSeparatorsFullHeight
+TabbedPane.tabType
 TabbedPane.tabWidthMode
 TabbedPane.tabsOpaque
 TabbedPane.tabsOverlapBorder


### PR DESCRIPTION
This pull request adds a new option to tabbed panes that changes how their active tab and content separator is painted.
It makes the content separator wrap around the active tab much like many typical tabbed pane designs (like metal laf).

![newTabsCrop](https://user-images.githubusercontent.com/44985061/122659060-f104cd00-d173-11eb-9cfd-2443611ebdcf.PNG)

### Why?
- It looks good and it's a widespread design that I've personally been missing in flatlaf. Aside from being present in most UI frameworks on desktop, it can also be found in flat web UI's made with react for example.
- Generally, this design makes the active tab (and whole tabbed pane) pop out / visible a lot more. 
I feel like the current flatlaf material design-ish tabs tend to be hard to find in certain situations/UIs. After all the only indicator of a tabbed pane at first sight (aside from content of the tabs themselves) is just the tiny selection indicator. That's fine for the most part and looks very clean, but in a more complex UI, especially when the tabbed pane is surrounded with other components, it can be hard to find. There is no visual indicator that would separate the top of the tabbed pane and the content above. This design makes the separator bend upwards around the active tab and outline the top of the tabbed pane where the active tab is.
- If the tab and content background are the same they visually merge together which is quite nice and, well, like a tab.

It can be enabled / disabled with the key `activeTabBorder` exactly like `showTabSeparators` is used.

So for example
```
tabbedPane.putClientProperty("JTabbedPane.activeTabBorder", true);
```
or
```
UIManager.put("TabbedPane.activeTabBorder", true);
```

It moves the selection indicator to the top and paints two lines on the sides of the active tab. The tab separator is drawn in parts to leave a gap where the active tab is. In reality, there is no gap since it's filled with a line of the active tab's background color to prevent an ugly line when the active tab is focused or hovered over. This was a bit of a pain since I had to add an extra repaint method for just the separator and handle repaint issues with focus. It does seem to work quite well though.

I've tested everything I thought of in the demo.
- Works with scrolling
- Works with all tab placements
- Works with trailing/leading components
- Works with the full border
- Works with tab separators
- Works with thicc separator height
- Works with different selection indicator heights

I haven't created any "rigorous" tests so I could have easily missed something.

### Example from React
![yee](https://user-images.githubusercontent.com/44985061/122659429-71c5c800-d178-11eb-9dbb-2cfa9d67df73.PNG)

I did add a demo to the demo. I did not edit the changelogs or anything.
Hope you like it.
