### PR TITLE
Tabbed pane scroll viewport edge fade gradients

### DIFF
--- a/flatlaf-core/src/main/resources/com/formdev/flatlaf/FlatLaf.properties
+++ b/flatlaf-core/src/main/resources/com/formdev/flatlaf/FlatLaf.properties
@@ -570,8 +570,8 @@ SplitPaneDivider.gripGap = 2
 TabbedPane.tabHeight = 32
 TabbedPane.tabSelectionHeight = 3
 TabbedPane.contentSeparatorHeight = 1
-TabbedPane.showTabSeparators = false
 TabbedPane.tabSeparatorsFullHeight = false
+TabbedPane.showTabSeparators = false
 TabbedPane.hasFullBorder = false
 TabbedPane.tabInsets = 4,12,4,12
 TabbedPane.tabAreaInsets = 0,0,0,0
@@ -603,6 +603,8 @@ TabbedPane.tabsPopupPolicy = asNeeded
 TabbedPane.scrollButtonsPolicy = asNeededSingle
 # allowed values: both or trailing
 TabbedPane.scrollButtonsPlacement = both
+TabbedPane.scrollEdgeFadeout = true
+TabbedPane.scrollEdgeFadeoutWidth = 12
 
 TabbedPane.closeIcon = com.formdev.flatlaf.icons.FlatTabbedPaneCloseIcon
 TabbedPane.closeSize = 16,16


### PR DESCRIPTION
This PR adds a different way of handling tabbed pane edge clipping when using the scroll tab layout.
Instead of a hard cutoff and title string clipping, gradients are added on the sides that obscure the tabs, making them disappear gradually.

### Comparison
![tabFadeouts](https://user-images.githubusercontent.com/44985061/123018355-adf26600-d3ce-11eb-8ed5-68d3dad90c8f.png)

### Why
It looks a bit better in my opinion. I don't feel like the title clipping with "..." is particularly modern.
Inspiration comes from IntelliJ's IDEA where tabs have this exact effect

![intellijTabFadeouts](https://user-images.githubusercontent.com/44985061/123018800-8223b000-d3cf-11eb-9500-65e87ed8e784.PNG)

It does not look so good with LEFT/RIGHT tab placements though and it makes a tab partially disappear even when its selected and fully visible. That could probably be explicitly solved, but curiously that happens in IDEA too.

### Usage
Its controlled with two UIManager properties
```
TabbedPane.scrollEdgeFadeout = true
TabbedPane.scrollEdgeFadeoutWidth = 12
```
---

It works by placing two components on the edges using the scroll tab layout manager, much like the forward/backward buttons. The selection indicator is not obscured, which required adding a way to track its position in the paintTabSelection() method.
Because of that it does conflict with the other PR I recently opened #343 but that can be easily resolved.