### PR TITLE
Theming improvements

### DIFF
--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/UIDefaultsLoader.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/UIDefaultsLoader.java
@@ -514,7 +514,7 @@ class UIDefaultsLoader
 	private static Object parseBorder( String value, Function<String, String> resolver, List<ClassLoader> addonClassLoaders ) {
 		if( value.indexOf( ',' ) >= 0 ) {
 			// top,left,bottom,right[,lineColor[,lineThickness]]
-			List<String> parts = StringUtils.split( value, ',', true, false );
+			List<String> parts = splitFunctionParams( value, ',' );
 			Insets insets = parseInsets( value );
 			ColorUIResource lineColor = (parts.size() >= 5)
 				? (ColorUIResource) parseColorOrFunction( resolver.apply( parts.get( 4 ) ), resolver, true )

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/icons/FlatCheckBoxMenuItemIcon.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/icons/FlatCheckBoxMenuItemIcon.java
@@ -31,8 +31,8 @@ import com.formdev.flatlaf.ui.FlatStylingSupport.Styleable;
 /**
  * Icon for {@link javax.swing.JCheckBoxMenuItem}.
  *
- * @uiDefault MenuItemCheckBox.icon.checkmarkColor				Color
- * @uiDefault MenuItemCheckBox.icon.disabledCheckmarkColor		Color
+ * @uiDefault CheckBoxMenuItem.icon.checkmarkColor				Color
+ * @uiDefault CheckBoxMenuItem.icon.disabledCheckmarkColor		Color
  * @uiDefault MenuItem.selectionForeground						Color
  * @uiDefault MenuItem.selectionType							String
  *
@@ -41,8 +41,8 @@ import com.formdev.flatlaf.ui.FlatStylingSupport.Styleable;
 public class FlatCheckBoxMenuItemIcon
 	extends FlatAbstractIcon
 {
-	@Styleable protected Color checkmarkColor = UIManager.getColor( "MenuItemCheckBox.icon.checkmarkColor" );
-	@Styleable protected Color disabledCheckmarkColor = UIManager.getColor( "MenuItemCheckBox.icon.disabledCheckmarkColor" );
+	@Styleable protected Color checkmarkColor = UIManager.getColor( "CheckBoxMenuItem.icon.checkmarkColor" );
+	@Styleable protected Color disabledCheckmarkColor = UIManager.getColor( "CheckBoxMenuItem.icon.disabledCheckmarkColor" );
 	@Styleable protected Color selectionForeground = UIManager.getColor( "MenuItem.selectionForeground" );
 
 	public FlatCheckBoxMenuItemIcon() {

--- a/flatlaf-core/src/main/resources/com/formdev/flatlaf/FlatDarculaLaf.properties
+++ b/flatlaf-core/src/main/resources/com/formdev/flatlaf/FlatDarculaLaf.properties
@@ -59,7 +59,7 @@ Component.arrowType = triangle
 
 #---- ProgressBar ----
 
-ProgressBar.foreground = #a0a0a0
+ProgressBar.foreground = darken(@foreground,10%)
 ProgressBar.selectionForeground = @background
 
 

--- a/flatlaf-core/src/main/resources/com/formdev/flatlaf/FlatDarkLaf.properties
+++ b/flatlaf-core/src/main/resources/com/formdev/flatlaf/FlatDarkLaf.properties
@@ -163,6 +163,12 @@ CheckBox.icon[filled].selectedHoverBackground = darken($CheckBox.icon[filled].se
 CheckBox.icon[filled].selectedPressedBackground = darken($CheckBox.icon[filled].selectedBackground,6%,derived)
 
 
+#---- CheckBoxMenuItem ----
+
+CheckBoxMenuItem.icon.checkmarkColor = @buttonArrowColor
+CheckBoxMenuItem.icon.disabledCheckmarkColor = @buttonDisabledArrowColor
+
+
 #---- Component ----
 
 Component.borderColor = tint(@background,19%)
@@ -226,12 +232,6 @@ Menu.icon.disabledArrowColor = @buttonDisabledArrowColor
 #---- MenuBar ----
 
 MenuBar.borderColor = $Separator.foreground
-
-
-#---- MenuItemCheckBox ----
-
-MenuItemCheckBox.icon.checkmarkColor = @buttonArrowColor
-MenuItemCheckBox.icon.disabledCheckmarkColor = @buttonDisabledArrowColor
 
 
 #---- PasswordField ----

--- a/flatlaf-core/src/main/resources/com/formdev/flatlaf/FlatDarkLaf.properties
+++ b/flatlaf-core/src/main/resources/com/formdev/flatlaf/FlatDarkLaf.properties
@@ -32,20 +32,29 @@
 
 #---- variables ----
 
+# general background and foreground (text color)
 @background = #3c3f41
 @foreground = #bbb
+@disabledText = shade(@foreground,25%)
+
+# component background
+@buttonBackground = tint(@background,9%)
+@textComponentBackground = tint(@background,5%)
+@menuBackground = darken(@background,5%)
+
+# selection
 @selectionBackground = @accentSelectionBackground
 @selectionForeground = contrast(@selectionBackground, @background, @foreground, 25%)
 @selectionInactiveBackground = spin(saturate(shade(@selectionBackground,70%),20%),-15)
 @selectionInactiveForeground = @foreground
-@disabledText = shade(@foreground,25%)
-@buttonBackground = tint(@background,9%)
-@textComponentBackground = tint(@background,5%)
-@menuBackground = darken(@background,5%)
+
+# menu
 @menuHoverBackground = lighten(@menuBackground,10%,derived)
 @menuCheckBackground = darken(@selectionBackground,10%,derived noAutoInverse)
 @menuAcceleratorForeground = darken(@foreground,15%)
 @menuAcceleratorSelectionForeground = @selectionForeground
+
+# misc
 @cellFocusColor = #000
 @icon = shade(@foreground,7%)
 

--- a/flatlaf-core/src/main/resources/com/formdev/flatlaf/FlatDarkLaf.properties
+++ b/flatlaf-core/src/main/resources/com/formdev/flatlaf/FlatDarkLaf.properties
@@ -35,18 +35,19 @@
 @background = #3c3f41
 @foreground = #bbb
 @selectionBackground = @accentSelectionBackground
-@selectionForeground = contrast(@selectionBackground,@background,@foreground,25%)
+@selectionForeground = contrast(@selectionBackground, @background, @foreground, 25%)
 @selectionInactiveBackground = spin(saturate(shade(@selectionBackground,70%),20%),-15)
 @selectionInactiveForeground = @foreground
-@disabledText = #888
-@textComponentBackground = #45494A
+@disabledText = shade(@foreground,25%)
+@buttonBackground = tint(@background,9%)
+@textComponentBackground = tint(@background,5%)
 @menuBackground = darken(@background,5%)
 @menuHoverBackground = lighten(@menuBackground,10%,derived)
 @menuCheckBackground = darken(@selectionBackground,10%,derived noAutoInverse)
 @menuAcceleratorForeground = darken(@foreground,15%)
 @menuAcceleratorSelectionForeground = @selectionForeground
 @cellFocusColor = #000
-@icon = #adadad
+@icon = shade(@foreground,7%)
 
 # accent colors (blueish)
 #   set @accentColor to use single accent color or
@@ -63,7 +64,7 @@
 @accentButtonDefaultBackground  = if(@accentColor, @accentColor, darken(spin(@accentBaseColor,-8),13%))
 
 # for buttons within components (e.g. combobox or spinner)
-@buttonArrowColor = #9A9DA1
+@buttonArrowColor = shade(@foreground,17%)
 @buttonDisabledArrowColor = darken(@buttonArrowColor,25%)
 @buttonHoverArrowColor = lighten(@buttonArrowColor,10%,derived noAutoInverse)
 @buttonPressedArrowColor = lighten(@buttonArrowColor,20%,derived noAutoInverse)
@@ -86,11 +87,11 @@ controlDkShadow = lighten($controlShadow,10%)
 
 #---- Button ----
 
-Button.background = #4c5052
+Button.background = @buttonBackground
 Button.hoverBackground = lighten($Button.background,3%,derived)
 Button.pressedBackground = lighten($Button.background,6%,derived)
 Button.selectedBackground = lighten($Button.background,10%,derived)
-Button.selectedForeground = @foreground
+Button.selectedForeground = $Button.foreground
 Button.disabledSelectedBackground = lighten($Button.background,3%,derived)
 
 Button.borderColor = tint($Button.background,10%)
@@ -101,7 +102,7 @@ Button.hoverBorderColor = $Button.focusedBorderColor
 Button.innerFocusWidth = 1
 
 Button.default.background = @accentButtonDefaultBackground
-Button.default.foreground = contrast($Button.default.background,@background,@foreground,25%)
+Button.default.foreground = contrast($Button.default.background, @background, $Button.foreground, 25%)
 Button.default.hoverBackground = lighten($Button.default.background,3%,derived)
 Button.default.pressedBackground = lighten($Button.default.background,6%,derived)
 Button.default.borderColor = tint($Button.default.background,15%)
@@ -118,16 +119,16 @@ Button.toolbar.selectedBackground = lighten($Button.background,7%,derived)
 #---- CheckBox ----
 
 # enabled
-CheckBox.icon.borderColor = #6B6B6B
-CheckBox.icon.background = #43494A
+CheckBox.icon.borderColor = tint($Component.borderColor,5%)
+CheckBox.icon.background = tint(@background,5%)
 CheckBox.icon.selectedBorderColor = $CheckBox.icon.borderColor
 CheckBox.icon.selectedBackground = $CheckBox.icon.background
-CheckBox.icon.checkmarkColor = #A7A7A7
+CheckBox.icon.checkmarkColor = shade(@foreground,10%)
 
 # disabled
-CheckBox.icon.disabledBorderColor = #545556
+CheckBox.icon.disabledBorderColor = shade($CheckBox.icon.borderColor,20%)
 CheckBox.icon.disabledBackground = @background
-CheckBox.icon.disabledCheckmarkColor = #606060
+CheckBox.icon.disabledCheckmarkColor = darken($CheckBox.icon.checkmarkColor,25%)
 
 # focused
 CheckBox.icon.focusedBorderColor = $Component.focusedBorderColor
@@ -152,14 +153,9 @@ CheckBox.icon[filled].selectedHoverBackground = darken($CheckBox.icon[filled].se
 CheckBox.icon[filled].selectedPressedBackground = darken($CheckBox.icon[filled].selectedBackground,6%,derived)
 
 
-#---- ComboBox ----
-
-ComboBox.buttonEditableBackground = darken($ComboBox.background,2%)
-
-
 #---- Component ----
 
-Component.borderColor = #646464
+Component.borderColor = tint(@background,19%)
 Component.disabledBorderColor = $Component.borderColor
 Component.focusedBorderColor = lighten($Component.focusColor,5%)
 Component.focusColor = @accentFocusColor
@@ -184,11 +180,17 @@ Desktop.background = #3E434C
 DesktopIcon.background = lighten($Desktop.background,10%,derived)
 
 
+#---- HelpButton ----
+
+HelpButton.questionMarkColor = shade(@foreground,10%)
+HelpButton.disabledQuestionMarkColor = tint(@background,30%)
+
+
 #---- InternalFrame ----
 
 InternalFrame.activeTitleBackground = darken(@background,10%)
 InternalFrame.activeTitleForeground = @foreground
-InternalFrame.inactiveTitleBackground = darken(@background,5%)
+InternalFrame.inactiveTitleBackground = lighten($InternalFrame.activeTitleBackground,5%)
 InternalFrame.inactiveTitleForeground = @disabledText
 
 InternalFrame.activeBorderColor = darken(@background,7%)
@@ -207,19 +209,19 @@ InternalFrame.inactiveDropShadowOpacity = 0.75
 
 #---- Menu ----
 
-Menu.icon.arrowColor = #A7A7A7
-Menu.icon.disabledArrowColor = #606060
+Menu.icon.arrowColor = @buttonArrowColor
+Menu.icon.disabledArrowColor = @buttonDisabledArrowColor
 
 
 #---- MenuBar ----
 
-MenuBar.borderColor = #515151
+MenuBar.borderColor = $Separator.foreground
 
 
 #---- MenuItemCheckBox ----
 
-MenuItemCheckBox.icon.checkmarkColor = #A7A7A7
-MenuItemCheckBox.icon.disabledCheckmarkColor = #606060
+MenuItemCheckBox.icon.checkmarkColor = @buttonArrowColor
+MenuItemCheckBox.icon.disabledCheckmarkColor = @buttonDisabledArrowColor
 
 
 #---- PasswordField ----
@@ -235,15 +237,15 @@ Popup.dropShadowOpacity = 0.25
 
 #---- PopupMenu ----
 
-PopupMenu.borderColor = #5e5e5e
+PopupMenu.borderColor = tint(@background,17%)
 
 
 #---- ProgressBar ----
 
-ProgressBar.background = #555
+ProgressBar.background = lighten(@background,8%)
 ProgressBar.foreground = @accentSliderColor
 ProgressBar.selectionBackground = @foreground
-ProgressBar.selectionForeground = contrast($ProgressBar.foreground,@background,@foreground,25%)
+ProgressBar.selectionForeground = contrast($ProgressBar.foreground, @background, @foreground, 25%)
 
 
 #---- RootPane ----
@@ -265,34 +267,34 @@ ScrollBar.pressedButtonBackground = lighten(@background,10%,derived noAutoInvers
 
 #---- Separator ----
 
-Separator.foreground = #515151
+Separator.foreground = tint(@background,10%)
 
 
 #---- Slider ----
 
 Slider.trackValueColor = @accentSliderColor
-Slider.trackColor = #646464
+Slider.trackColor = lighten(@background,15%)
 Slider.thumbColor = $Slider.trackValueColor
-Slider.tickColor = #888
+Slider.tickColor = @disabledText
 Slider.focusedColor = fade($Component.focusColor,70%,derived)
 Slider.hoverThumbColor = lighten($Slider.thumbColor,5%,derived)
 Slider.pressedThumbColor = lighten($Slider.thumbColor,8%,derived)
-Slider.disabledTrackColor = #4c5052
+Slider.disabledTrackColor = lighten(@background,10%)
 Slider.disabledThumbColor = $Slider.disabledTrackColor
 
 
 #---- SplitPane ----
 
-SplitPaneDivider.draggingColor = #646464
+SplitPaneDivider.draggingColor = $Component.borderColor
 
 
 #---- TabbedPane ----
 
 TabbedPane.underlineColor = @accentUnderlineColor
-TabbedPane.disabledUnderlineColor = #7a7a7a
+TabbedPane.disabledUnderlineColor = lighten(@background,23%)
 TabbedPane.hoverColor = darken($TabbedPane.background,5%,derived noAutoInverse)
 TabbedPane.focusColor = mix(@selectionBackground,$TabbedPane.background,25%)
-TabbedPane.contentAreaColor = #646464
+TabbedPane.contentAreaColor = $Component.borderColor
 
 TabbedPane.buttonHoverBackground = darken($TabbedPane.background,5%,derived noAutoInverse)
 TabbedPane.buttonPressedBackground = darken($TabbedPane.background,8%,derived noAutoInverse)
@@ -334,7 +336,7 @@ ToggleButton.toolbar.selectedBackground = lighten($ToggleButton.background,7%,de
 #---- ToolTip ----
 
 ToolTip.border = 4,6,4,6
-ToolTip.background = #1e2123
+ToolTip.background = shade(@background,50%)
 
 
 #---- Tree ----

--- a/flatlaf-core/src/main/resources/com/formdev/flatlaf/FlatDarkLaf.properties
+++ b/flatlaf-core/src/main/resources/com/formdev/flatlaf/FlatDarkLaf.properties
@@ -35,11 +35,12 @@
 # general background and foreground (text color)
 @background = #3c3f41
 @foreground = #bbb
-@disabledText = shade(@foreground,25%)
+@disabledBackground = @background
+@disabledForeground = shade(@foreground,25%)
 
 # component background
 @buttonBackground = tint(@background,9%)
-@textComponentBackground = tint(@background,5%)
+@componentBackground = tint(@background,5%)
 @menuBackground = darken(@background,5%)
 
 # selection
@@ -136,7 +137,7 @@ CheckBox.icon.checkmarkColor = shade(@foreground,10%)
 
 # disabled
 CheckBox.icon.disabledBorderColor = shade($CheckBox.icon.borderColor,20%)
-CheckBox.icon.disabledBackground = @background
+CheckBox.icon.disabledBackground = @disabledBackground
 CheckBox.icon.disabledCheckmarkColor = darken($CheckBox.icon.checkmarkColor,25%)
 
 # focused
@@ -200,7 +201,7 @@ HelpButton.disabledQuestionMarkColor = tint(@background,30%)
 InternalFrame.activeTitleBackground = darken(@background,10%)
 InternalFrame.activeTitleForeground = @foreground
 InternalFrame.inactiveTitleBackground = lighten($InternalFrame.activeTitleBackground,5%)
-InternalFrame.inactiveTitleForeground = @disabledText
+InternalFrame.inactiveTitleForeground = @disabledForeground
 
 InternalFrame.activeBorderColor = darken(@background,7%)
 InternalFrame.inactiveBorderColor = darken(@background,3%)
@@ -284,7 +285,7 @@ Separator.foreground = tint(@background,10%)
 Slider.trackValueColor = @accentSliderColor
 Slider.trackColor = lighten(@background,15%)
 Slider.thumbColor = $Slider.trackValueColor
-Slider.tickColor = @disabledText
+Slider.tickColor = @disabledForeground
 Slider.focusedColor = fade($Component.focusColor,70%,derived)
 Slider.hoverThumbColor = lighten($Slider.thumbColor,5%,derived)
 Slider.pressedThumbColor = lighten($Slider.thumbColor,8%,derived)
@@ -309,7 +310,7 @@ TabbedPane.buttonHoverBackground = darken($TabbedPane.background,5%,derived noAu
 TabbedPane.buttonPressedBackground = darken($TabbedPane.background,8%,derived noAutoInverse)
 
 TabbedPane.closeBackground = null
-TabbedPane.closeForeground = @disabledText
+TabbedPane.closeForeground = @disabledForeground
 TabbedPane.closeHoverBackground = lighten($TabbedPane.background,5%,derived)
 TabbedPane.closeHoverForeground = @foreground
 TabbedPane.closePressedBackground = lighten($TabbedPane.background,10%,derived)

--- a/flatlaf-core/src/main/resources/com/formdev/flatlaf/FlatIntelliJLaf.properties
+++ b/flatlaf-core/src/main/resources/com/formdev/flatlaf/FlatIntelliJLaf.properties
@@ -42,7 +42,7 @@
 Button.focusedBackground = null
 
 Button.default.background = @accentButtonDefaultBackground
-Button.default.foreground = contrast($Button.default.background,lighten(@foreground,50%),#fff,50%)
+Button.default.foreground = contrast($Button.default.background, tint($Button.foreground,50%), #fff, 50%)
 Button.default.focusedBackground = null
 Button.default.borderColor = shade($Button.default.background,15%)
 Button.default.hoverBorderColor = tint($Button.default.background,50%)
@@ -54,6 +54,7 @@ Button.default.borderWidth = 1
 #---- CheckBox ----
 
 CheckBox.icon.style = filled
+CheckBox.icon.focusedBackground = null
 
 
 #---- Component ----

--- a/flatlaf-core/src/main/resources/com/formdev/flatlaf/FlatLaf.properties
+++ b/flatlaf-core/src/main/resources/com/formdev/flatlaf/FlatLaf.properties
@@ -75,7 +75,7 @@ ViewportUI = com.formdev.flatlaf.ui.FlatViewportUI
 
 #---- variables ----
 
-@textComponentMargin = 2,6,2,6
+@componentMargin = 2,6,2,6
 @menuItemMargin = 3,6,3,6
 
 
@@ -83,21 +83,21 @@ ViewportUI = com.formdev.flatlaf.ui.FlatViewportUI
 
 *.background = @background
 *.foreground = @foreground
-*.caretForeground = @foreground
-*.inactiveBackground = @background
-*.inactiveForeground = @disabledText
+*.disabledBackground = @disabledBackground
+*.disabledForeground = @disabledForeground
+*.disabledText = @disabledForeground
+*.inactiveBackground = @disabledBackground
+*.inactiveForeground = @disabledForeground
 *.selectionBackground = @selectionBackground
 *.selectionForeground = @selectionForeground
-*.disabledBackground = @background
-*.disabledForeground = @disabledText
-*.disabledText = @disabledText
+*.caretForeground = @foreground
 *.acceleratorForeground = @menuAcceleratorForeground
 *.acceleratorSelectionForeground = @menuAcceleratorSelectionForeground
 
 
 #---- system colors ----
 
-desktop = @textComponentBackground
+desktop = @componentBackground
 activeCaptionText = @foreground
 activeCaptionBorder = $activeCaption
 inactiveCaptionText = @foreground
@@ -107,11 +107,11 @@ windowBorder = @foreground
 windowText = @foreground
 menu = @background
 menuText = @foreground
-text = @textComponentBackground
+text = @componentBackground
 textText = @foreground
 textHighlight = @selectionBackground
 textHighlightText = @selectionForeground
-textInactiveText = @disabledText
+textInactiveText = @disabledForeground
 control = @background
 controlText = @foreground
 controlShadow = $Component.borderColor
@@ -205,14 +205,14 @@ ColorChooser.swatchesDefaultRecentColor = $control
 #---- ComboBox ----
 
 ComboBox.border = com.formdev.flatlaf.ui.FlatRoundBorder
-ComboBox.padding = @textComponentMargin
+ComboBox.padding = @componentMargin
 ComboBox.minimumWidth = 72
 ComboBox.editorColumns = 0
 ComboBox.maximumRowCount = 15
 [mac]ComboBox.showPopupOnNavigation = true
 # allowed values: auto, button or none
 ComboBox.buttonStyle = auto
-ComboBox.background = @textComponentBackground
+ComboBox.background = @componentBackground
 ComboBox.buttonBackground = $ComboBox.background
 ComboBox.buttonEditableBackground = darken($ComboBox.background,2%)
 ComboBox.buttonSeparatorColor = $Component.borderColor
@@ -246,8 +246,8 @@ DesktopIcon.closeIcon = com.formdev.flatlaf.icons.FlatInternalFrameCloseIcon
 #---- EditorPane ----
 
 EditorPane.border = com.formdev.flatlaf.ui.FlatMarginBorder
-EditorPane.margin = @textComponentMargin
-EditorPane.background = @textComponentBackground
+EditorPane.margin = @componentMargin
+EditorPane.background = @componentBackground
 
 
 #---- FileChooser ----
@@ -273,9 +273,9 @@ FileView.floppyDriveIcon = com.formdev.flatlaf.icons.FlatFileViewFloppyDriveIcon
 #---- FormattedTextField ----
 
 FormattedTextField.border = com.formdev.flatlaf.ui.FlatTextBorder
-FormattedTextField.margin = @textComponentMargin
-FormattedTextField.background = @textComponentBackground
-FormattedTextField.placeholderForeground = @disabledText
+FormattedTextField.margin = @componentMargin
+FormattedTextField.background = @componentBackground
+FormattedTextField.placeholderForeground = @disabledForeground
 FormattedTextField.iconTextGap = 4
 
 
@@ -329,7 +329,7 @@ List.cellFocusColor = @cellFocusColor
 List.cellNoFocusBorder = com.formdev.flatlaf.ui.FlatListCellBorder$Default
 List.focusCellHighlightBorder = com.formdev.flatlaf.ui.FlatListCellBorder$Focused
 List.focusSelectedCellHighlightBorder = com.formdev.flatlaf.ui.FlatListCellBorder$Selected
-List.background = @textComponentBackground
+List.background = @componentBackground
 List.selectionInactiveBackground = @selectionInactiveBackground
 List.selectionInactiveForeground = @selectionInactiveForeground
 List.dropCellBackground = @dropCellBackground
@@ -412,9 +412,9 @@ OptionPane.warningIcon = com.formdev.flatlaf.icons.FlatOptionPaneWarningIcon
 #---- PasswordField ----
 
 PasswordField.border = com.formdev.flatlaf.ui.FlatTextBorder
-PasswordField.margin = @textComponentMargin
-PasswordField.background = @textComponentBackground
-PasswordField.placeholderForeground = @disabledText
+PasswordField.margin = @componentMargin
+PasswordField.background = @componentBackground
+PasswordField.placeholderForeground = @disabledForeground
 PasswordField.iconTextGap = 4
 PasswordField.echoChar = \u2022
 PasswordField.showCapsLock = true
@@ -546,7 +546,7 @@ Slider.focusWidth = 4
 #---- Spinner ----
 
 Spinner.border = com.formdev.flatlaf.ui.FlatRoundBorder
-Spinner.background = @textComponentBackground
+Spinner.background = @componentBackground
 Spinner.buttonBackground = darken($Spinner.background,2%)
 Spinner.buttonSeparatorColor = $Component.borderColor
 Spinner.buttonDisabledSeparatorColor = $Component.disabledBorderColor
@@ -554,7 +554,7 @@ Spinner.buttonArrowColor = @buttonArrowColor
 Spinner.buttonDisabledArrowColor = @buttonDisabledArrowColor
 Spinner.buttonHoverArrowColor = @buttonHoverArrowColor
 Spinner.buttonPressedArrowColor = @buttonPressedArrowColor
-Spinner.padding = @textComponentMargin
+Spinner.padding = @componentMargin
 Spinner.editorBorderPainted = false
 # allowed values: button or none
 Spinner.buttonStyle = button
@@ -594,7 +594,7 @@ TabbedPane.tabAreaInsets = 0,0,0,0
 TabbedPane.selectedTabPadInsets = 0,0,0,0
 TabbedPane.tabRunOverlay = 0
 TabbedPane.tabsOverlapBorder = false
-TabbedPane.disabledForeground = @disabledText
+TabbedPane.disabledForeground = @disabledForeground
 TabbedPane.shadow = @background
 TabbedPane.contentBorderInsets = null
 # allowed values: moreTabsButton or arrowButtons
@@ -647,7 +647,7 @@ Table.focusCellHighlightBorder = com.formdev.flatlaf.ui.FlatTableCellBorder$Focu
 Table.focusSelectedCellHighlightBorder = com.formdev.flatlaf.ui.FlatTableCellBorder$Selected
 Table.focusCellBackground = $Table.background
 Table.focusCellForeground = $Table.foreground
-Table.background = @textComponentBackground
+Table.background = @componentBackground
 Table.selectionInactiveBackground = @selectionInactiveBackground
 Table.selectionInactiveForeground = @selectionInactiveForeground
 Table.dropCellBackground = @dropCellBackground
@@ -662,15 +662,15 @@ TableHeader.height = 25
 TableHeader.cellBorder = com.formdev.flatlaf.ui.FlatTableHeaderBorder
 TableHeader.cellMargins = 2,3,2,3
 TableHeader.focusCellBackground = $TableHeader.background
-TableHeader.background = @textComponentBackground
+TableHeader.background = @componentBackground
 TableHeader.showTrailingVerticalLine = false
 
 
 #---- TextArea ----
 
 TextArea.border = com.formdev.flatlaf.ui.FlatMarginBorder
-TextArea.margin = @textComponentMargin
-TextArea.background = @textComponentBackground
+TextArea.margin = @componentMargin
+TextArea.background = @componentBackground
 
 
 #---- TextComponent ----
@@ -684,17 +684,17 @@ TextComponent.arc = 0
 #---- TextField ----
 
 TextField.border = com.formdev.flatlaf.ui.FlatTextBorder
-TextField.margin = @textComponentMargin
-TextField.background = @textComponentBackground
-TextField.placeholderForeground = @disabledText
+TextField.margin = @componentMargin
+TextField.background = @componentBackground
+TextField.placeholderForeground = @disabledForeground
 TextField.iconTextGap = 4
 
 
 #---- TextPane ----
 
 TextPane.border = com.formdev.flatlaf.ui.FlatMarginBorder
-TextPane.margin = @textComponentMargin
-TextPane.background = @textComponentBackground
+TextPane.margin = @componentMargin
+TextPane.background = @componentBackground
 
 
 #---- TitledBorder ----
@@ -724,7 +724,7 @@ TitlePane.restoreIcon = com.formdev.flatlaf.icons.FlatWindowRestoreIcon
 TitlePane.background = $MenuBar.background
 TitlePane.inactiveBackground = $TitlePane.background
 TitlePane.foreground = @foreground
-TitlePane.inactiveForeground = @disabledText
+TitlePane.inactiveForeground = @disabledForeground
 
 TitlePane.closeHoverBackground = #e81123
 TitlePane.closePressedBackground = fade($TitlePane.closeHoverBackground,60%)
@@ -783,7 +783,7 @@ ToolTipManager.enableToolTipMode = activeApplication
 
 Tree.border = 1,1,1,1
 Tree.editorBorder = 1,1,1,1,@cellFocusColor
-Tree.background = @textComponentBackground
+Tree.background = @componentBackground
 Tree.selectionInactiveBackground = @selectionInactiveBackground
 Tree.selectionInactiveForeground = @selectionInactiveForeground
 Tree.textBackground = $Tree.background

--- a/flatlaf-core/src/main/resources/com/formdev/flatlaf/FlatLaf.properties
+++ b/flatlaf-core/src/main/resources/com/formdev/flatlaf/FlatLaf.properties
@@ -205,7 +205,7 @@ ColorChooser.swatchesDefaultRecentColor = $control
 #---- ComboBox ----
 
 ComboBox.border = com.formdev.flatlaf.ui.FlatRoundBorder
-ComboBox.padding = 2,6,2,6
+ComboBox.padding = @textComponentMargin
 ComboBox.minimumWidth = 72
 ComboBox.editorColumns = 0
 ComboBox.maximumRowCount = 15
@@ -213,7 +213,8 @@ ComboBox.maximumRowCount = 15
 # allowed values: auto, button or none
 ComboBox.buttonStyle = auto
 ComboBox.background = @textComponentBackground
-ComboBox.buttonBackground = @textComponentBackground
+ComboBox.buttonBackground = $ComboBox.background
+ComboBox.buttonEditableBackground = darken($ComboBox.background,2%)
 ComboBox.buttonSeparatorColor = $Component.borderColor
 ComboBox.buttonDisabledSeparatorColor = $Component.disabledBorderColor
 ComboBox.buttonArrowColor = @buttonArrowColor
@@ -281,17 +282,15 @@ FormattedTextField.iconTextGap = 4
 #---- HelpButton ----
 
 HelpButton.icon = com.formdev.flatlaf.icons.FlatHelpButtonIcon
-HelpButton.borderColor = $CheckBox.icon.borderColor
-HelpButton.disabledBorderColor = $CheckBox.icon.disabledBorderColor
-HelpButton.focusedBorderColor = $CheckBox.icon.focusedBorderColor
-HelpButton.hoverBorderColor = $?CheckBox.icon.hoverBorderColor
-HelpButton.background = $CheckBox.icon.background
-HelpButton.disabledBackground = $CheckBox.icon.disabledBackground
+HelpButton.borderColor = $Button.borderColor
+HelpButton.disabledBorderColor = $Button.disabledBorderColor
+HelpButton.focusedBorderColor = $Button.focusedBorderColor
+HelpButton.hoverBorderColor = $?Button.hoverBorderColor
+HelpButton.background = $Button.background
+HelpButton.disabledBackground = $Button.disabledBackground
 HelpButton.focusedBackground = $?Button.focusedBackground
-HelpButton.hoverBackground = $?CheckBox.icon.hoverBackground
-HelpButton.pressedBackground = $?CheckBox.icon.pressedBackground
-HelpButton.questionMarkColor = $CheckBox.icon.checkmarkColor
-HelpButton.disabledQuestionMarkColor = $CheckBox.icon.disabledCheckmarkColor
+HelpButton.hoverBackground = $?Button.hoverBackground
+HelpButton.pressedBackground = $?Button.pressedBackground
 
 HelpButton.borderWidth = $?Button.borderWidth
 HelpButton.innerFocusWidth = $?Button.innerFocusWidth
@@ -383,7 +382,7 @@ MenuItem.acceleratorDelimiter = -
 # for MenuItem.selectionType = underline
 MenuItem.underlineSelectionBackground = @menuHoverBackground
 MenuItem.underlineSelectionCheckBackground = @menuCheckBackground
-MenuItem.underlineSelectionColor = $TabbedPane.underlineColor
+MenuItem.underlineSelectionColor = @accentUnderlineColor
 MenuItem.underlineSelectionHeight = 3
 
 
@@ -548,7 +547,7 @@ Slider.focusWidth = 4
 
 Spinner.border = com.formdev.flatlaf.ui.FlatRoundBorder
 Spinner.background = @textComponentBackground
-Spinner.buttonBackground = $ComboBox.buttonEditableBackground
+Spinner.buttonBackground = darken($Spinner.background,2%)
 Spinner.buttonSeparatorColor = $Component.borderColor
 Spinner.buttonDisabledSeparatorColor = $Component.disabledBorderColor
 Spinner.buttonArrowColor = @buttonArrowColor
@@ -646,8 +645,8 @@ Table.cellFocusColor = @cellFocusColor
 Table.cellNoFocusBorder = com.formdev.flatlaf.ui.FlatTableCellBorder$Default
 Table.focusCellHighlightBorder = com.formdev.flatlaf.ui.FlatTableCellBorder$Focused
 Table.focusSelectedCellHighlightBorder = com.formdev.flatlaf.ui.FlatTableCellBorder$Selected
-Table.focusCellBackground = @textComponentBackground
-Table.focusCellForeground = @foreground
+Table.focusCellBackground = $Table.background
+Table.focusCellForeground = $Table.foreground
 Table.background = @textComponentBackground
 Table.selectionInactiveBackground = @selectionInactiveBackground
 Table.selectionInactiveForeground = @selectionInactiveForeground
@@ -665,6 +664,7 @@ TableHeader.cellMargins = 2,3,2,3
 TableHeader.focusCellBackground = $TableHeader.background
 TableHeader.background = @textComponentBackground
 TableHeader.showTrailingVerticalLine = false
+
 
 #---- TextArea ----
 
@@ -741,7 +741,7 @@ ToggleButton.rollover = true
 
 ToggleButton.background = $Button.background
 ToggleButton.pressedBackground = $Button.pressedBackground
-ToggleButton.selectedForeground = @foreground
+ToggleButton.selectedForeground = $ToggleButton.foreground
 
 ToggleButton.toolbar.hoverBackground = $Button.toolbar.hoverBackground
 ToggleButton.toolbar.pressedBackground = $Button.toolbar.pressedBackground
@@ -761,10 +761,10 @@ ToolBar.border = com.formdev.flatlaf.ui.FlatToolBarBorder
 ToolBar.borderMargins = 2,2,2,2
 ToolBar.isRollover = true
 ToolBar.gripColor = @icon
-ToolBar.dockingBackground = @background
-ToolBar.dockingForeground = @foreground
-ToolBar.floatingBackground = @background
-ToolBar.floatingForeground = @disabledText
+ToolBar.dockingBackground = darken($ToolBar.background,5%)
+ToolBar.dockingForeground = $Component.borderColor
+ToolBar.floatingBackground = $ToolBar.background
+ToolBar.floatingForeground = $Component.borderColor
 
 ToolBar.separatorSize = null
 ToolBar.separatorWidth = 7

--- a/flatlaf-core/src/main/resources/com/formdev/flatlaf/FlatLightLaf.properties
+++ b/flatlaf-core/src/main/resources/com/formdev/flatlaf/FlatLightLaf.properties
@@ -35,11 +35,12 @@
 # general background and foreground (text color)
 @background = #f2f2f2
 @foreground = #000
-@disabledText = tint(@foreground,55%)
+@disabledBackground = @background
+@disabledForeground = tint(@foreground,55%)
 
 # component background
 @buttonBackground = lighten(@background,5%)
-@textComponentBackground = lighten(@background,5%)
+@componentBackground = lighten(@background,5%)
 @menuBackground = lighten(@background,5%)
 
 # selection
@@ -139,7 +140,7 @@ CheckBox.icon.checkmarkColor = @accentCheckmarkColor
 
 # disabled
 CheckBox.icon.disabledBorderColor = tint($CheckBox.icon.borderColor,20%)
-CheckBox.icon.disabledBackground = @background
+CheckBox.icon.disabledBackground = @disabledBackground
 CheckBox.icon.disabledCheckmarkColor = shade(@background,30%)
 
 # focused
@@ -207,7 +208,7 @@ HelpButton.disabledQuestionMarkColor = shade(@background,30%)
 InternalFrame.activeTitleBackground = #fff
 InternalFrame.activeTitleForeground = @foreground
 InternalFrame.inactiveTitleBackground = darken($InternalFrame.activeTitleBackground,2%)
-InternalFrame.inactiveTitleForeground = @disabledText
+InternalFrame.inactiveTitleForeground = @disabledForeground
 
 InternalFrame.activeBorderColor = shade(@background,40%)
 InternalFrame.inactiveBorderColor = shade(@background,20%)
@@ -261,7 +262,7 @@ PopupMenu.borderColor = shade(@background,28%)
 ProgressBar.background = darken(@background,13%)
 ProgressBar.foreground = @accentSliderColor
 ProgressBar.selectionBackground = @foreground
-ProgressBar.selectionForeground = contrast($ProgressBar.foreground, @foreground, @textComponentBackground)
+ProgressBar.selectionForeground = contrast($ProgressBar.foreground, @foreground, @componentBackground)
 
 
 #---- RootPane ----
@@ -291,7 +292,7 @@ Separator.foreground = shade(@background,15%)
 Slider.trackValueColor = @accentSliderColor
 Slider.trackColor = darken(@background,18%)
 Slider.thumbColor = $Slider.trackValueColor
-Slider.tickColor = @disabledText
+Slider.tickColor = @disabledForeground
 Slider.focusedColor = fade($Component.focusColor,50%,derived)
 Slider.hoverThumbColor = darken($Slider.thumbColor,5%,derived)
 Slider.pressedThumbColor = darken($Slider.thumbColor,8%,derived)
@@ -316,7 +317,7 @@ TabbedPane.buttonHoverBackground = darken($TabbedPane.background,7%,derived)
 TabbedPane.buttonPressedBackground = darken($TabbedPane.background,10%,derived)
 
 TabbedPane.closeBackground = null
-TabbedPane.closeForeground = @disabledText
+TabbedPane.closeForeground = @disabledForeground
 TabbedPane.closeHoverBackground = darken($TabbedPane.background,20%,derived)
 TabbedPane.closeHoverForeground = @foreground
 TabbedPane.closePressedBackground = darken($TabbedPane.background,25%,derived)

--- a/flatlaf-core/src/main/resources/com/formdev/flatlaf/FlatLightLaf.properties
+++ b/flatlaf-core/src/main/resources/com/formdev/flatlaf/FlatLightLaf.properties
@@ -170,6 +170,12 @@ CheckBox.icon[filled].selectedHoverBackground = darken($CheckBox.icon[filled].se
 CheckBox.icon[filled].selectedPressedBackground = darken($CheckBox.icon[filled].selectedBackground,10%,derived)
 
 
+#---- CheckBoxMenuItem ----
+
+CheckBoxMenuItem.icon.checkmarkColor = @accentCheckmarkColor
+CheckBoxMenuItem.icon.disabledCheckmarkColor = @buttonDisabledArrowColor
+
+
 #---- Component ----
 
 Component.borderColor = shade(@background,20%)
@@ -233,12 +239,6 @@ Menu.icon.disabledArrowColor = @buttonDisabledArrowColor
 #---- MenuBar ----
 
 MenuBar.borderColor = $Separator.foreground
-
-
-#---- MenuItemCheckBox ----
-
-MenuItemCheckBox.icon.checkmarkColor = @accentCheckmarkColor
-MenuItemCheckBox.icon.disabledCheckmarkColor = @buttonDisabledArrowColor
 
 
 #---- PasswordField ----

--- a/flatlaf-core/src/main/resources/com/formdev/flatlaf/FlatLightLaf.properties
+++ b/flatlaf-core/src/main/resources/com/formdev/flatlaf/FlatLightLaf.properties
@@ -32,20 +32,29 @@
 
 #---- variables ----
 
+# general background and foreground (text color)
 @background = #f2f2f2
 @foreground = #000
+@disabledText = tint(@foreground,55%)
+
+# component background
+@buttonBackground = lighten(@background,5%)
+@textComponentBackground = lighten(@background,5%)
+@menuBackground = lighten(@background,5%)
+
+# selection
 @selectionBackground = @accentSelectionBackground
 @selectionForeground = contrast(@selectionBackground, @foreground, #fff)
 @selectionInactiveBackground = shade(@background,13%)
 @selectionInactiveForeground = @foreground
-@disabledText = tint(@foreground,55%)
-@buttonBackground = lighten(@background,5%)
-@textComponentBackground = lighten(@background,5%)
-@menuBackground = lighten(@background,5%)
+
+# menu
 @menuHoverBackground = darken(@menuBackground,10%,derived)
 @menuCheckBackground = lighten(@selectionBackground,40%,derived noAutoInverse)
 @menuAcceleratorForeground = lighten(@foreground,30%)
 @menuAcceleratorSelectionForeground = @selectionForeground
+
+# misc
 @cellFocusColor = #000
 @icon = shade(@background,27%)
 

--- a/flatlaf-core/src/main/resources/com/formdev/flatlaf/FlatLightLaf.properties
+++ b/flatlaf-core/src/main/resources/com/formdev/flatlaf/FlatLightLaf.properties
@@ -35,18 +35,19 @@
 @background = #f2f2f2
 @foreground = #000
 @selectionBackground = @accentSelectionBackground
-@selectionForeground = contrast(@selectionBackground,@foreground,#fff)
-@selectionInactiveBackground = #d4d4d4
+@selectionForeground = contrast(@selectionBackground, @foreground, #fff)
+@selectionInactiveBackground = shade(@background,13%)
 @selectionInactiveForeground = @foreground
-@disabledText = #8C8C8C
-@textComponentBackground = #fff
-@menuBackground = #fff
+@disabledText = tint(@foreground,55%)
+@buttonBackground = lighten(@background,5%)
+@textComponentBackground = lighten(@background,5%)
+@menuBackground = lighten(@background,5%)
 @menuHoverBackground = darken(@menuBackground,10%,derived)
 @menuCheckBackground = lighten(@selectionBackground,40%,derived noAutoInverse)
 @menuAcceleratorForeground = lighten(@foreground,30%)
 @menuAcceleratorSelectionForeground = @selectionForeground
 @cellFocusColor = #000
-@icon = #afafaf
+@icon = shade(@background,27%)
 
 # accent colors (blueish)
 #   set @accentColor to use single accent color or
@@ -64,7 +65,7 @@
 @accentButtonDefaultBorderColor = if(@accentColor, @accentColor, tint(@accentBase2Color,20%))
 
 # for buttons within components (e.g. combobox or spinner)
-@buttonArrowColor = #666
+@buttonArrowColor = tint(@foreground,40%)
 @buttonDisabledArrowColor = lighten(@buttonArrowColor,25%)
 @buttonHoverArrowColor = lighten(@buttonArrowColor,20%,derived noAutoInverse)
 @buttonPressedArrowColor = lighten(@buttonArrowColor,30%,derived noAutoInverse)
@@ -87,12 +88,12 @@ controlDkShadow = darken($controlShadow,15%)
 
 #---- Button ----
 
-Button.background = #fff
-Button.focusedBackground = changeLightness(@selectionBackground,95%)
+Button.background = @buttonBackground
+Button.focusedBackground = changeLightness($Component.focusColor,95%)
 Button.hoverBackground = darken($Button.background,3%,derived)
 Button.pressedBackground = darken($Button.background,10%,derived)
 Button.selectedBackground = darken($Button.background,20%,derived)
-Button.selectedForeground = @foreground
+Button.selectedForeground = $Button.foreground
 Button.disabledSelectedBackground = darken($Button.background,13%,derived)
 
 Button.borderColor = $Component.borderColor
@@ -103,7 +104,7 @@ Button.hoverBorderColor = $Button.focusedBorderColor
 Button.innerFocusWidth = 0
 
 Button.default.background = $Button.background
-Button.default.foreground = @foreground
+Button.default.foreground = $Button.foreground
 Button.default.focusedBackground = $Button.focusedBackground
 Button.default.hoverBackground = darken($Button.default.background,3%,derived)
 Button.default.pressedBackground = darken($Button.default.background,10%,derived)
@@ -121,34 +122,34 @@ Button.toolbar.selectedBackground = $Button.selectedBackground
 #---- CheckBox ----
 
 # enabled
-CheckBox.icon.borderColor = #b0b0b0
-CheckBox.icon.background = #fff
+CheckBox.icon.borderColor = shade($Component.borderColor,10%)
+CheckBox.icon.background = @buttonBackground
 CheckBox.icon.selectedBorderColor = $CheckBox.icon.borderColor
 CheckBox.icon.selectedBackground = $CheckBox.icon.background
 CheckBox.icon.checkmarkColor = @accentCheckmarkColor
 
 # disabled
-CheckBox.icon.disabledBorderColor = #BDBDBD
+CheckBox.icon.disabledBorderColor = tint($CheckBox.icon.borderColor,20%)
 CheckBox.icon.disabledBackground = @background
-CheckBox.icon.disabledCheckmarkColor = #ABABAB
+CheckBox.icon.disabledCheckmarkColor = shade(@background,30%)
 
 # focused
 CheckBox.icon.focusedBorderColor = shade($Component.focusedBorderColor,10%)
-CheckBox.icon.focusedBackground = $Button.focusedBackground
+CheckBox.icon.focusedBackground = changeLightness($Component.focusColor,95%)
 
 # hover
 CheckBox.icon.hoverBorderColor = $CheckBox.icon.focusedBorderColor
-CheckBox.icon.hoverBackground = $Button.hoverBackground
+CheckBox.icon.hoverBackground = darken($CheckBox.icon.background,3%,derived)
 
 # pressed
-CheckBox.icon.pressedBackground = $Button.pressedBackground
+CheckBox.icon.pressedBackground = darken($CheckBox.icon.background,10%,derived)
 
 
 # used if CheckBox.icon.style = filled
 # enabled
 CheckBox.icon[filled].selectedBorderColor = shade($CheckBox.icon[filled].selectedBackground,5%)
 CheckBox.icon[filled].selectedBackground = @accentCheckmarkColor
-CheckBox.icon[filled].checkmarkColor = #fff
+CheckBox.icon[filled].checkmarkColor = @buttonBackground
 # focused
 CheckBox.icon[filled].selectedFocusedBorderColor = tint($CheckBox.icon[filled].selectedBackground,50%)
 CheckBox.icon[filled].selectedFocusedBackground = $CheckBox.icon[filled].selectedBackground
@@ -159,15 +160,10 @@ CheckBox.icon[filled].selectedHoverBackground = darken($CheckBox.icon[filled].se
 CheckBox.icon[filled].selectedPressedBackground = darken($CheckBox.icon[filled].selectedBackground,10%,derived)
 
 
-#---- ComboBox ----
-
-ComboBox.buttonEditableBackground = darken($ComboBox.background,2%)
-
-
 #---- Component ----
 
-Component.borderColor = #c4c4c4
-Component.disabledBorderColor = lighten($Component.borderColor,4%)
+Component.borderColor = shade(@background,20%)
+Component.disabledBorderColor = tint($Component.borderColor,20%)
 Component.focusedBorderColor = shade($Component.focusColor,10%)
 Component.focusColor = @accentFocusColor
 Component.linkColor = @accentLinkColor
@@ -194,17 +190,18 @@ DesktopIcon.background = darken($Desktop.background,10%,derived)
 #---- HelpButton ----
 
 HelpButton.questionMarkColor = @accentCheckmarkColor
+HelpButton.disabledQuestionMarkColor = shade(@background,30%)
 
 
 #---- InternalFrame ----
 
 InternalFrame.activeTitleBackground = #fff
 InternalFrame.activeTitleForeground = @foreground
-InternalFrame.inactiveTitleBackground = #fafafa
+InternalFrame.inactiveTitleBackground = darken($InternalFrame.activeTitleBackground,2%)
 InternalFrame.inactiveTitleForeground = @disabledText
 
-InternalFrame.activeBorderColor = darken($Component.borderColor,20%)
-InternalFrame.inactiveBorderColor = $Component.borderColor
+InternalFrame.activeBorderColor = shade(@background,40%)
+InternalFrame.inactiveBorderColor = shade(@background,20%)
 
 InternalFrame.buttonHoverBackground = darken($InternalFrame.activeTitleBackground,10%,derived)
 InternalFrame.buttonPressedBackground = darken($InternalFrame.activeTitleBackground,20%,derived)
@@ -219,19 +216,19 @@ InternalFrame.inactiveDropShadowOpacity = 0.5
 
 #---- Menu ----
 
-Menu.icon.arrowColor = #666
-Menu.icon.disabledArrowColor = #ABABAB
+Menu.icon.arrowColor = @buttonArrowColor
+Menu.icon.disabledArrowColor = @buttonDisabledArrowColor
 
 
 #---- MenuBar ----
 
-MenuBar.borderColor = #cdcdcd
+MenuBar.borderColor = $Separator.foreground
 
 
 #---- MenuItemCheckBox ----
 
 MenuItemCheckBox.icon.checkmarkColor = @accentCheckmarkColor
-MenuItemCheckBox.icon.disabledCheckmarkColor = #ABABAB
+MenuItemCheckBox.icon.disabledCheckmarkColor = @buttonDisabledArrowColor
 
 
 #---- PasswordField ----
@@ -247,15 +244,15 @@ Popup.dropShadowOpacity = 0.15
 
 #---- PopupMenu ----
 
-PopupMenu.borderColor = #adadad
+PopupMenu.borderColor = shade(@background,28%)
 
 
 #---- ProgressBar ----
 
-ProgressBar.background = #D1D1D1
+ProgressBar.background = darken(@background,13%)
 ProgressBar.foreground = @accentSliderColor
 ProgressBar.selectionBackground = @foreground
-ProgressBar.selectionForeground = contrast($ProgressBar.foreground,@foreground,@textComponentBackground)
+ProgressBar.selectionForeground = contrast($ProgressBar.foreground, @foreground, @textComponentBackground)
 
 
 #---- RootPane ----
@@ -277,34 +274,34 @@ ScrollBar.pressedButtonBackground = darken(@background,10%,derived noAutoInverse
 
 #---- Separator ----
 
-Separator.foreground = #d1d1d1
+Separator.foreground = shade(@background,15%)
 
 
 #---- Slider ----
 
 Slider.trackValueColor = @accentSliderColor
-Slider.trackColor = #c4c4c4
+Slider.trackColor = darken(@background,18%)
 Slider.thumbColor = $Slider.trackValueColor
-Slider.tickColor = #888
+Slider.tickColor = @disabledText
 Slider.focusedColor = fade($Component.focusColor,50%,derived)
 Slider.hoverThumbColor = darken($Slider.thumbColor,5%,derived)
 Slider.pressedThumbColor = darken($Slider.thumbColor,8%,derived)
-Slider.disabledTrackColor = #c0c0c0
+Slider.disabledTrackColor = darken(@background,13%)
 Slider.disabledThumbColor = $Slider.disabledTrackColor
 
 
 #---- SplitPane ----
 
-SplitPaneDivider.draggingColor = #c4c4c4
+SplitPaneDivider.draggingColor = $Component.borderColor
 
 
 #---- TabbedPane ----
 
 TabbedPane.underlineColor = @accentUnderlineColor
-TabbedPane.disabledUnderlineColor = #ababab
+TabbedPane.disabledUnderlineColor = darken(@background,28%)
 TabbedPane.hoverColor = darken($TabbedPane.background,7%,derived)
 TabbedPane.focusColor = mix(@selectionBackground,$TabbedPane.background,10%)
-TabbedPane.contentAreaColor = #bfbfbf
+TabbedPane.contentAreaColor = $Component.borderColor
 
 TabbedPane.buttonHoverBackground = darken($TabbedPane.background,7%,derived)
 TabbedPane.buttonPressedBackground = darken($TabbedPane.background,10%,derived)
@@ -345,8 +342,8 @@ ToggleButton.toolbar.selectedBackground = $ToggleButton.selectedBackground
 
 #---- ToolTip ----
 
-ToolTip.border = 4,6,4,6,$InternalFrame.activeBorderColor
-ToolTip.background = #fafafa
+ToolTip.border = 4,6,4,6,shade(@background,40%)
+ToolTip.background = lighten(@background,3%)
 
 
 #---- Tree ----

--- a/flatlaf-core/src/main/resources/com/formdev/flatlaf/IntelliJTheme$ThemeLaf.properties
+++ b/flatlaf-core/src/main/resources/com/formdev/flatlaf/IntelliJTheme$ThemeLaf.properties
@@ -60,16 +60,16 @@ Button.hoverBorderColor = null
 Button.default.hoverBorderColor = null
 
 
+#---- CheckBoxMenuItem ----
+
+# colors from intellij/checkmark.svg and darcula/checkmark.svg
+[light]CheckBoxMenuItem.icon.checkmarkColor=#3E3E3C
+[dark]CheckBoxMenuItem.icon.checkmarkColor=#fff9
+
+
 #---- HelpButton ----
 
 HelpButton.hoverBorderColor = null
-
-
-#---- MenuItemCheckBox ----
-
-# colors from intellij/checkmark.svg and darcula/checkmark.svg
-[light]MenuItemCheckBox.icon.checkmarkColor=#3E3E3C
-[dark]MenuItemCheckBox.icon.checkmarkColor=#fff9
 
 
 #---- Slider ----

--- a/flatlaf-swingx/src/main/resources/com/formdev/flatlaf/swingx/FlatDarkLaf.properties
+++ b/flatlaf-swingx/src/main/resources/com/formdev/flatlaf/swingx/FlatDarkLaf.properties
@@ -28,19 +28,19 @@ JXHeader.startBackground = #4c5052
 
 #---- HighlighterFactory ----
 
-UIColorHighlighter.stripingBackground = lighten(@textComponentBackground,5%)
+UIColorHighlighter.stripingBackground = lighten(@componentBackground,5%)
 
 
 #---- Hyperlink ----
 
 Hyperlink.linkColor = $Component.linkColor
 Hyperlink.visitedColor = $Hyperlink.linkColor
-Hyperlink.disabledText = @disabledText
+Hyperlink.disabledText = @disabledForeground
 
 
 #---- MonthView ----
 
-JXMonthView.background = @textComponentBackground
+JXMonthView.background = @componentBackground
 JXMonthView.monthStringBackground = #4c5052
 JXMonthView.monthStringForeground = @foreground
 JXMonthView.daysOfTheWeekForeground = #aaa
@@ -48,10 +48,10 @@ JXMonthView.weekOfTheYearForeground = #888
 JXMonthView.unselectableDayForeground = #E05555
 JXMonthView.selectedBackground = @selectionBackground
 JXMonthView.flaggedDayForeground = #E05555
-JXMonthView.leadingDayForeground = @disabledText
-JXMonthView.trailingDayForeground = @disabledText
+JXMonthView.leadingDayForeground = @disabledForeground
+JXMonthView.trailingDayForeground = @disabledForeground
 JXMonthView.arrowColor = @foreground
-JXMonthView.disabledArrowColor = @disabledText
+JXMonthView.disabledArrowColor = @disabledForeground
 
 
 #---- TaskPaneContainer ----

--- a/flatlaf-swingx/src/main/resources/com/formdev/flatlaf/swingx/FlatLightLaf.properties
+++ b/flatlaf-swingx/src/main/resources/com/formdev/flatlaf/swingx/FlatLightLaf.properties
@@ -28,19 +28,19 @@ JXHeader.startBackground = #fff
 
 #---- HighlighterFactory ----
 
-UIColorHighlighter.stripingBackground = darken(@textComponentBackground,5%)
+UIColorHighlighter.stripingBackground = darken(@componentBackground,5%)
 
 
 #---- Hyperlink ----
 
 Hyperlink.linkColor = $Component.linkColor
 Hyperlink.visitedColor = $Hyperlink.linkColor
-Hyperlink.disabledText = @disabledText
+Hyperlink.disabledText = @disabledForeground
 
 
 #---- MonthView ----
 
-JXMonthView.background = @textComponentBackground
+JXMonthView.background = @componentBackground
 JXMonthView.monthStringBackground = #dfdfdf
 JXMonthView.monthStringForeground = @foreground
 JXMonthView.daysOfTheWeekForeground = #444
@@ -48,10 +48,10 @@ JXMonthView.weekOfTheYearForeground = #666
 JXMonthView.unselectableDayForeground = #E02222
 JXMonthView.selectedBackground = changeLightness(@selectionBackground,85%)
 JXMonthView.flaggedDayForeground = #E02222
-JXMonthView.leadingDayForeground = @disabledText
-JXMonthView.trailingDayForeground = @disabledText
+JXMonthView.leadingDayForeground = @disabledForeground
+JXMonthView.trailingDayForeground = @disabledForeground
 JXMonthView.arrowColor = @foreground
-JXMonthView.disabledArrowColor = @disabledText
+JXMonthView.disabledArrowColor = @disabledForeground
 
 
 #---- TaskPaneContainer ----

--- a/flatlaf-testing/dumps/uidefaults/FlatDarculaLaf_1.8.0_202.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatDarculaLaf_1.8.0_202.txt
@@ -72,7 +72,7 @@
 #---- ProgressBar ----
 
 - ProgressBar.foreground         #4c87c8  HSL 211  53  54    javax.swing.plaf.ColorUIResource [UI]
-+ ProgressBar.foreground         #a0a0a0  HSL   0   0  63    javax.swing.plaf.ColorUIResource [UI]
++ ProgressBar.foreground         #a2a2a2  HSL   0   0  64    javax.swing.plaf.ColorUIResource [UI]
 
 - ProgressBar.selectionForeground #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
 + ProgressBar.selectionForeground #3c3f41  HSL 204   4  25    javax.swing.plaf.ColorUIResource [UI]

--- a/flatlaf-testing/dumps/uidefaults/FlatDarkLaf_1.8.0_202.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatDarkLaf_1.8.0_202.txt
@@ -62,11 +62,11 @@ BusyLabelUI                    com.formdev.flatlaf.swingx.ui.FlatBusyLabelUI
 #---- Button ----
 
 Button.arc                     6
-Button.background              #4c5052  HSL 200   4  31    javax.swing.plaf.ColorUIResource [UI]
+Button.background              #4e5052  HSL 210   2  31    javax.swing.plaf.ColorUIResource [UI]
 Button.border                  [lazy] 1,1,1,1  false    com.formdev.flatlaf.ui.FlatButtonBorder [UI]
-Button.borderColor             #5e6263  HSL 192   3  38    javax.swing.plaf.ColorUIResource [UI]
+Button.borderColor             #606263  HSL 200   2  38    javax.swing.plaf.ColorUIResource [UI]
 Button.borderWidth             1
-Button.darkShadow              #7e7e7e  HSL   0   0  49    javax.swing.plaf.ColorUIResource [UI]
+Button.darkShadow              #7a7d7f  HSL 204   2  49    javax.swing.plaf.ColorUIResource [UI]
 Button.default.background      #375a81  HSL 212  40  36    javax.swing.plaf.ColorUIResource [UI]
 Button.default.boldText        true
 Button.default.borderColor     #557394  HSL 211  27  46    javax.swing.plaf.ColorUIResource [UI]
@@ -79,32 +79,32 @@ Button.default.hoverBorderColor #5b7898  HSL 211  25  48    javax.swing.plaf.Col
 Button.default.pressedBackground #406996  HSL 211  40  42    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(6% autoInverse)
 Button.defaultButtonFollowsFocus false
 Button.disabledBackground      #3c3f41  HSL 204   4  25    javax.swing.plaf.ColorUIResource [UI]
-Button.disabledBorderColor     #5e6263  HSL 192   3  38    javax.swing.plaf.ColorUIResource [UI]
-Button.disabledForeground      #888888  HSL   0   0  53    javax.swing.plaf.ColorUIResource [UI]
-Button.disabledSelectedBackground #53585a  HSL 197   4  34    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(3% autoInverse)
-Button.disabledText            #888888  HSL   0   0  53    javax.swing.plaf.ColorUIResource [UI]
+Button.disabledBorderColor     #606263  HSL 200   2  38    javax.swing.plaf.ColorUIResource [UI]
+Button.disabledForeground      #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
+Button.disabledSelectedBackground #55585a  HSL 204   3  34    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(3% autoInverse)
+Button.disabledText            #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
 Button.focusedBorderColor      #446e9e  HSL 212  40  44    javax.swing.plaf.ColorUIResource [UI]
 Button.font                    [active] $defaultFont [UI]
 Button.foreground              #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
-Button.highlight               #242424  HSL   0   0  14    javax.swing.plaf.ColorUIResource [UI]
-Button.hoverBackground         #53585a  HSL 197   4  34    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(3% autoInverse)
+Button.highlight               #232324  HSL 240   1  14    javax.swing.plaf.ColorUIResource [UI]
+Button.hoverBackground         #55585a  HSL 204   3  34    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(3% autoInverse)
 Button.hoverBorderColor        #446e9e  HSL 212  40  44    javax.swing.plaf.ColorUIResource [UI]
 Button.iconTextGap             4
 Button.innerFocusWidth         1
-Button.light                   #313131  HSL   0   0  19    javax.swing.plaf.ColorUIResource [UI]
+Button.light                   #2f3031  HSL 210   2  19    javax.swing.plaf.ColorUIResource [UI]
 Button.margin                  2,14,2,14    javax.swing.plaf.InsetsUIResource [UI]
 Button.minimumWidth            72
-Button.pressedBackground       #5b5f62  HSL 206   4  37    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(6% autoInverse)
+Button.pressedBackground       #5d5f62  HSL 216   3  37    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(6% autoInverse)
 Button.rollover                true
-Button.selectedBackground      #656a6c  HSL 197   3  41    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(10% autoInverse)
+Button.selectedBackground      #676a6c  HSL 204   2  41    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(10% autoInverse)
 Button.selectedForeground      #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
-Button.shadow                  #646464  HSL   0   0  39    javax.swing.plaf.ColorUIResource [UI]
+Button.shadow                  #616365  HSL 210   2  39    javax.swing.plaf.ColorUIResource [UI]
 Button.textIconGap             4
 Button.textShiftOffset         0
-Button.toolbar.hoverBackground #4e5355  HSL 197   4  32    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(1% autoInverse)
+Button.toolbar.hoverBackground #505355  HSL 204   3  32    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(1% autoInverse)
 Button.toolbar.margin          3,3,3,3    javax.swing.plaf.InsetsUIResource [UI]
-Button.toolbar.pressedBackground #565a5d  HSL 206   4  35    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(4% autoInverse)
-Button.toolbar.selectedBackground #5d6265  HSL 203   4  38    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(7% autoInverse)
+Button.toolbar.pressedBackground #585a5c  HSL 210   2  35    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(4% autoInverse)
+Button.toolbar.selectedBackground #5f6264  HSL 204   3  38    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(7% autoInverse)
 Button.toolbar.spacingInsets   1,2,1,2    javax.swing.plaf.InsetsUIResource [UI]
 ButtonUI                       com.formdev.flatlaf.ui.FlatButtonUI
 
@@ -119,29 +119,29 @@ Caret.width                    [active] 1
 CheckBox.arc                   4
 CheckBox.background            #3c3f41  HSL 204   4  25    javax.swing.plaf.ColorUIResource [UI]
 CheckBox.border                [lazy] 0,0,0,0  false    com.formdev.flatlaf.ui.FlatMarginBorder [UI]
-CheckBox.disabledText          #888888  HSL   0   0  53    javax.swing.plaf.ColorUIResource [UI]
+CheckBox.disabledText          #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
 CheckBox.font                  [active] $defaultFont [UI]
 CheckBox.foreground            #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
-CheckBox.icon.background       #43494a  HSL 189   5  28    javax.swing.plaf.ColorUIResource [UI]
-CheckBox.icon.borderColor      #6b6b6b  HSL   0   0  42    javax.swing.plaf.ColorUIResource [UI]
-CheckBox.icon.checkmarkColor   #a7a7a7  HSL   0   0  65    javax.swing.plaf.ColorUIResource [UI]
+CheckBox.icon.background       #46494b  HSL 204   3  28    javax.swing.plaf.ColorUIResource [UI]
+CheckBox.icon.borderColor      #696b6d  HSL 210   2  42    javax.swing.plaf.ColorUIResource [UI]
+CheckBox.icon.checkmarkColor   #a8a8a8  HSL   0   0  66    javax.swing.plaf.ColorUIResource [UI]
 CheckBox.icon.disabledBackground #3c3f41  HSL 204   4  25    javax.swing.plaf.ColorUIResource [UI]
-CheckBox.icon.disabledBorderColor #545556  HSL 210   1  33    javax.swing.plaf.ColorUIResource [UI]
-CheckBox.icon.disabledCheckmarkColor #606060  HSL   0   0  38    javax.swing.plaf.ColorUIResource [UI]
+CheckBox.icon.disabledBorderColor #545657  HSL 200   2  34    javax.swing.plaf.ColorUIResource [UI]
+CheckBox.icon.disabledCheckmarkColor #686868  HSL   0   0  41    javax.swing.plaf.ColorUIResource [UI]
 CheckBox.icon.focusedBackground #446e9e4d  30%  HSLA 212  40  44 30    javax.swing.plaf.ColorUIResource [UI]
 CheckBox.icon.focusedBorderColor #446e9e  HSL 212  40  44    javax.swing.plaf.ColorUIResource [UI]
-CheckBox.icon.hoverBackground  #4a5152  HSL 188   5  31    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(3% autoInverse)
+CheckBox.icon.hoverBackground  #4d5153  HSL 200   4  31    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(3% autoInverse)
 CheckBox.icon.hoverBorderColor #446e9e  HSL 212  40  44    javax.swing.plaf.ColorUIResource [UI]
-CheckBox.icon.pressedBackground #52595a  HSL 188   5  34    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(6% autoInverse)
-CheckBox.icon.selectedBackground #43494a  HSL 189   5  28    javax.swing.plaf.ColorUIResource [UI]
-CheckBox.icon.selectedBorderColor #6b6b6b  HSL   0   0  42    javax.swing.plaf.ColorUIResource [UI]
+CheckBox.icon.pressedBackground #55585b  HSL 210   3  35    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(6% autoInverse)
+CheckBox.icon.selectedBackground #46494b  HSL 204   3  28    javax.swing.plaf.ColorUIResource [UI]
+CheckBox.icon.selectedBorderColor #696b6d  HSL 210   2  42    javax.swing.plaf.ColorUIResource [UI]
 CheckBox.icon                  [lazy] 15,15    com.formdev.flatlaf.icons.FlatCheckBoxIcon [UI]
 CheckBox.iconTextGap           4
-CheckBox.icon[filled].checkmarkColor #43494a  HSL 189   5  28    javax.swing.plaf.ColorUIResource [UI]
-CheckBox.icon[filled].selectedBackground #a7a7a7  HSL   0   0  65    javax.swing.plaf.ColorUIResource [UI]
-CheckBox.icon[filled].selectedBorderColor #a7a7a7  HSL   0   0  65    javax.swing.plaf.ColorUIResource [UI]
-CheckBox.icon[filled].selectedHoverBackground #9f9f9f  HSL   0   0  62    com.formdev.flatlaf.util.DerivedColor [UI]    darken(3% autoInverse)
-CheckBox.icon[filled].selectedPressedBackground #989898  HSL   0   0  60    com.formdev.flatlaf.util.DerivedColor [UI]    darken(6% autoInverse)
+CheckBox.icon[filled].checkmarkColor #46494b  HSL 204   3  28    javax.swing.plaf.ColorUIResource [UI]
+CheckBox.icon[filled].selectedBackground #a8a8a8  HSL   0   0  66    javax.swing.plaf.ColorUIResource [UI]
+CheckBox.icon[filled].selectedBorderColor #a8a8a8  HSL   0   0  66    javax.swing.plaf.ColorUIResource [UI]
+CheckBox.icon[filled].selectedHoverBackground #a0a0a0  HSL   0   0  63    com.formdev.flatlaf.util.DerivedColor [UI]    darken(3% autoInverse)
+CheckBox.icon[filled].selectedPressedBackground #999999  HSL   0   0  60    com.formdev.flatlaf.util.DerivedColor [UI]    darken(6% autoInverse)
 CheckBox.margin                2,2,2,2    javax.swing.plaf.InsetsUIResource [UI]
 CheckBox.rollover              true
 CheckBox.textIconGap           4
@@ -158,7 +158,7 @@ CheckBoxMenuItem.background    #303234  HSL 210   4  20    javax.swing.plaf.Colo
 CheckBoxMenuItem.border        [lazy] 0,0,0,0  false    com.formdev.flatlaf.ui.FlatMenuItemBorder [UI]
 CheckBoxMenuItem.borderPainted true
 CheckBoxMenuItem.checkIcon     [lazy] 15,15    com.formdev.flatlaf.icons.FlatCheckBoxMenuItemIcon [UI]
-CheckBoxMenuItem.disabledForeground #888888  HSL   0   0  53    javax.swing.plaf.ColorUIResource [UI]
+CheckBoxMenuItem.disabledForeground #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
 CheckBoxMenuItem.font          [active] $defaultFont [UI]
 CheckBoxMenuItem.foreground    #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
 CheckBoxMenuItem.margin        3,6,3,6    javax.swing.plaf.InsetsUIResource [UI]
@@ -186,22 +186,22 @@ ColorChooserUI                 com.formdev.flatlaf.ui.FlatColorChooserUI
 
 #---- ComboBox ----
 
-ComboBox.background            #45494a  HSL 192   3  28    javax.swing.plaf.ColorUIResource [UI]
+ComboBox.background            #46494b  HSL 204   3  28    javax.swing.plaf.ColorUIResource [UI]
 ComboBox.border                [lazy] 1,1,1,1  false    com.formdev.flatlaf.ui.FlatRoundBorder [UI]
-ComboBox.buttonArrowColor      #9a9da1  HSL 214   4  62    javax.swing.plaf.ColorUIResource [UI]
-ComboBox.buttonBackground      #45494a  HSL 192   3  28    javax.swing.plaf.ColorUIResource [UI]
-ComboBox.buttonDarkShadow      #7e7e7e  HSL   0   0  49    javax.swing.plaf.ColorUIResource [UI]
-ComboBox.buttonDisabledArrowColor #5a5d61  HSL 214   4  37    javax.swing.plaf.ColorUIResource [UI]
-ComboBox.buttonDisabledSeparatorColor #646464  HSL   0   0  39    javax.swing.plaf.ColorUIResource [UI]
-ComboBox.buttonEditableBackground #404445  HSL 192   4  26    javax.swing.plaf.ColorUIResource [UI]
-ComboBox.buttonHighlight       #242424  HSL   0   0  14    javax.swing.plaf.ColorUIResource [UI]
-ComboBox.buttonHoverArrowColor #b4b7ba  HSL 210   4  72    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(10%)
-ComboBox.buttonPressedArrowColor #cfd0d2  HSL 220   3  82    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(20%)
-ComboBox.buttonSeparatorColor  #646464  HSL   0   0  39    javax.swing.plaf.ColorUIResource [UI]
-ComboBox.buttonShadow          #646464  HSL   0   0  39    javax.swing.plaf.ColorUIResource [UI]
+ComboBox.buttonArrowColor      #9b9b9b  HSL   0   0  61    javax.swing.plaf.ColorUIResource [UI]
+ComboBox.buttonBackground      #46494b  HSL 204   3  28    javax.swing.plaf.ColorUIResource [UI]
+ComboBox.buttonDarkShadow      #7a7d7f  HSL 204   2  49    javax.swing.plaf.ColorUIResource [UI]
+ComboBox.buttonDisabledArrowColor #5b5b5b  HSL   0   0  36    javax.swing.plaf.ColorUIResource [UI]
+ComboBox.buttonDisabledSeparatorColor #616365  HSL 210   2  39    javax.swing.plaf.ColorUIResource [UI]
+ComboBox.buttonEditableBackground #414446  HSL 204   4  26    javax.swing.plaf.ColorUIResource [UI]
+ComboBox.buttonHighlight       #232324  HSL 240   1  14    javax.swing.plaf.ColorUIResource [UI]
+ComboBox.buttonHoverArrowColor #b5b5b5  HSL   0   0  71    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(10%)
+ComboBox.buttonPressedArrowColor #cecece  HSL   0   0  81    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(20%)
+ComboBox.buttonSeparatorColor  #616365  HSL 210   2  39    javax.swing.plaf.ColorUIResource [UI]
+ComboBox.buttonShadow          #616365  HSL 210   2  39    javax.swing.plaf.ColorUIResource [UI]
 ComboBox.buttonStyle           auto
 ComboBox.disabledBackground    #3c3f41  HSL 204   4  25    javax.swing.plaf.ColorUIResource [UI]
-ComboBox.disabledForeground    #888888  HSL   0   0  53    javax.swing.plaf.ColorUIResource [UI]
+ComboBox.disabledForeground    #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
 ComboBox.editorColumns         0
 ComboBox.font                  [active] $defaultFont [UI]
 ComboBox.foreground            #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
@@ -221,9 +221,9 @@ ComboBoxUI                     com.formdev.flatlaf.ui.FlatComboBoxUI
 Component.accentColor          #4b6eaf  HSL 219  40  49    javax.swing.plaf.ColorUIResource [UI]
 Component.arc                  5
 Component.arrowType            chevron
-Component.borderColor          #646464  HSL   0   0  39    javax.swing.plaf.ColorUIResource [UI]
+Component.borderColor          #616365  HSL 210   2  39    javax.swing.plaf.ColorUIResource [UI]
 Component.custom.borderColor   #bf4040  HSL   0  50  50    com.formdev.flatlaf.util.DerivedColor [UI]    desaturate(50% relative)
-Component.disabledBorderColor  #646464  HSL   0   0  39    javax.swing.plaf.ColorUIResource [UI]
+Component.disabledBorderColor  #616365  HSL 210   2  39    javax.swing.plaf.ColorUIResource [UI]
 Component.error.borderColor    #725555  HSL   0  15  39    javax.swing.plaf.ColorUIResource [UI]
 Component.error.focusedBorderColor #8b3c3c  HSL   0  40  39    javax.swing.plaf.ColorUIResource [UI]
 Component.focusColor           #3c628c  HSL 212  40  39    javax.swing.plaf.ColorUIResource [UI]
@@ -268,7 +268,7 @@ DesktopPaneUI                  com.formdev.flatlaf.ui.FlatDesktopPaneUI
 
 #---- EditorPane ----
 
-EditorPane.background          #45494a  HSL 192   3  28    javax.swing.plaf.ColorUIResource [UI]
+EditorPane.background          #46494b  HSL 204   3  28    javax.swing.plaf.ColorUIResource [UI]
 EditorPane.border              [lazy] 0,0,0,0  false    com.formdev.flatlaf.ui.FlatMarginBorder [UI]
 EditorPane.caretBlinkRate      500
 EditorPane.caretForeground     #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
@@ -276,7 +276,7 @@ EditorPane.disabledBackground  #3c3f41  HSL 204   4  25    javax.swing.plaf.Colo
 EditorPane.font                [active] $defaultFont [UI]
 EditorPane.foreground          #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
 EditorPane.inactiveBackground  #3c3f41  HSL 204   4  25    javax.swing.plaf.ColorUIResource [UI]
-EditorPane.inactiveForeground  #888888  HSL   0   0  53    javax.swing.plaf.ColorUIResource [UI]
+EditorPane.inactiveForeground  #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
 EditorPane.margin              2,6,2,6    javax.swing.plaf.InsetsUIResource [UI]
 EditorPane.selectionBackground #4b6eaf  HSL 219  40  49    javax.swing.plaf.ColorUIResource [UI]
 EditorPane.selectionForeground #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
@@ -307,7 +307,7 @@ FileView.hardDriveIcon         [lazy] 16,16    com.formdev.flatlaf.icons.FlatFil
 
 #---- FormattedTextField ----
 
-FormattedTextField.background  #45494a  HSL 192   3  28    javax.swing.plaf.ColorUIResource [UI]
+FormattedTextField.background  #46494b  HSL 204   3  28    javax.swing.plaf.ColorUIResource [UI]
 FormattedTextField.border      [lazy] 1,1,1,1  false    com.formdev.flatlaf.ui.FlatTextBorder [UI]
 FormattedTextField.caretBlinkRate 500
 FormattedTextField.caretForeground #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
@@ -316,9 +316,9 @@ FormattedTextField.font        [active] $defaultFont [UI]
 FormattedTextField.foreground  #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
 FormattedTextField.iconTextGap 4
 FormattedTextField.inactiveBackground #3c3f41  HSL 204   4  25    javax.swing.plaf.ColorUIResource [UI]
-FormattedTextField.inactiveForeground #888888  HSL   0   0  53    javax.swing.plaf.ColorUIResource [UI]
+FormattedTextField.inactiveForeground #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
 FormattedTextField.margin      2,6,2,6    javax.swing.plaf.InsetsUIResource [UI]
-FormattedTextField.placeholderForeground #888888  HSL   0   0  53    javax.swing.plaf.ColorUIResource [UI]
+FormattedTextField.placeholderForeground #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
 FormattedTextField.selectionBackground #4b6eaf  HSL 219  40  49    javax.swing.plaf.ColorUIResource [UI]
 FormattedTextField.selectionForeground #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
 FormattedTextFieldUI           com.formdev.flatlaf.ui.FlatFormattedTextFieldUI
@@ -331,24 +331,24 @@ HeaderUI                       com.formdev.flatlaf.swingx.ui.FlatHeaderUI
 
 #---- HelpButton ----
 
-HelpButton.background          #43494a  HSL 189   5  28    javax.swing.plaf.ColorUIResource [UI]
-HelpButton.borderColor         #6b6b6b  HSL   0   0  42    javax.swing.plaf.ColorUIResource [UI]
+HelpButton.background          #4e5052  HSL 210   2  31    javax.swing.plaf.ColorUIResource [UI]
+HelpButton.borderColor         #606263  HSL 200   2  38    javax.swing.plaf.ColorUIResource [UI]
 HelpButton.borderWidth         1
 HelpButton.disabledBackground  #3c3f41  HSL 204   4  25    javax.swing.plaf.ColorUIResource [UI]
-HelpButton.disabledBorderColor #545556  HSL 210   1  33    javax.swing.plaf.ColorUIResource [UI]
-HelpButton.disabledQuestionMarkColor #606060  HSL   0   0  38    javax.swing.plaf.ColorUIResource [UI]
+HelpButton.disabledBorderColor #606263  HSL 200   2  38    javax.swing.plaf.ColorUIResource [UI]
+HelpButton.disabledQuestionMarkColor #77797a  HSL 200   1  47    javax.swing.plaf.ColorUIResource [UI]
 HelpButton.focusedBorderColor  #446e9e  HSL 212  40  44    javax.swing.plaf.ColorUIResource [UI]
-HelpButton.hoverBackground     #4a5152  HSL 188   5  31    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(3% autoInverse)
+HelpButton.hoverBackground     #55585a  HSL 204   3  34    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(3% autoInverse)
 HelpButton.hoverBorderColor    #446e9e  HSL 212  40  44    javax.swing.plaf.ColorUIResource [UI]
 HelpButton.icon                [lazy] 22,22    com.formdev.flatlaf.icons.FlatHelpButtonIcon [UI]
 HelpButton.innerFocusWidth     1
-HelpButton.pressedBackground   #52595a  HSL 188   5  34    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(6% autoInverse)
-HelpButton.questionMarkColor   #a7a7a7  HSL   0   0  65    javax.swing.plaf.ColorUIResource [UI]
+HelpButton.pressedBackground   #5d5f62  HSL 216   3  37    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(6% autoInverse)
+HelpButton.questionMarkColor   #a8a8a8  HSL   0   0  66    javax.swing.plaf.ColorUIResource [UI]
 
 
 #---- Hyperlink ----
 
-Hyperlink.disabledText         #888888  HSL   0   0  53    javax.swing.plaf.ColorUIResource [UI]
+Hyperlink.disabledText         #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
 Hyperlink.linkColor            #579bf6  HSL 214  90  65    javax.swing.plaf.ColorUIResource [UI]
 Hyperlink.visitedColor         #579bf6  HSL 214  90  65    javax.swing.plaf.ColorUIResource [UI]
 HyperlinkUI                    com.formdev.flatlaf.swingx.ui.FlatHyperlinkUI
@@ -363,12 +363,12 @@ InternalFrame.activeTitleBackground #242526  HSL 210   3  15    javax.swing.plaf
 InternalFrame.activeTitleForeground #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
 InternalFrame.border           [lazy] 6,6,6,6  false    com.formdev.flatlaf.ui.FlatInternalFrameUI$FlatInternalFrameBorder [UI]
 InternalFrame.borderColor      #3c3f41  HSL 204   4  25    javax.swing.plaf.ColorUIResource [UI]
-InternalFrame.borderDarkShadow #7e7e7e  HSL   0   0  49    javax.swing.plaf.ColorUIResource [UI]
-InternalFrame.borderHighlight  #242424  HSL   0   0  14    javax.swing.plaf.ColorUIResource [UI]
-InternalFrame.borderLight      #313131  HSL   0   0  19    javax.swing.plaf.ColorUIResource [UI]
+InternalFrame.borderDarkShadow #7a7d7f  HSL 204   2  49    javax.swing.plaf.ColorUIResource [UI]
+InternalFrame.borderHighlight  #232324  HSL 240   1  14    javax.swing.plaf.ColorUIResource [UI]
+InternalFrame.borderLight      #2f3031  HSL 210   2  19    javax.swing.plaf.ColorUIResource [UI]
 InternalFrame.borderLineWidth  1
 InternalFrame.borderMargins    6,6,6,6    javax.swing.plaf.InsetsUIResource [UI]
-InternalFrame.borderShadow     #646464  HSL   0   0  39    javax.swing.plaf.ColorUIResource [UI]
+InternalFrame.borderShadow     #616365  HSL 210   2  39    javax.swing.plaf.ColorUIResource [UI]
 InternalFrame.buttonHoverBackground #3d3f40  HSL 200   2  25    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(10% autoInverse)
 InternalFrame.buttonPressedBackground #56585a  HSL 210   2  35    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(20% autoInverse)
 InternalFrame.buttonSize       24,24    javax.swing.plaf.DimensionUIResource [UI]
@@ -383,8 +383,8 @@ InternalFrame.iconifyIcon      [lazy] 24,24    com.formdev.flatlaf.icons.FlatInt
 InternalFrame.inactiveBorderColor #353739  HSL 210   4  22    javax.swing.plaf.ColorUIResource [UI]
 InternalFrame.inactiveDropShadowInsets 3,3,4,4    javax.swing.plaf.InsetsUIResource [UI]
 InternalFrame.inactiveDropShadowOpacity 0.75
-InternalFrame.inactiveTitleBackground #303234  HSL 210   4  20    javax.swing.plaf.ColorUIResource [UI]
-InternalFrame.inactiveTitleForeground #888888  HSL   0   0  53    javax.swing.plaf.ColorUIResource [UI]
+InternalFrame.inactiveTitleBackground #303233  HSL 200   3  19    javax.swing.plaf.ColorUIResource [UI]
+InternalFrame.inactiveTitleForeground #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
 InternalFrame.maximizeIcon     [lazy] 24,24    com.formdev.flatlaf.icons.FlatInternalFrameMaximizeIcon [UI]
 InternalFrame.minimizeIcon     [lazy] 24,24    com.formdev.flatlaf.icons.FlatInternalFrameRestoreIcon [UI]
 InternalFrame.titleFont        [active] $defaultFont [UI]
@@ -423,24 +423,24 @@ JXHeader.startBackground       #4c5052  HSL 200   4  31    javax.swing.plaf.Colo
 #---- JXMonthView ----
 
 JXMonthView.arrowColor         #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
-JXMonthView.background         #45494a  HSL 192   3  28    javax.swing.plaf.ColorUIResource [UI]
+JXMonthView.background         #46494b  HSL 204   3  28    javax.swing.plaf.ColorUIResource [UI]
 JXMonthView.daysOfTheWeekForeground #aaaaaa  HSL   0   0  67    javax.swing.plaf.ColorUIResource [UI]
-JXMonthView.disabledArrowColor #888888  HSL   0   0  53    javax.swing.plaf.ColorUIResource [UI]
+JXMonthView.disabledArrowColor #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
 JXMonthView.flaggedDayForeground #e05555  HSL   0  69  61    javax.swing.plaf.ColorUIResource [UI]
-JXMonthView.leadingDayForeground #888888  HSL   0   0  53    javax.swing.plaf.ColorUIResource [UI]
+JXMonthView.leadingDayForeground #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
 JXMonthView.monthDownFileName  [lazy] 20,20    com.formdev.flatlaf.swingx.ui.FlatMonthDownIcon [UI]
 JXMonthView.monthStringBackground #4c5052  HSL 200   4  31    javax.swing.plaf.ColorUIResource [UI]
 JXMonthView.monthStringForeground #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
 JXMonthView.monthUpFileName    [lazy] 20,20    com.formdev.flatlaf.swingx.ui.FlatMonthUpIcon [UI]
 JXMonthView.selectedBackground #4b6eaf  HSL 219  40  49    javax.swing.plaf.ColorUIResource [UI]
-JXMonthView.trailingDayForeground #888888  HSL   0   0  53    javax.swing.plaf.ColorUIResource [UI]
+JXMonthView.trailingDayForeground #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
 JXMonthView.unselectableDayForeground #e05555  HSL   0  69  61    javax.swing.plaf.ColorUIResource [UI]
 JXMonthView.weekOfTheYearForeground #888888  HSL   0   0  53    javax.swing.plaf.ColorUIResource [UI]
 
 
 #---- JXTitledPanel ----
 
-JXTitledPanel.borderColor      #5e6263  HSL 192   3  38    javax.swing.plaf.ColorUIResource [UI]
+JXTitledPanel.borderColor      #606263  HSL 200   2  38    javax.swing.plaf.ColorUIResource [UI]
 JXTitledPanel.captionInsets    4,10,4,10    javax.swing.plaf.InsetsUIResource [UI]
 JXTitledPanel.titleBackground  #4c5052  HSL 200   4  31    javax.swing.plaf.ColorUIResource [UI]
 JXTitledPanel.titleForeground  #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
@@ -448,18 +448,18 @@ JXTitledPanel.titleForeground  #bbbbbb  HSL   0   0  73    javax.swing.plaf.Colo
 
 #---- JideButton ----
 
-JideButton.background          #4c5052  HSL 200   4  31    javax.swing.plaf.ColorUIResource [UI]
+JideButton.background          #4e5052  HSL 210   2  31    javax.swing.plaf.ColorUIResource [UI]
 JideButton.border              [lazy] 0,0,0,0  false    com.formdev.flatlaf.ui.FlatMarginBorder [UI]
-JideButton.borderColor         #5e6263  HSL 192   3  38    javax.swing.plaf.ColorUIResource [UI]
-JideButton.darkShadow          #5e6263  HSL 192   3  38    javax.swing.plaf.ColorUIResource [UI]
-JideButton.focusedBackground   #4e5355  HSL 197   4  32    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(1% autoInverse)
+JideButton.borderColor         #606263  HSL 200   2  38    javax.swing.plaf.ColorUIResource [UI]
+JideButton.darkShadow          #606263  HSL 200   2  38    javax.swing.plaf.ColorUIResource [UI]
+JideButton.focusedBackground   #505355  HSL 204   3  32    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(1% autoInverse)
 JideButton.foreground          #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
-JideButton.highlight           #656a6c  HSL 197   3  41    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(10% autoInverse)
-JideButton.light               #5e6263  HSL 192   3  38    javax.swing.plaf.ColorUIResource [UI]
+JideButton.highlight           #676a6c  HSL 204   2  41    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(10% autoInverse)
+JideButton.light               #606263  HSL 200   2  38    javax.swing.plaf.ColorUIResource [UI]
 JideButton.margin              3,3,3,3    javax.swing.plaf.InsetsUIResource [UI]
-JideButton.selectedAndFocusedBackground #565a5d  HSL 206   4  35    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(4% autoInverse)
-JideButton.selectedBackground  #5d6265  HSL 203   4  38    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(7% autoInverse)
-JideButton.shadow              #5e6263  HSL 192   3  38    javax.swing.plaf.ColorUIResource [UI]
+JideButton.selectedAndFocusedBackground #585a5c  HSL 210   2  35    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(4% autoInverse)
+JideButton.selectedBackground  #5f6264  HSL 204   3  38    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(7% autoInverse)
+JideButton.shadow              #606263  HSL 200   2  38    javax.swing.plaf.ColorUIResource [UI]
 JideButton.textIconGap         [active] 4
 JideButtonUI                   com.formdev.flatlaf.jideoss.ui.FlatJideButtonUI
 
@@ -467,7 +467,7 @@ JideButtonUI                   com.formdev.flatlaf.jideoss.ui.FlatJideButtonUI
 #---- JideLabel ----
 
 JideLabel.background           #3c3f41  HSL 204   4  25    javax.swing.plaf.ColorUIResource [UI]
-JideLabel.disabledForeground   #888888  HSL   0   0  53    javax.swing.plaf.ColorUIResource [UI]
+JideLabel.disabledForeground   #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
 JideLabel.foreground           #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
 JideLabelUI                    com.formdev.flatlaf.jideoss.ui.FlatJideLabelUI
 
@@ -479,10 +479,10 @@ JidePopupMenuUI                com.formdev.flatlaf.jideoss.ui.FlatJidePopupMenuU
 
 #---- JideSplitButton ----
 
-JideSplitButton.background     #4c5052  HSL 200   4  31    javax.swing.plaf.ColorUIResource [UI]
+JideSplitButton.background     #4e5052  HSL 210   2  31    javax.swing.plaf.ColorUIResource [UI]
 JideSplitButton.border         [lazy] 0,0,0,0  false    com.formdev.flatlaf.ui.FlatMarginBorder [UI]
-JideSplitButton.buttonArrowColor #9a9da1  HSL 214   4  62    javax.swing.plaf.ColorUIResource [UI]
-JideSplitButton.buttonDisabledArrowColor #5a5d61  HSL 214   4  37    javax.swing.plaf.ColorUIResource [UI]
+JideSplitButton.buttonArrowColor #9b9b9b  HSL   0   0  61    javax.swing.plaf.ColorUIResource [UI]
+JideSplitButton.buttonDisabledArrowColor #5b5b5b  HSL   0   0  36    javax.swing.plaf.ColorUIResource [UI]
 JideSplitButton.foreground     #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
 JideSplitButton.margin         3,3,3,3    javax.swing.plaf.InsetsUIResource [UI]
 JideSplitButton.selectionForeground #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
@@ -510,8 +510,8 @@ JideTabbedPaneUI               com.formdev.flatlaf.jideoss.ui.FlatJideTabbedPane
 #---- Label ----
 
 Label.background               #3c3f41  HSL 204   4  25    javax.swing.plaf.ColorUIResource [UI]
-Label.disabledForeground       #888888  HSL   0   0  53    javax.swing.plaf.ColorUIResource [UI]
-Label.disabledShadow           #646464  HSL   0   0  39    javax.swing.plaf.ColorUIResource [UI]
+Label.disabledForeground       #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
+Label.disabledShadow           #616365  HSL 210   2  39    javax.swing.plaf.ColorUIResource [UI]
 Label.font                     [active] $defaultFont [UI]
 Label.foreground               #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
 LabelUI                        com.formdev.flatlaf.ui.FlatLabelUI
@@ -519,7 +519,7 @@ LabelUI                        com.formdev.flatlaf.ui.FlatLabelUI
 
 #---- List ----
 
-List.background                #45494a  HSL 192   3  28    javax.swing.plaf.ColorUIResource [UI]
+List.background                #46494b  HSL 204   3  28    javax.swing.plaf.ColorUIResource [UI]
 List.border                    [lazy] 0,0,0,0  false    com.formdev.flatlaf.ui.FlatEmptyBorder [UI]
 List.cellFocusColor            #000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]
 List.cellMargins               1,6,1,6    javax.swing.plaf.InsetsUIResource [UI]
@@ -553,11 +553,11 @@ Menu.border                    [lazy] 0,0,0,0  false    com.formdev.flatlaf.ui.F
 Menu.borderPainted             true
 Menu.cancelMode                hideLastSubmenu
 Menu.crossMenuMnemonic         true
-Menu.disabledForeground        #888888  HSL   0   0  53    javax.swing.plaf.ColorUIResource [UI]
+Menu.disabledForeground        #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
 Menu.font                      [active] $defaultFont [UI]
 Menu.foreground                #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
-Menu.icon.arrowColor           #a7a7a7  HSL   0   0  65    javax.swing.plaf.ColorUIResource [UI]
-Menu.icon.disabledArrowColor   #606060  HSL   0   0  38    javax.swing.plaf.ColorUIResource [UI]
+Menu.icon.arrowColor           #9b9b9b  HSL   0   0  61    javax.swing.plaf.ColorUIResource [UI]
+Menu.icon.disabledArrowColor   #5b5b5b  HSL   0   0  36    javax.swing.plaf.ColorUIResource [UI]
 Menu.margin                    3,6,3,6    javax.swing.plaf.InsetsUIResource [UI]
 Menu.menuPopupOffsetX          0
 Menu.menuPopupOffsetY          0
@@ -575,13 +575,13 @@ Menu.submenuPopupOffsetY       [active] -4
 
 MenuBar.background             #303234  HSL 210   4  20    javax.swing.plaf.ColorUIResource [UI]
 MenuBar.border                 [lazy] 0,0,1,0  false    com.formdev.flatlaf.ui.FlatMenuBarBorder [UI]
-MenuBar.borderColor            #515151  HSL   0   0  32    javax.swing.plaf.ColorUIResource [UI]
+MenuBar.borderColor            #505254  HSL 210   2  32    javax.swing.plaf.ColorUIResource [UI]
 MenuBar.font                   [active] $defaultFont [UI]
 MenuBar.foreground             #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
-MenuBar.highlight              #242424  HSL   0   0  14    javax.swing.plaf.ColorUIResource [UI]
+MenuBar.highlight              #232324  HSL 240   1  14    javax.swing.plaf.ColorUIResource [UI]
 MenuBar.hoverBackground        #484c4f  HSL 206   5  30    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(10% autoInverse)
 MenuBar.itemMargins            3,8,3,8    javax.swing.plaf.InsetsUIResource [UI]
-MenuBar.shadow                 #646464  HSL   0   0  39    javax.swing.plaf.ColorUIResource [UI]
+MenuBar.shadow                 #616365  HSL 210   2  39    javax.swing.plaf.ColorUIResource [UI]
 MenuBar.windowBindings         length=2    [Ljava.lang.Object;
     [0] F10
     [1] takeFocus
@@ -601,7 +601,7 @@ MenuItem.border                [lazy] 0,0,0,0  false    com.formdev.flatlaf.ui.F
 MenuItem.borderPainted         true
 MenuItem.checkBackground       #3c588b  HSL 219  40  39    com.formdev.flatlaf.util.DerivedColor [UI]    darken(10%)
 MenuItem.checkMargins          2,2,2,2    javax.swing.plaf.InsetsUIResource [UI]
-MenuItem.disabledForeground    #888888  HSL   0   0  53    javax.swing.plaf.ColorUIResource [UI]
+MenuItem.disabledForeground    #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
 MenuItem.font                  [active] $defaultFont [UI]
 MenuItem.foreground            #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
 MenuItem.iconTextGap           6
@@ -621,8 +621,8 @@ MenuItem.underlineSelectionHeight 3
 
 #---- MenuItemCheckBox ----
 
-MenuItemCheckBox.icon.checkmarkColor #a7a7a7  HSL   0   0  65    javax.swing.plaf.ColorUIResource [UI]
-MenuItemCheckBox.icon.disabledCheckmarkColor #606060  HSL   0   0  38    javax.swing.plaf.ColorUIResource [UI]
+MenuItemCheckBox.icon.checkmarkColor #9b9b9b  HSL   0   0  61    javax.swing.plaf.ColorUIResource [UI]
+MenuItemCheckBox.icon.disabledCheckmarkColor #5b5b5b  HSL   0   0  36    javax.swing.plaf.ColorUIResource [UI]
 
 
 #---- MenuItem ----
@@ -693,7 +693,7 @@ PanelUI                        com.formdev.flatlaf.ui.FlatPanelUI
 
 #---- PasswordField ----
 
-PasswordField.background       #45494a  HSL 192   3  28    javax.swing.plaf.ColorUIResource [UI]
+PasswordField.background       #46494b  HSL 204   3  28    javax.swing.plaf.ColorUIResource [UI]
 PasswordField.border           [lazy] 1,1,1,1  false    com.formdev.flatlaf.ui.FlatTextBorder [UI]
 PasswordField.capsLockIcon     [lazy] 16,16    com.formdev.flatlaf.icons.FlatCapsLockIcon [UI]
 PasswordField.capsLockIconColor #ffffff64  39%  HSLA   0   0 100 39    javax.swing.plaf.ColorUIResource [UI]
@@ -705,9 +705,9 @@ PasswordField.font             [active] $defaultFont [UI]
 PasswordField.foreground       #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
 PasswordField.iconTextGap      4
 PasswordField.inactiveBackground #3c3f41  HSL 204   4  25    javax.swing.plaf.ColorUIResource [UI]
-PasswordField.inactiveForeground #888888  HSL   0   0  53    javax.swing.plaf.ColorUIResource [UI]
+PasswordField.inactiveForeground #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
 PasswordField.margin           2,6,2,6    javax.swing.plaf.InsetsUIResource [UI]
-PasswordField.placeholderForeground #888888  HSL   0   0  53    javax.swing.plaf.ColorUIResource [UI]
+PasswordField.placeholderForeground #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
 PasswordField.selectionBackground #4b6eaf  HSL 219  40  49    javax.swing.plaf.ColorUIResource [UI]
 PasswordField.selectionForeground #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
 PasswordField.showCapsLock     true
@@ -725,8 +725,8 @@ Popup.dropShadowPainted        true
 #---- PopupMenu ----
 
 PopupMenu.background           #303234  HSL 210   4  20    javax.swing.plaf.ColorUIResource [UI]
-PopupMenu.border               [lazy] 4,1,4,1  false    com.formdev.flatlaf.ui.FlatPopupMenuBorder [UI]    lineColor=#5e5e5e  HSL   0   0  37    javax.swing.plaf.ColorUIResource [UI]    lineThickness=1.000000
-PopupMenu.borderColor          #5e5e5e  HSL   0   0  37    javax.swing.plaf.ColorUIResource [UI]
+PopupMenu.border               [lazy] 4,1,4,1  false    com.formdev.flatlaf.ui.FlatPopupMenuBorder [UI]    lineColor=#5d6061  HSL 195   2  37    javax.swing.plaf.ColorUIResource [UI]    lineThickness=1.000000
+PopupMenu.borderColor          #5d6061  HSL 195   2  37    javax.swing.plaf.ColorUIResource [UI]
 PopupMenu.borderInsets         4,1,4,1    javax.swing.plaf.InsetsUIResource [UI]
 PopupMenu.consumeEventOnClose  false
 PopupMenu.font                 [active] $defaultFont [UI]
@@ -749,7 +749,7 @@ PopupMenuUI                    com.formdev.flatlaf.ui.FlatPopupMenuUI
 #---- ProgressBar ----
 
 ProgressBar.arc                4
-ProgressBar.background         #555555  HSL   0   0  33    javax.swing.plaf.ColorUIResource [UI]
+ProgressBar.background         #505456  HSL 200   4  33    javax.swing.plaf.ColorUIResource [UI]
 ProgressBar.border             [lazy] 0,0,0,0  false    com.formdev.flatlaf.ui.FlatEmptyBorder [UI]
 ProgressBar.cellLength         1
 ProgressBar.cellSpacing        0
@@ -768,19 +768,19 @@ ProgressBarUI                  com.formdev.flatlaf.ui.FlatProgressBarUI
 
 RadioButton.background         #3c3f41  HSL 204   4  25    javax.swing.plaf.ColorUIResource [UI]
 RadioButton.border             [lazy] 0,0,0,0  false    com.formdev.flatlaf.ui.FlatMarginBorder [UI]
-RadioButton.darkShadow         #7e7e7e  HSL   0   0  49    javax.swing.plaf.ColorUIResource [UI]
-RadioButton.disabledText       #888888  HSL   0   0  53    javax.swing.plaf.ColorUIResource [UI]
+RadioButton.darkShadow         #7a7d7f  HSL 204   2  49    javax.swing.plaf.ColorUIResource [UI]
+RadioButton.disabledText       #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
 RadioButton.font               [active] $defaultFont [UI]
 RadioButton.foreground         #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
-RadioButton.highlight          #242424  HSL   0   0  14    javax.swing.plaf.ColorUIResource [UI]
+RadioButton.highlight          #232324  HSL 240   1  14    javax.swing.plaf.ColorUIResource [UI]
 RadioButton.icon.centerDiameter 8
 RadioButton.icon               [lazy] 15,15    com.formdev.flatlaf.icons.FlatRadioButtonIcon [UI]
 RadioButton.iconTextGap        4
 RadioButton.icon[filled].centerDiameter 5
-RadioButton.light              #313131  HSL   0   0  19    javax.swing.plaf.ColorUIResource [UI]
+RadioButton.light              #2f3031  HSL 210   2  19    javax.swing.plaf.ColorUIResource [UI]
 RadioButton.margin             2,2,2,2    javax.swing.plaf.InsetsUIResource [UI]
 RadioButton.rollover           true
-RadioButton.shadow             #646464  HSL   0   0  39    javax.swing.plaf.ColorUIResource [UI]
+RadioButton.shadow             #616365  HSL 210   2  39    javax.swing.plaf.ColorUIResource [UI]
 RadioButton.textIconGap        4
 RadioButton.textShiftOffset    0
 
@@ -795,7 +795,7 @@ RadioButtonMenuItem.background #303234  HSL 210   4  20    javax.swing.plaf.Colo
 RadioButtonMenuItem.border     [lazy] 0,0,0,0  false    com.formdev.flatlaf.ui.FlatMenuItemBorder [UI]
 RadioButtonMenuItem.borderPainted true
 RadioButtonMenuItem.checkIcon  [lazy] 15,15    com.formdev.flatlaf.icons.FlatRadioButtonMenuItemIcon [UI]
-RadioButtonMenuItem.disabledForeground #888888  HSL   0   0  53    javax.swing.plaf.ColorUIResource [UI]
+RadioButtonMenuItem.disabledForeground #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
 RadioButtonMenuItem.font       [active] $defaultFont [UI]
 RadioButtonMenuItem.foreground #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
 RadioButtonMenuItem.margin     3,6,3,6    javax.swing.plaf.InsetsUIResource [UI]
@@ -817,7 +817,7 @@ RangeSliderUI                  com.formdev.flatlaf.jideoss.ui.FlatRangeSliderUI
 
 #---- Resizable ----
 
-Resizable.resizeBorder         [lazy] 4,4,4,4  false    com.formdev.flatlaf.ui.FlatLineBorder [UI]    lineColor=#5e5e5e  HSL   0   0  37    javax.swing.plaf.ColorUIResource [UI]    lineThickness=1.000000
+Resizable.resizeBorder         [lazy] 4,4,4,4  false    com.formdev.flatlaf.ui.FlatLineBorder [UI]    lineColor=#5d6061  HSL 195   2  37    javax.swing.plaf.ColorUIResource [UI]    lineThickness=1.000000
 
 
 #---- RootPane ----
@@ -845,8 +845,8 @@ RootPaneUI                     com.formdev.flatlaf.ui.FlatRootPaneUI
 
 ScrollBar.allowsAbsolutePositioning true
 ScrollBar.background           #3c3f41  HSL 204   4  25    javax.swing.plaf.ColorUIResource [UI]
-ScrollBar.buttonArrowColor     #9a9da1  HSL 214   4  62    javax.swing.plaf.ColorUIResource [UI]
-ScrollBar.buttonDisabledArrowColor #5a5d61  HSL 214   4  37    javax.swing.plaf.ColorUIResource [UI]
+ScrollBar.buttonArrowColor     #9b9b9b  HSL   0   0  61    javax.swing.plaf.ColorUIResource [UI]
+ScrollBar.buttonDisabledArrowColor #5b5b5b  HSL   0   0  36    javax.swing.plaf.ColorUIResource [UI]
 ScrollBar.foreground           #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
 ScrollBar.hoverButtonBackground #484c4e  HSL 200   4  29    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(5%)
 ScrollBar.hoverThumbColor      #6e767a  HSL 200   5  45    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(10%)
@@ -861,13 +861,13 @@ ScrollBar.showButtons          false
 ScrollBar.squareButtons        false
 ScrollBar.thumb                #565c5f  HSL 200   5  35    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(10%)
 ScrollBar.thumbArc             0
-ScrollBar.thumbDarkShadow      #7e7e7e  HSL   0   0  49    javax.swing.plaf.ColorUIResource [UI]
-ScrollBar.thumbHighlight       #242424  HSL   0   0  14    javax.swing.plaf.ColorUIResource [UI]
+ScrollBar.thumbDarkShadow      #7a7d7f  HSL 204   2  49    javax.swing.plaf.ColorUIResource [UI]
+ScrollBar.thumbHighlight       #232324  HSL 240   1  14    javax.swing.plaf.ColorUIResource [UI]
 ScrollBar.thumbInsets          0,0,0,0    javax.swing.plaf.InsetsUIResource [UI]
-ScrollBar.thumbShadow          #646464  HSL   0   0  39    javax.swing.plaf.ColorUIResource [UI]
+ScrollBar.thumbShadow          #616365  HSL 210   2  39    javax.swing.plaf.ColorUIResource [UI]
 ScrollBar.track                #3e4244  HSL 200   5  25    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(1%)
 ScrollBar.trackArc             0
-ScrollBar.trackHighlight       #7e7e7e  HSL   0   0  49    javax.swing.plaf.ColorUIResource [UI]
+ScrollBar.trackHighlight       #7a7d7f  HSL 204   2  49    javax.swing.plaf.ColorUIResource [UI]
 ScrollBar.trackInsets          0,0,0,0    javax.swing.plaf.InsetsUIResource [UI]
 ScrollBar.width                10
 ScrollBarUI                    com.formdev.flatlaf.ui.FlatScrollBarUI
@@ -906,10 +906,10 @@ SearchField.searchIconPressedColor [lazy] #7f8b9180  50%  HSLA 200   8  53 50   
 #---- Separator ----
 
 Separator.background           #3c3f41  HSL 204   4  25    javax.swing.plaf.ColorUIResource [UI]
-Separator.foreground           #515151  HSL   0   0  32    javax.swing.plaf.ColorUIResource [UI]
+Separator.foreground           #505254  HSL 210   2  32    javax.swing.plaf.ColorUIResource [UI]
 Separator.height               3
-Separator.highlight            #242424  HSL   0   0  14    javax.swing.plaf.ColorUIResource [UI]
-Separator.shadow               #646464  HSL   0   0  39    javax.swing.plaf.ColorUIResource [UI]
+Separator.highlight            #232324  HSL 240   1  14    javax.swing.plaf.ColorUIResource [UI]
+Separator.shadow               #616365  HSL 210   2  39    javax.swing.plaf.ColorUIResource [UI]
 Separator.stripeIndent         1
 Separator.stripeWidth          1
 SeparatorUI                    com.formdev.flatlaf.ui.FlatSeparatorUI
@@ -918,26 +918,26 @@ SeparatorUI                    com.formdev.flatlaf.ui.FlatSeparatorUI
 #---- Slider ----
 
 Slider.background              #3c3f41  HSL 204   4  25    javax.swing.plaf.ColorUIResource [UI]
-Slider.disabledThumbColor      #4c5052  HSL 200   4  31    javax.swing.plaf.ColorUIResource [UI]
-Slider.disabledTrackColor      #4c5052  HSL 200   4  31    javax.swing.plaf.ColorUIResource [UI]
-Slider.focus                   #7e7e7e  HSL   0   0  49    javax.swing.plaf.ColorUIResource [UI]
+Slider.disabledThumbColor      #54595c  HSL 203   5  35    javax.swing.plaf.ColorUIResource [UI]
+Slider.disabledTrackColor      #54595c  HSL 203   5  35    javax.swing.plaf.ColorUIResource [UI]
+Slider.focus                   #7a7d7f  HSL 204   2  49    javax.swing.plaf.ColorUIResource [UI]
 Slider.focusInsets             0,0,0,0    javax.swing.plaf.InsetsUIResource [UI]
 Slider.focusWidth              4
 Slider.focusedColor            #3c628cb3  70%  HSLA 212  40  39 70    com.formdev.flatlaf.util.DerivedColor [UI]    fade(70%)
 Slider.font                    [active] $defaultFont [UI]
 Slider.foreground              #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
-Slider.highlight               #242424  HSL   0   0  14    javax.swing.plaf.ColorUIResource [UI]
+Slider.highlight               #232324  HSL 240   1  14    javax.swing.plaf.ColorUIResource [UI]
 Slider.horizontalSize          200,21    java.awt.Dimension
 Slider.hoverThumbColor         #6094ce  HSL 212  53  59    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(5% autoInverse)
 Slider.minimumHorizontalSize   36,21    java.awt.Dimension
 Slider.minimumVerticalSize     21,36    java.awt.Dimension
 Slider.onlyLeftMouseButtonDrag true
 Slider.pressedThumbColor       #6b9cd2  HSL 211  53  62    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(8% autoInverse)
-Slider.shadow                  #646464  HSL   0   0  39    javax.swing.plaf.ColorUIResource [UI]
+Slider.shadow                  #616365  HSL 210   2  39    javax.swing.plaf.ColorUIResource [UI]
 Slider.thumbColor              #4c87c8  HSL 211  53  54    javax.swing.plaf.ColorUIResource [UI]
 Slider.thumbSize               12,12    javax.swing.plaf.DimensionUIResource [UI]
-Slider.tickColor               #888888  HSL   0   0  53    javax.swing.plaf.ColorUIResource [UI]
-Slider.trackColor              #646464  HSL   0   0  39    javax.swing.plaf.ColorUIResource [UI]
+Slider.tickColor               #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
+Slider.trackColor              #616669  HSL 203   4  40    javax.swing.plaf.ColorUIResource [UI]
 Slider.trackValueColor         #4c87c8  HSL 211  53  54    javax.swing.plaf.ColorUIResource [UI]
 Slider.trackWidth              2
 Slider.verticalSize            21,200    java.awt.Dimension
@@ -947,18 +947,18 @@ SliderUI                       com.formdev.flatlaf.ui.FlatSliderUI
 #---- Spinner ----
 
 Spinner.arrowButtonSize        16,5    java.awt.Dimension
-Spinner.background             #45494a  HSL 192   3  28    javax.swing.plaf.ColorUIResource [UI]
+Spinner.background             #46494b  HSL 204   3  28    javax.swing.plaf.ColorUIResource [UI]
 Spinner.border                 [lazy] 1,1,1,1  false    com.formdev.flatlaf.ui.FlatRoundBorder [UI]
-Spinner.buttonArrowColor       #9a9da1  HSL 214   4  62    javax.swing.plaf.ColorUIResource [UI]
-Spinner.buttonBackground       #404445  HSL 192   4  26    javax.swing.plaf.ColorUIResource [UI]
-Spinner.buttonDisabledArrowColor #5a5d61  HSL 214   4  37    javax.swing.plaf.ColorUIResource [UI]
-Spinner.buttonDisabledSeparatorColor #646464  HSL   0   0  39    javax.swing.plaf.ColorUIResource [UI]
-Spinner.buttonHoverArrowColor  #b4b7ba  HSL 210   4  72    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(10%)
-Spinner.buttonPressedArrowColor #cfd0d2  HSL 220   3  82    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(20%)
-Spinner.buttonSeparatorColor   #646464  HSL   0   0  39    javax.swing.plaf.ColorUIResource [UI]
+Spinner.buttonArrowColor       #9b9b9b  HSL   0   0  61    javax.swing.plaf.ColorUIResource [UI]
+Spinner.buttonBackground       #414446  HSL 204   4  26    javax.swing.plaf.ColorUIResource [UI]
+Spinner.buttonDisabledArrowColor #5b5b5b  HSL   0   0  36    javax.swing.plaf.ColorUIResource [UI]
+Spinner.buttonDisabledSeparatorColor #616365  HSL 210   2  39    javax.swing.plaf.ColorUIResource [UI]
+Spinner.buttonHoverArrowColor  #b5b5b5  HSL   0   0  71    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(10%)
+Spinner.buttonPressedArrowColor #cecece  HSL   0   0  81    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(20%)
+Spinner.buttonSeparatorColor   #616365  HSL 210   2  39    javax.swing.plaf.ColorUIResource [UI]
 Spinner.buttonStyle            button
 Spinner.disabledBackground     #3c3f41  HSL 204   4  25    javax.swing.plaf.ColorUIResource [UI]
-Spinner.disabledForeground     #888888  HSL   0   0  53    javax.swing.plaf.ColorUIResource [UI]
+Spinner.disabledForeground     #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
 Spinner.editorAlignment        11
 Spinner.editorBorderPainted    false
 Spinner.font                   [active] $defaultFont [UI]
@@ -972,24 +972,24 @@ SpinnerUI                      com.formdev.flatlaf.ui.FlatSpinnerUI
 SplitPane.background           #3c3f41  HSL 204   4  25    javax.swing.plaf.ColorUIResource [UI]
 SplitPane.centerOneTouchButtons true
 SplitPane.continuousLayout     true
-SplitPane.darkShadow           #7e7e7e  HSL   0   0  49    javax.swing.plaf.ColorUIResource [UI]
+SplitPane.darkShadow           #7a7d7f  HSL 204   2  49    javax.swing.plaf.ColorUIResource [UI]
 SplitPane.dividerSize          5
-SplitPane.highlight            #242424  HSL   0   0  14    javax.swing.plaf.ColorUIResource [UI]
+SplitPane.highlight            #232324  HSL 240   1  14    javax.swing.plaf.ColorUIResource [UI]
 SplitPane.oneTouchButtonOffset [active] 2
 SplitPane.oneTouchButtonSize   [active] 6
-SplitPane.shadow               #646464  HSL   0   0  39    javax.swing.plaf.ColorUIResource [UI]
+SplitPane.shadow               #616365  HSL 210   2  39    javax.swing.plaf.ColorUIResource [UI]
 
 
 #---- SplitPaneDivider ----
 
-SplitPaneDivider.draggingColor #646464  HSL   0   0  39    javax.swing.plaf.ColorUIResource [UI]
-SplitPaneDivider.gripColor     #adadad  HSL   0   0  68    javax.swing.plaf.ColorUIResource [UI]
+SplitPaneDivider.draggingColor #616365  HSL 210   2  39    javax.swing.plaf.ColorUIResource [UI]
+SplitPaneDivider.gripColor     #aeaeae  HSL   0   0  68    javax.swing.plaf.ColorUIResource [UI]
 SplitPaneDivider.gripDotCount  3
 SplitPaneDivider.gripDotSize   3
 SplitPaneDivider.gripGap       2
-SplitPaneDivider.oneTouchArrowColor #9a9da1  HSL 214   4  62    javax.swing.plaf.ColorUIResource [UI]
-SplitPaneDivider.oneTouchHoverArrowColor #b4b7ba  HSL 210   4  72    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(10%)
-SplitPaneDivider.oneTouchPressedArrowColor #cfd0d2  HSL 220   3  82    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(20%)
+SplitPaneDivider.oneTouchArrowColor #9b9b9b  HSL   0   0  61    javax.swing.plaf.ColorUIResource [UI]
+SplitPaneDivider.oneTouchHoverArrowColor #b5b5b5  HSL   0   0  71    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(10%)
+SplitPaneDivider.oneTouchPressedArrowColor #cecece  HSL   0   0  81    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(20%)
 SplitPaneDivider.style         grip
 
 
@@ -1010,29 +1010,29 @@ TabbedPane.closeArc            4
 TabbedPane.closeCrossFilledSize 7.5
 TabbedPane.closeCrossLineWidth 1.0
 TabbedPane.closeCrossPlainSize 7.5
-TabbedPane.closeForeground     #888888  HSL   0   0  53    javax.swing.plaf.ColorUIResource [UI]
+TabbedPane.closeForeground     #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
 TabbedPane.closeHoverBackground #484c4e  HSL 200   4  29    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(5% autoInverse)
 TabbedPane.closeHoverForeground #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
 TabbedPane.closeIcon           [lazy] 16,16    com.formdev.flatlaf.icons.FlatTabbedPaneCloseIcon [UI]
 TabbedPane.closePressedBackground #54595c  HSL 203   5  35    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(10% autoInverse)
 TabbedPane.closePressedForeground #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
 TabbedPane.closeSize           16,16    javax.swing.plaf.DimensionUIResource [UI]
-TabbedPane.contentAreaColor    #646464  HSL   0   0  39    javax.swing.plaf.ColorUIResource [UI]
+TabbedPane.contentAreaColor    #616365  HSL 210   2  39    javax.swing.plaf.ColorUIResource [UI]
 TabbedPane.contentOpaque       true
 TabbedPane.contentSeparatorHeight 1
-TabbedPane.darkShadow          #7e7e7e  HSL   0   0  49    javax.swing.plaf.ColorUIResource [UI]
-TabbedPane.disabledForeground  #888888  HSL   0   0  53    javax.swing.plaf.ColorUIResource [UI]
-TabbedPane.disabledUnderlineColor #7a7a7a  HSL   0   0  48    javax.swing.plaf.ColorUIResource [UI]
+TabbedPane.darkShadow          #7a7d7f  HSL 204   2  49    javax.swing.plaf.ColorUIResource [UI]
+TabbedPane.disabledForeground  #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
+TabbedPane.disabledUnderlineColor #747a7e  HSL 204   4  47    javax.swing.plaf.ColorUIResource [UI]
 TabbedPane.focus               #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
 TabbedPane.focusColor          #404b5d  HSL 217  18  31    javax.swing.plaf.ColorUIResource [UI]
 TabbedPane.font                [active] $defaultFont [UI]
 TabbedPane.foreground          #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
 TabbedPane.hasFullBorder       false
 TabbedPane.hiddenTabsNavigation moreTabsButton
-TabbedPane.highlight           #242424  HSL   0   0  14    javax.swing.plaf.ColorUIResource [UI]
+TabbedPane.highlight           #232324  HSL 240   1  14    javax.swing.plaf.ColorUIResource [UI]
 TabbedPane.hoverColor          #303234  HSL 210   4  20    com.formdev.flatlaf.util.DerivedColor [UI]    darken(5%)
 TabbedPane.labelShift          1
-TabbedPane.light               #313131  HSL   0   0  19    javax.swing.plaf.ColorUIResource [UI]
+TabbedPane.light               #2f3031  HSL 210   2  19    javax.swing.plaf.ColorUIResource [UI]
 TabbedPane.scrollButtonsPlacement both
 TabbedPane.scrollButtonsPolicy asNeededSingle
 TabbedPane.selectedLabelShift  -1
@@ -1060,7 +1060,7 @@ TabbedPaneUI                   com.formdev.flatlaf.ui.FlatTabbedPaneUI
 #---- Table ----
 
 Table.ascendingSortIcon        [lazy] 10,5    com.formdev.flatlaf.icons.FlatAscendingSortIcon [UI]
-Table.background               #45494a  HSL 192   3  28    javax.swing.plaf.ColorUIResource [UI]
+Table.background               #46494b  HSL 204   3  28    javax.swing.plaf.ColorUIResource [UI]
 Table.cellFocusColor           #000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]
 Table.cellMargins              2,3,2,3    javax.swing.plaf.InsetsUIResource [UI]
 Table.cellNoFocusBorder        [lazy] 2,3,2,3  false    com.formdev.flatlaf.ui.FlatTableCellBorder$Default [UI]    lineColor=#000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]    lineThickness=1.000000
@@ -1070,13 +1070,13 @@ Table.dropCellBackground       [lazy] #3c588b  HSL 219  40  39    javax.swing.pl
 Table.dropCellForeground       [lazy] #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
 Table.dropLineColor            [lazy] #6d8ac0  HSL 219  40  59    javax.swing.plaf.ColorUIResource [UI]
 Table.dropLineShortColor       [lazy] #b4c3df  HSL 219  40  79    javax.swing.plaf.ColorUIResource [UI]
-Table.focusCellBackground      #45494a  HSL 192   3  28    javax.swing.plaf.ColorUIResource [UI]
+Table.focusCellBackground      #46494b  HSL 204   3  28    javax.swing.plaf.ColorUIResource [UI]
 Table.focusCellForeground      #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
 Table.focusCellHighlightBorder [lazy] 2,3,2,3  false    com.formdev.flatlaf.ui.FlatTableCellBorder$Focused [UI]    lineColor=#000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]    lineThickness=1.000000
 Table.focusSelectedCellHighlightBorder [lazy] 2,3,2,3  false    com.formdev.flatlaf.ui.FlatTableCellBorder$Selected [UI]    lineColor=#000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]    lineThickness=1.000000
 Table.font                     [active] $defaultFont [UI]
 Table.foreground               #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
-Table.gridColor                #515657  HSL 190   4  33    javax.swing.plaf.ColorUIResource [UI]
+Table.gridColor                #525658  HSL 200   4  33    javax.swing.plaf.ColorUIResource [UI]
 Table.intercellSpacing         0,0    javax.swing.plaf.DimensionUIResource [UI]
 Table.rowHeight                20
 Table.scrollPaneBorder         [lazy] 1,1,1,1  false    com.formdev.flatlaf.ui.FlatBorder [UI]
@@ -1087,20 +1087,20 @@ Table.selectionInactiveForeground #bbbbbb  HSL   0   0  73    javax.swing.plaf.C
 Table.showHorizontalLines      false
 Table.showTrailingVerticalLine false
 Table.showVerticalLines        false
-Table.sortIconColor            #adadad  HSL   0   0  68    javax.swing.plaf.ColorUIResource [UI]
+Table.sortIconColor            #aeaeae  HSL   0   0  68    javax.swing.plaf.ColorUIResource [UI]
 
 
 #---- TableHeader ----
 
-TableHeader.background         #45494a  HSL 192   3  28    javax.swing.plaf.ColorUIResource [UI]
-TableHeader.bottomSeparatorColor #5e6364  HSL 190   3  38    javax.swing.plaf.ColorUIResource [UI]
+TableHeader.background         #46494b  HSL 204   3  28    javax.swing.plaf.ColorUIResource [UI]
+TableHeader.bottomSeparatorColor #5f6365  HSL 200   3  38    javax.swing.plaf.ColorUIResource [UI]
 TableHeader.cellBorder         [lazy] 2,3,2,3  false    com.formdev.flatlaf.ui.FlatTableHeaderBorder [UI]
 TableHeader.cellMargins        2,3,2,3    javax.swing.plaf.InsetsUIResource [UI]
-TableHeader.focusCellBackground #45494a  HSL 192   3  28    javax.swing.plaf.ColorUIResource [UI]
+TableHeader.focusCellBackground #46494b  HSL 204   3  28    javax.swing.plaf.ColorUIResource [UI]
 TableHeader.font               [active] $defaultFont [UI]
 TableHeader.foreground         #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
 TableHeader.height             25
-TableHeader.separatorColor     #5e6364  HSL 190   3  38    javax.swing.plaf.ColorUIResource [UI]
+TableHeader.separatorColor     #5f6365  HSL 200   3  38    javax.swing.plaf.ColorUIResource [UI]
 TableHeader.showTrailingVerticalLine false
 TableHeaderUI                  com.formdev.flatlaf.ui.FlatTableHeaderUI
 
@@ -1113,7 +1113,7 @@ TableUI                        com.formdev.flatlaf.ui.FlatTableUI
 #---- TaskPane ----
 
 TaskPane.background            #3c3f41  HSL 204   4  25    javax.swing.plaf.ColorUIResource [UI]
-TaskPane.borderColor           #5e6263  HSL 192   3  38    javax.swing.plaf.ColorUIResource [UI]
+TaskPane.borderColor           #606263  HSL 200   2  38    javax.swing.plaf.ColorUIResource [UI]
 TaskPane.contentInsets         10,10,10,10    javax.swing.plaf.InsetsUIResource [UI]
 TaskPane.specialTitleBackground #afafaf  HSL   0   0  69    javax.swing.plaf.ColorUIResource [UI]
 TaskPane.specialTitleForeground #222222  HSL   0   0  13    javax.swing.plaf.ColorUIResource [UI]
@@ -1131,7 +1131,7 @@ TaskPaneContainer.border       [lazy] 10,10,10,10  false    com.formdev.flatlaf.
 
 #---- TextArea ----
 
-TextArea.background            #45494a  HSL 192   3  28    javax.swing.plaf.ColorUIResource [UI]
+TextArea.background            #46494b  HSL 204   3  28    javax.swing.plaf.ColorUIResource [UI]
 TextArea.border                [lazy] 0,0,0,0  false    com.formdev.flatlaf.ui.FlatMarginBorder [UI]
 TextArea.caretBlinkRate        500
 TextArea.caretForeground       #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
@@ -1139,7 +1139,7 @@ TextArea.disabledBackground    #3c3f41  HSL 204   4  25    javax.swing.plaf.Colo
 TextArea.font                  [active] $defaultFont [UI]
 TextArea.foreground            #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
 TextArea.inactiveBackground    #3c3f41  HSL 204   4  25    javax.swing.plaf.ColorUIResource [UI]
-TextArea.inactiveForeground    #888888  HSL   0   0  53    javax.swing.plaf.ColorUIResource [UI]
+TextArea.inactiveForeground    #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
 TextArea.margin                2,6,2,6    javax.swing.plaf.InsetsUIResource [UI]
 TextArea.selectionBackground   #4b6eaf  HSL 219  40  49    javax.swing.plaf.ColorUIResource [UI]
 TextArea.selectionForeground   #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
@@ -1155,30 +1155,30 @@ TextComponent.selectAllOnMouseClick false
 
 #---- TextField ----
 
-TextField.background           #45494a  HSL 192   3  28    javax.swing.plaf.ColorUIResource [UI]
+TextField.background           #46494b  HSL 204   3  28    javax.swing.plaf.ColorUIResource [UI]
 TextField.border               [lazy] 1,1,1,1  false    com.formdev.flatlaf.ui.FlatTextBorder [UI]
 TextField.caretBlinkRate       500
 TextField.caretForeground      #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
-TextField.darkShadow           #7e7e7e  HSL   0   0  49    javax.swing.plaf.ColorUIResource [UI]
+TextField.darkShadow           #7a7d7f  HSL 204   2  49    javax.swing.plaf.ColorUIResource [UI]
 TextField.disabledBackground   #3c3f41  HSL 204   4  25    javax.swing.plaf.ColorUIResource [UI]
 TextField.font                 [active] $defaultFont [UI]
 TextField.foreground           #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
-TextField.highlight            #242424  HSL   0   0  14    javax.swing.plaf.ColorUIResource [UI]
+TextField.highlight            #232324  HSL 240   1  14    javax.swing.plaf.ColorUIResource [UI]
 TextField.iconTextGap          4
 TextField.inactiveBackground   #3c3f41  HSL 204   4  25    javax.swing.plaf.ColorUIResource [UI]
-TextField.inactiveForeground   #888888  HSL   0   0  53    javax.swing.plaf.ColorUIResource [UI]
-TextField.light                #313131  HSL   0   0  19    javax.swing.plaf.ColorUIResource [UI]
+TextField.inactiveForeground   #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
+TextField.light                #2f3031  HSL 210   2  19    javax.swing.plaf.ColorUIResource [UI]
 TextField.margin               2,6,2,6    javax.swing.plaf.InsetsUIResource [UI]
-TextField.placeholderForeground #888888  HSL   0   0  53    javax.swing.plaf.ColorUIResource [UI]
+TextField.placeholderForeground #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
 TextField.selectionBackground  #4b6eaf  HSL 219  40  49    javax.swing.plaf.ColorUIResource [UI]
 TextField.selectionForeground  #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
-TextField.shadow               #646464  HSL   0   0  39    javax.swing.plaf.ColorUIResource [UI]
+TextField.shadow               #616365  HSL 210   2  39    javax.swing.plaf.ColorUIResource [UI]
 TextFieldUI                    com.formdev.flatlaf.ui.FlatTextFieldUI
 
 
 #---- TextPane ----
 
-TextPane.background            #45494a  HSL 192   3  28    javax.swing.plaf.ColorUIResource [UI]
+TextPane.background            #46494b  HSL 204   3  28    javax.swing.plaf.ColorUIResource [UI]
 TextPane.border                [lazy] 0,0,0,0  false    com.formdev.flatlaf.ui.FlatMarginBorder [UI]
 TextPane.caretBlinkRate        500
 TextPane.caretForeground       #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
@@ -1186,7 +1186,7 @@ TextPane.disabledBackground    #3c3f41  HSL 204   4  25    javax.swing.plaf.Colo
 TextPane.font                  [active] $defaultFont [UI]
 TextPane.foreground            #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
 TextPane.inactiveBackground    #3c3f41  HSL 204   4  25    javax.swing.plaf.ColorUIResource [UI]
-TextPane.inactiveForeground    #888888  HSL   0   0  53    javax.swing.plaf.ColorUIResource [UI]
+TextPane.inactiveForeground    #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
 TextPane.margin                2,6,2,6    javax.swing.plaf.InsetsUIResource [UI]
 TextPane.selectionBackground   #4b6eaf  HSL 219  40  49    javax.swing.plaf.ColorUIResource [UI]
 TextPane.selectionForeground   #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
@@ -1214,7 +1214,7 @@ TitlePane.iconMargins          3,8,3,8    javax.swing.plaf.InsetsUIResource [UI]
 TitlePane.iconSize             16,16    javax.swing.plaf.DimensionUIResource [UI]
 TitlePane.iconifyIcon          [lazy] 44,30    com.formdev.flatlaf.icons.FlatWindowIconifyIcon [UI]
 TitlePane.inactiveBackground   #303234  HSL 210   4  20    javax.swing.plaf.ColorUIResource [UI]
-TitlePane.inactiveForeground   #888888  HSL   0   0  53    javax.swing.plaf.ColorUIResource [UI]
+TitlePane.inactiveForeground   #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
 TitlePane.maximizeIcon         [lazy] 44,30    com.formdev.flatlaf.icons.FlatWindowMaximizeIcon [UI]
 TitlePane.menuBarEmbedded      true
 TitlePane.menuBarTitleGap      20
@@ -1226,7 +1226,7 @@ TitlePane.useWindowDecorations true
 
 #---- TitledBorder ----
 
-TitledBorder.border            [lazy] 1,1,1,1  false    com.formdev.flatlaf.ui.FlatLineBorder [UI]    lineColor=#515151  HSL   0   0  32    javax.swing.plaf.ColorUIResource [UI]    lineThickness=1.000000
+TitledBorder.border            [lazy] 1,1,1,1  false    com.formdev.flatlaf.ui.FlatLineBorder [UI]    lineColor=#505254  HSL 210   2  32    javax.swing.plaf.ColorUIResource [UI]    lineThickness=1.000000
 TitledBorder.font              [active] $defaultFont [UI]
 TitledBorder.titleColor        #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
 
@@ -1238,33 +1238,33 @@ TitledPanelUI                  com.formdev.flatlaf.swingx.ui.FlatTitledPanelUI
 
 #---- ToggleButton ----
 
-ToggleButton.background        #4c5052  HSL 200   4  31    javax.swing.plaf.ColorUIResource [UI]
+ToggleButton.background        #4e5052  HSL 210   2  31    javax.swing.plaf.ColorUIResource [UI]
 ToggleButton.border            [lazy] 1,1,1,1  false    com.formdev.flatlaf.ui.FlatButtonBorder [UI]
-ToggleButton.darkShadow        #7e7e7e  HSL   0   0  49    javax.swing.plaf.ColorUIResource [UI]
+ToggleButton.darkShadow        #7a7d7f  HSL 204   2  49    javax.swing.plaf.ColorUIResource [UI]
 ToggleButton.disabledBackground #3c3f41  HSL 204   4  25    javax.swing.plaf.ColorUIResource [UI]
-ToggleButton.disabledSelectedBackground #53585a  HSL 197   4  34    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(3% autoInverse)
-ToggleButton.disabledText      #888888  HSL   0   0  53    javax.swing.plaf.ColorUIResource [UI]
+ToggleButton.disabledSelectedBackground #55585a  HSL 204   3  34    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(3% autoInverse)
+ToggleButton.disabledText      #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
 ToggleButton.font              [active] $defaultFont [UI]
 ToggleButton.foreground        #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
-ToggleButton.highlight         #242424  HSL   0   0  14    javax.swing.plaf.ColorUIResource [UI]
+ToggleButton.highlight         #232324  HSL 240   1  14    javax.swing.plaf.ColorUIResource [UI]
 ToggleButton.iconTextGap       4
-ToggleButton.light             #313131  HSL   0   0  19    javax.swing.plaf.ColorUIResource [UI]
+ToggleButton.light             #2f3031  HSL 210   2  19    javax.swing.plaf.ColorUIResource [UI]
 ToggleButton.margin            2,14,2,14    javax.swing.plaf.InsetsUIResource [UI]
-ToggleButton.pressedBackground #5b5f62  HSL 206   4  37    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(6% autoInverse)
+ToggleButton.pressedBackground #5d5f62  HSL 216   3  37    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(6% autoInverse)
 ToggleButton.rollover          true
-ToggleButton.selectedBackground #656a6c  HSL 197   3  41    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(10% autoInverse)
+ToggleButton.selectedBackground #676a6c  HSL 204   2  41    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(10% autoInverse)
 ToggleButton.selectedForeground #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
-ToggleButton.shadow            #646464  HSL   0   0  39    javax.swing.plaf.ColorUIResource [UI]
-ToggleButton.tab.disabledUnderlineColor #7a7a7a  HSL   0   0  48    javax.swing.plaf.ColorUIResource [UI]
+ToggleButton.shadow            #616365  HSL 210   2  39    javax.swing.plaf.ColorUIResource [UI]
+ToggleButton.tab.disabledUnderlineColor #747a7e  HSL 204   4  47    javax.swing.plaf.ColorUIResource [UI]
 ToggleButton.tab.focusBackground #404b5d  HSL 217  18  31    javax.swing.plaf.ColorUIResource [UI]
 ToggleButton.tab.hoverBackground #303234  HSL 210   4  20    com.formdev.flatlaf.util.DerivedColor [UI]    darken(5%)
 ToggleButton.tab.underlineColor #4c87c8  HSL 211  53  54    javax.swing.plaf.ColorUIResource [UI]
 ToggleButton.tab.underlineHeight 2
 ToggleButton.textIconGap       4
 ToggleButton.textShiftOffset   0
-ToggleButton.toolbar.hoverBackground #4e5355  HSL 197   4  32    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(1% autoInverse)
-ToggleButton.toolbar.pressedBackground #565a5d  HSL 206   4  35    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(4% autoInverse)
-ToggleButton.toolbar.selectedBackground #5d6265  HSL 203   4  38    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(7% autoInverse)
+ToggleButton.toolbar.hoverBackground #505355  HSL 204   3  32    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(1% autoInverse)
+ToggleButton.toolbar.pressedBackground #585a5c  HSL 210   2  35    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(4% autoInverse)
+ToggleButton.toolbar.selectedBackground #5f6264  HSL 204   3  38    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(7% autoInverse)
 ToggleButtonUI                 com.formdev.flatlaf.ui.FlatToggleButtonUI
 
 
@@ -1273,21 +1273,21 @@ ToggleButtonUI                 com.formdev.flatlaf.ui.FlatToggleButtonUI
 ToolBar.background             #3c3f41  HSL 204   4  25    javax.swing.plaf.ColorUIResource [UI]
 ToolBar.border                 [lazy] 2,2,2,2  false    com.formdev.flatlaf.ui.FlatToolBarBorder [UI]
 ToolBar.borderMargins          2,2,2,2    javax.swing.plaf.InsetsUIResource [UI]
-ToolBar.darkShadow             #7e7e7e  HSL   0   0  49    javax.swing.plaf.ColorUIResource [UI]
-ToolBar.dockingBackground      #3c3f41  HSL 204   4  25    javax.swing.plaf.ColorUIResource [UI]
-ToolBar.dockingForeground      #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+ToolBar.darkShadow             #7a7d7f  HSL 204   2  49    javax.swing.plaf.ColorUIResource [UI]
+ToolBar.dockingBackground      #303234  HSL 210   4  20    javax.swing.plaf.ColorUIResource [UI]
+ToolBar.dockingForeground      #616365  HSL 210   2  39    javax.swing.plaf.ColorUIResource [UI]
 ToolBar.floatingBackground     #3c3f41  HSL 204   4  25    javax.swing.plaf.ColorUIResource [UI]
-ToolBar.floatingForeground     #888888  HSL   0   0  53    javax.swing.plaf.ColorUIResource [UI]
+ToolBar.floatingForeground     #616365  HSL 210   2  39    javax.swing.plaf.ColorUIResource [UI]
 ToolBar.focusableButtons       false
 ToolBar.font                   [active] $defaultFont [UI]
 ToolBar.foreground             #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
-ToolBar.gripColor              #adadad  HSL   0   0  68    javax.swing.plaf.ColorUIResource [UI]
-ToolBar.highlight              #242424  HSL   0   0  14    javax.swing.plaf.ColorUIResource [UI]
+ToolBar.gripColor              #aeaeae  HSL   0   0  68    javax.swing.plaf.ColorUIResource [UI]
+ToolBar.highlight              #232324  HSL 240   1  14    javax.swing.plaf.ColorUIResource [UI]
 ToolBar.isRollover             true
-ToolBar.light                  #313131  HSL   0   0  19    javax.swing.plaf.ColorUIResource [UI]
-ToolBar.separatorColor         #515151  HSL   0   0  32    javax.swing.plaf.ColorUIResource [UI]
+ToolBar.light                  #2f3031  HSL 210   2  19    javax.swing.plaf.ColorUIResource [UI]
+ToolBar.separatorColor         #505254  HSL 210   2  32    javax.swing.plaf.ColorUIResource [UI]
 ToolBar.separatorWidth         7
-ToolBar.shadow                 #646464  HSL   0   0  39    javax.swing.plaf.ColorUIResource [UI]
+ToolBar.shadow                 #616365  HSL 210   2  39    javax.swing.plaf.ColorUIResource [UI]
 ToolBar.spacingBorder          [lazy] 1,2,1,2  false    com.formdev.flatlaf.ui.FlatEmptyBorder [UI]
 
 
@@ -1303,7 +1303,7 @@ ToolBarUI                      com.formdev.flatlaf.ui.FlatToolBarUI
 
 #---- ToolTip ----
 
-ToolTip.background             #1e2123  HSL 204   8  13    javax.swing.plaf.ColorUIResource [UI]
+ToolTip.background             #1e2021  HSL 200   5  12    javax.swing.plaf.ColorUIResource [UI]
 ToolTip.border                 [lazy] 4,6,4,6  false    com.formdev.flatlaf.ui.FlatEmptyBorder [UI]
 ToolTip.font                   [active] $defaultFont [UI]
 ToolTip.foreground             #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
@@ -1321,7 +1321,7 @@ ToolTipUI                      com.formdev.flatlaf.ui.FlatToolTipUI
 
 #---- Tree ----
 
-Tree.background                #45494a  HSL 192   3  28    javax.swing.plaf.ColorUIResource [UI]
+Tree.background                #46494b  HSL 204   3  28    javax.swing.plaf.ColorUIResource [UI]
 Tree.border                    [lazy] 1,1,1,1  false    com.formdev.flatlaf.ui.FlatEmptyBorder [UI]
 Tree.changeSelectionWithFocus  true
 Tree.closedIcon                [lazy] 16,16    com.formdev.flatlaf.icons.FlatTreeClosedIcon [UI]
@@ -1334,12 +1334,12 @@ Tree.editorBorder              [lazy] 1,1,1,1  false    com.formdev.flatlaf.ui.F
 Tree.expandedIcon              [lazy] 11,11    com.formdev.flatlaf.icons.FlatTreeExpandedIcon [UI]
 Tree.font                      [active] $defaultFont [UI]
 Tree.foreground                #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
-Tree.hash                      #515657  HSL 190   4  33    javax.swing.plaf.ColorUIResource [UI]
-Tree.icon.closedColor          #adadad  HSL   0   0  68    javax.swing.plaf.ColorUIResource [UI]
-Tree.icon.collapsedColor       #adadad  HSL   0   0  68    javax.swing.plaf.ColorUIResource [UI]
-Tree.icon.expandedColor        #adadad  HSL   0   0  68    javax.swing.plaf.ColorUIResource [UI]
-Tree.icon.leafColor            #adadad  HSL   0   0  68    javax.swing.plaf.ColorUIResource [UI]
-Tree.icon.openColor            #adadad  HSL   0   0  68    javax.swing.plaf.ColorUIResource [UI]
+Tree.hash                      #525658  HSL 200   4  33    javax.swing.plaf.ColorUIResource [UI]
+Tree.icon.closedColor          #aeaeae  HSL   0   0  68    javax.swing.plaf.ColorUIResource [UI]
+Tree.icon.collapsedColor       #aeaeae  HSL   0   0  68    javax.swing.plaf.ColorUIResource [UI]
+Tree.icon.expandedColor        #aeaeae  HSL   0   0  68    javax.swing.plaf.ColorUIResource [UI]
+Tree.icon.leafColor            #aeaeae  HSL   0   0  68    javax.swing.plaf.ColorUIResource [UI]
+Tree.icon.openColor            #aeaeae  HSL   0   0  68    javax.swing.plaf.ColorUIResource [UI]
 Tree.leafIcon                  [lazy] 16,16    com.formdev.flatlaf.icons.FlatTreeLeafIcon [UI]
 Tree.leftChildIndent           7
 Tree.lineTypeDashed            false
@@ -1357,7 +1357,7 @@ Tree.selectionForeground       #bbbbbb  HSL   0   0  73    javax.swing.plaf.Colo
 Tree.selectionInactiveBackground #0f2a3d  HSL 205  61  15    javax.swing.plaf.ColorUIResource [UI]
 Tree.selectionInactiveForeground #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
 Tree.showCellFocusIndicator    false
-Tree.textBackground            #45494a  HSL 192   3  28    javax.swing.plaf.ColorUIResource [UI]
+Tree.textBackground            #46494b  HSL 204   3  28    javax.swing.plaf.ColorUIResource [UI]
 Tree.textForeground            #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
 Tree.timeFactor                1000
 Tree.wideSelection             true
@@ -1376,7 +1376,7 @@ TristateCheckBox.setMixed.clientProperty length=2    [Ljava.lang.Object;
 
 #---- UIColorHighlighter ----
 
-UIColorHighlighter.stripingBackground #515657  HSL 190   4  33    javax.swing.plaf.ColorUIResource [UI]
+UIColorHighlighter.stripingBackground #525658  HSL 200   4  33    javax.swing.plaf.ColorUIResource [UI]
 
 
 #---- Viewport ----
@@ -1393,13 +1393,13 @@ activeCaption                  #434e60  HSL 217  18  32    javax.swing.plaf.Colo
 activeCaptionBorder            #434e60  HSL 217  18  32    javax.swing.plaf.ColorUIResource [UI]
 activeCaptionText              #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
 control                        #3c3f41  HSL 204   4  25    javax.swing.plaf.ColorUIResource [UI]
-controlDkShadow                #7e7e7e  HSL   0   0  49    javax.swing.plaf.ColorUIResource [UI]
-controlHighlight               #313131  HSL   0   0  19    javax.swing.plaf.ColorUIResource [UI]
-controlLtHighlight             #242424  HSL   0   0  14    javax.swing.plaf.ColorUIResource [UI]
-controlShadow                  #646464  HSL   0   0  39    javax.swing.plaf.ColorUIResource [UI]
+controlDkShadow                #7a7d7f  HSL 204   2  49    javax.swing.plaf.ColorUIResource [UI]
+controlHighlight               #2f3031  HSL 210   2  19    javax.swing.plaf.ColorUIResource [UI]
+controlLtHighlight             #232324  HSL 240   1  14    javax.swing.plaf.ColorUIResource [UI]
+controlShadow                  #616365  HSL 210   2  39    javax.swing.plaf.ColorUIResource [UI]
 controlText                    #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
 defaultFont                    Segoe UI plain 12    javax.swing.plaf.FontUIResource [UI]
-desktop                        #45494a  HSL 192   3  28    javax.swing.plaf.ColorUIResource [UI]
+desktop                        #46494b  HSL 204   3  28    javax.swing.plaf.ColorUIResource [UI]
 
 
 #---- html ----
@@ -1413,7 +1413,7 @@ html.pendingImage              [lazy] 38,38    sun.swing.ImageIconUIResource [UI
 inactiveCaption                #393c3d  HSL 195   3  23    javax.swing.plaf.ColorUIResource [UI]
 inactiveCaptionBorder          #393c3d  HSL 195   3  23    javax.swing.plaf.ColorUIResource [UI]
 inactiveCaptionText            #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
-info                           #1e2123  HSL 204   8  13    javax.swing.plaf.ColorUIResource [UI]
+info                           #1e2021  HSL 200   5  12    javax.swing.plaf.ColorUIResource [UI]
 infoText                       #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
 
 
@@ -1437,10 +1437,10 @@ swingx/TaskPaneUI              com.formdev.flatlaf.swingx.ui.FlatTaskPaneUI
 
 #----  ----
 
-text                           #45494a  HSL 192   3  28    javax.swing.plaf.ColorUIResource [UI]
+text                           #46494b  HSL 204   3  28    javax.swing.plaf.ColorUIResource [UI]
 textHighlight                  #4b6eaf  HSL 219  40  49    javax.swing.plaf.ColorUIResource [UI]
 textHighlightText              #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
-textInactiveText               #888888  HSL   0   0  53    javax.swing.plaf.ColorUIResource [UI]
+textInactiveText               #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
 textText                       #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
 window                         #3c3f41  HSL 204   4  25    javax.swing.plaf.ColorUIResource [UI]
 windowBorder                   #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]

--- a/flatlaf-testing/dumps/uidefaults/FlatDarkLaf_1.8.0_202.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatDarkLaf_1.8.0_202.txt
@@ -161,6 +161,8 @@ CheckBoxMenuItem.checkIcon     [lazy] 15,15    com.formdev.flatlaf.icons.FlatChe
 CheckBoxMenuItem.disabledForeground #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
 CheckBoxMenuItem.font          [active] $defaultFont [UI]
 CheckBoxMenuItem.foreground    #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+CheckBoxMenuItem.icon.checkmarkColor #9b9b9b  HSL   0   0  61    javax.swing.plaf.ColorUIResource [UI]
+CheckBoxMenuItem.icon.disabledCheckmarkColor #5b5b5b  HSL   0   0  36    javax.swing.plaf.ColorUIResource [UI]
 CheckBoxMenuItem.margin        3,6,3,6    javax.swing.plaf.InsetsUIResource [UI]
 CheckBoxMenuItem.opaque        false
 CheckBoxMenuItem.selectionBackground #4b6eaf  HSL 219  40  49    javax.swing.plaf.ColorUIResource [UI]
@@ -617,16 +619,6 @@ MenuItem.underlineSelectionBackground #484c4f  HSL 206   5  30    com.formdev.fl
 MenuItem.underlineSelectionCheckBackground #3c588b  HSL 219  40  39    com.formdev.flatlaf.util.DerivedColor [UI]    darken(10%)
 MenuItem.underlineSelectionColor #4c87c8  HSL 211  53  54    javax.swing.plaf.ColorUIResource [UI]
 MenuItem.underlineSelectionHeight 3
-
-
-#---- MenuItemCheckBox ----
-
-MenuItemCheckBox.icon.checkmarkColor #9b9b9b  HSL   0   0  61    javax.swing.plaf.ColorUIResource [UI]
-MenuItemCheckBox.icon.disabledCheckmarkColor #5b5b5b  HSL   0   0  36    javax.swing.plaf.ColorUIResource [UI]
-
-
-#---- MenuItem ----
-
 MenuItemUI                     com.formdev.flatlaf.ui.FlatMenuItemUI
 
 

--- a/flatlaf-testing/dumps/uidefaults/FlatLightLaf_1.8.0_202.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatLightLaf_1.8.0_202.txt
@@ -165,6 +165,8 @@ CheckBoxMenuItem.checkIcon     [lazy] 15,15    com.formdev.flatlaf.icons.FlatChe
 CheckBoxMenuItem.disabledForeground #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
 CheckBoxMenuItem.font          [active] $defaultFont [UI]
 CheckBoxMenuItem.foreground    #000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]
+CheckBoxMenuItem.icon.checkmarkColor #4e9de7  HSL 209  76  61    javax.swing.plaf.ColorUIResource [UI]
+CheckBoxMenuItem.icon.disabledCheckmarkColor #a6a6a6  HSL   0   0  65    javax.swing.plaf.ColorUIResource [UI]
 CheckBoxMenuItem.margin        3,6,3,6    javax.swing.plaf.InsetsUIResource [UI]
 CheckBoxMenuItem.opaque        false
 CheckBoxMenuItem.selectionBackground #2675bf  HSL 209  67  45    javax.swing.plaf.ColorUIResource [UI]
@@ -622,16 +624,6 @@ MenuItem.underlineSelectionBackground #e6e6e6  HSL   0   0  90    com.formdev.fl
 MenuItem.underlineSelectionCheckBackground #bfd9f2  HSL 209  66  85    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(40%)
 MenuItem.underlineSelectionColor #3c83c5  HSL 209  54  50    javax.swing.plaf.ColorUIResource [UI]
 MenuItem.underlineSelectionHeight 3
-
-
-#---- MenuItemCheckBox ----
-
-MenuItemCheckBox.icon.checkmarkColor #4e9de7  HSL 209  76  61    javax.swing.plaf.ColorUIResource [UI]
-MenuItemCheckBox.icon.disabledCheckmarkColor #a6a6a6  HSL   0   0  65    javax.swing.plaf.ColorUIResource [UI]
-
-
-#---- MenuItem ----
-
 MenuItemUI                     com.formdev.flatlaf.ui.FlatMenuItemUI
 
 

--- a/flatlaf-testing/dumps/uidefaults/FlatLightLaf_1.8.0_202.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatLightLaf_1.8.0_202.txt
@@ -64,9 +64,9 @@ BusyLabelUI                    com.formdev.flatlaf.swingx.ui.FlatBusyLabelUI
 Button.arc                     6
 Button.background              #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
 Button.border                  [lazy] 1,1,1,1  false    com.formdev.flatlaf.ui.FlatButtonBorder [UI]
-Button.borderColor             #c4c4c4  HSL   0   0  77    javax.swing.plaf.ColorUIResource [UI]
+Button.borderColor             #c2c2c2  HSL   0   0  76    javax.swing.plaf.ColorUIResource [UI]
 Button.borderWidth             1
-Button.darkShadow              #9e9e9e  HSL   0   0  62    javax.swing.plaf.ColorUIResource [UI]
+Button.darkShadow              #9c9c9c  HSL   0   0  61    javax.swing.plaf.ColorUIResource [UI]
 Button.default.background      #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
 Button.default.borderColor     #4e9de7  HSL 209  76  61    javax.swing.plaf.ColorUIResource [UI]
 Button.default.borderWidth     2
@@ -92,14 +92,14 @@ Button.hoverBackground         #f7f7f7  HSL   0   0  97    com.formdev.flatlaf.u
 Button.hoverBorderColor        #89b0d4  HSL 209  47  68    javax.swing.plaf.ColorUIResource [UI]
 Button.iconTextGap             4
 Button.innerFocusWidth         0
-Button.light                   #e3e3e3  HSL   0   0  89    javax.swing.plaf.ColorUIResource [UI]
+Button.light                   #e1e1e1  HSL   0   0  88    javax.swing.plaf.ColorUIResource [UI]
 Button.margin                  2,14,2,14    javax.swing.plaf.InsetsUIResource [UI]
 Button.minimumWidth            72
 Button.pressedBackground       #e6e6e6  HSL   0   0  90    com.formdev.flatlaf.util.DerivedColor [UI]    darken(10% autoInverse)
 Button.rollover                true
 Button.selectedBackground      #cccccc  HSL   0   0  80    com.formdev.flatlaf.util.DerivedColor [UI]    darken(20% autoInverse)
 Button.selectedForeground      #000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]
-Button.shadow                  #c4c4c4  HSL   0   0  77    javax.swing.plaf.ColorUIResource [UI]
+Button.shadow                  #c2c2c2  HSL   0   0  76    javax.swing.plaf.ColorUIResource [UI]
 Button.textIconGap             4
 Button.textShiftOffset         0
 Button.toolbar.hoverBackground #e0e0e0  HSL   0   0  88    com.formdev.flatlaf.util.DerivedColor [UI]    darken(12% autoInverse)
@@ -124,18 +124,18 @@ CheckBox.disabledText          #8c8c8c  HSL   0   0  55    javax.swing.plaf.Colo
 CheckBox.font                  [active] $defaultFont [UI]
 CheckBox.foreground            #000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]
 CheckBox.icon.background       #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
-CheckBox.icon.borderColor      #b0b0b0  HSL   0   0  69    javax.swing.plaf.ColorUIResource [UI]
+CheckBox.icon.borderColor      #afafaf  HSL   0   0  69    javax.swing.plaf.ColorUIResource [UI]
 CheckBox.icon.checkmarkColor   #4e9de7  HSL 209  76  61    javax.swing.plaf.ColorUIResource [UI]
 CheckBox.icon.disabledBackground #f2f2f2  HSL   0   0  95    javax.swing.plaf.ColorUIResource [UI]
-CheckBox.icon.disabledBorderColor #bdbdbd  HSL   0   0  74    javax.swing.plaf.ColorUIResource [UI]
-CheckBox.icon.disabledCheckmarkColor #ababab  HSL   0   0  67    javax.swing.plaf.ColorUIResource [UI]
+CheckBox.icon.disabledBorderColor #bfbfbf  HSL   0   0  75    javax.swing.plaf.ColorUIResource [UI]
+CheckBox.icon.disabledCheckmarkColor #a9a9a9  HSL   0   0  66    javax.swing.plaf.ColorUIResource [UI]
 CheckBox.icon.focusedBackground #eaf3fb  HSL 208  68  95    javax.swing.plaf.ColorUIResource [UI]
 CheckBox.icon.focusedBorderColor #7b9ebf  HSL 209  35  62    javax.swing.plaf.ColorUIResource [UI]
 CheckBox.icon.hoverBackground  #f7f7f7  HSL   0   0  97    com.formdev.flatlaf.util.DerivedColor [UI]    darken(3% autoInverse)
 CheckBox.icon.hoverBorderColor #7b9ebf  HSL 209  35  62    javax.swing.plaf.ColorUIResource [UI]
 CheckBox.icon.pressedBackground #e6e6e6  HSL   0   0  90    com.formdev.flatlaf.util.DerivedColor [UI]    darken(10% autoInverse)
 CheckBox.icon.selectedBackground #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
-CheckBox.icon.selectedBorderColor #b0b0b0  HSL   0   0  69    javax.swing.plaf.ColorUIResource [UI]
+CheckBox.icon.selectedBorderColor #afafaf  HSL   0   0  69    javax.swing.plaf.ColorUIResource [UI]
 CheckBox.icon                  [lazy] 15,15    com.formdev.flatlaf.icons.FlatCheckBoxIcon [UI]
 CheckBox.iconTextGap           4
 CheckBox.icon[filled].checkmarkColor #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
@@ -194,15 +194,15 @@ ComboBox.background            #ffffff  HSL   0   0 100    javax.swing.plaf.Colo
 ComboBox.border                [lazy] 1,1,1,1  false    com.formdev.flatlaf.ui.FlatRoundBorder [UI]
 ComboBox.buttonArrowColor      #666666  HSL   0   0  40    javax.swing.plaf.ColorUIResource [UI]
 ComboBox.buttonBackground      #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
-ComboBox.buttonDarkShadow      #9e9e9e  HSL   0   0  62    javax.swing.plaf.ColorUIResource [UI]
+ComboBox.buttonDarkShadow      #9c9c9c  HSL   0   0  61    javax.swing.plaf.ColorUIResource [UI]
 ComboBox.buttonDisabledArrowColor #a6a6a6  HSL   0   0  65    javax.swing.plaf.ColorUIResource [UI]
 ComboBox.buttonDisabledSeparatorColor #cecece  HSL   0   0  81    javax.swing.plaf.ColorUIResource [UI]
 ComboBox.buttonEditableBackground #fafafa  HSL   0   0  98    javax.swing.plaf.ColorUIResource [UI]
 ComboBox.buttonHighlight       #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
 ComboBox.buttonHoverArrowColor #999999  HSL   0   0  60    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(20%)
 ComboBox.buttonPressedArrowColor #b3b3b3  HSL   0   0  70    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(30%)
-ComboBox.buttonSeparatorColor  #c4c4c4  HSL   0   0  77    javax.swing.plaf.ColorUIResource [UI]
-ComboBox.buttonShadow          #c4c4c4  HSL   0   0  77    javax.swing.plaf.ColorUIResource [UI]
+ComboBox.buttonSeparatorColor  #c2c2c2  HSL   0   0  76    javax.swing.plaf.ColorUIResource [UI]
+ComboBox.buttonShadow          #c2c2c2  HSL   0   0  76    javax.swing.plaf.ColorUIResource [UI]
 ComboBox.buttonStyle           auto
 ComboBox.disabledBackground    #f2f2f2  HSL   0   0  95    javax.swing.plaf.ColorUIResource [UI]
 ComboBox.disabledForeground    #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
@@ -225,7 +225,7 @@ ComboBoxUI                     com.formdev.flatlaf.ui.FlatComboBoxUI
 Component.accentColor          #2675bf  HSL 209  67  45    javax.swing.plaf.ColorUIResource [UI]
 Component.arc                  5
 Component.arrowType            chevron
-Component.borderColor          #c4c4c4  HSL   0   0  77    javax.swing.plaf.ColorUIResource [UI]
+Component.borderColor          #c2c2c2  HSL   0   0  76    javax.swing.plaf.ColorUIResource [UI]
 Component.custom.borderColor   #f38d8d  HSL   0  81  75    com.formdev.flatlaf.util.DerivedColor [UI]    desaturate(20%) lighten(25%)
 Component.disabledBorderColor  #cecece  HSL   0   0  81    javax.swing.plaf.ColorUIResource [UI]
 Component.error.borderColor    #ebb8bc  HSL 355  56  82    javax.swing.plaf.ColorUIResource [UI]
@@ -336,15 +336,15 @@ HeaderUI                       com.formdev.flatlaf.swingx.ui.FlatHeaderUI
 #---- HelpButton ----
 
 HelpButton.background          #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
-HelpButton.borderColor         #b0b0b0  HSL   0   0  69    javax.swing.plaf.ColorUIResource [UI]
+HelpButton.borderColor         #c2c2c2  HSL   0   0  76    javax.swing.plaf.ColorUIResource [UI]
 HelpButton.borderWidth         1
 HelpButton.disabledBackground  #f2f2f2  HSL   0   0  95    javax.swing.plaf.ColorUIResource [UI]
-HelpButton.disabledBorderColor #bdbdbd  HSL   0   0  74    javax.swing.plaf.ColorUIResource [UI]
-HelpButton.disabledQuestionMarkColor #ababab  HSL   0   0  67    javax.swing.plaf.ColorUIResource [UI]
+HelpButton.disabledBorderColor #cecece  HSL   0   0  81    javax.swing.plaf.ColorUIResource [UI]
+HelpButton.disabledQuestionMarkColor #a9a9a9  HSL   0   0  66    javax.swing.plaf.ColorUIResource [UI]
 HelpButton.focusedBackground   #eaf3fb  HSL 208  68  95    javax.swing.plaf.ColorUIResource [UI]
-HelpButton.focusedBorderColor  #7b9ebf  HSL 209  35  62    javax.swing.plaf.ColorUIResource [UI]
+HelpButton.focusedBorderColor  #89b0d4  HSL 209  47  68    javax.swing.plaf.ColorUIResource [UI]
 HelpButton.hoverBackground     #f7f7f7  HSL   0   0  97    com.formdev.flatlaf.util.DerivedColor [UI]    darken(3% autoInverse)
-HelpButton.hoverBorderColor    #7b9ebf  HSL 209  35  62    javax.swing.plaf.ColorUIResource [UI]
+HelpButton.hoverBorderColor    #89b0d4  HSL 209  47  68    javax.swing.plaf.ColorUIResource [UI]
 HelpButton.icon                [lazy] 22,22    com.formdev.flatlaf.icons.FlatHelpButtonIcon [UI]
 HelpButton.innerFocusWidth     0
 HelpButton.pressedBackground   #e6e6e6  HSL   0   0  90    com.formdev.flatlaf.util.DerivedColor [UI]    darken(10% autoInverse)
@@ -368,12 +368,12 @@ InternalFrame.activeTitleBackground #ffffff  HSL   0   0 100    javax.swing.plaf
 InternalFrame.activeTitleForeground #000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]
 InternalFrame.border           [lazy] 6,6,6,6  false    com.formdev.flatlaf.ui.FlatInternalFrameUI$FlatInternalFrameBorder [UI]
 InternalFrame.borderColor      #f2f2f2  HSL   0   0  95    javax.swing.plaf.ColorUIResource [UI]
-InternalFrame.borderDarkShadow #9e9e9e  HSL   0   0  62    javax.swing.plaf.ColorUIResource [UI]
+InternalFrame.borderDarkShadow #9c9c9c  HSL   0   0  61    javax.swing.plaf.ColorUIResource [UI]
 InternalFrame.borderHighlight  #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
-InternalFrame.borderLight      #e3e3e3  HSL   0   0  89    javax.swing.plaf.ColorUIResource [UI]
+InternalFrame.borderLight      #e1e1e1  HSL   0   0  88    javax.swing.plaf.ColorUIResource [UI]
 InternalFrame.borderLineWidth  1
 InternalFrame.borderMargins    6,6,6,6    javax.swing.plaf.InsetsUIResource [UI]
-InternalFrame.borderShadow     #c4c4c4  HSL   0   0  77    javax.swing.plaf.ColorUIResource [UI]
+InternalFrame.borderShadow     #c2c2c2  HSL   0   0  76    javax.swing.plaf.ColorUIResource [UI]
 InternalFrame.buttonHoverBackground #e6e6e6  HSL   0   0  90    com.formdev.flatlaf.util.DerivedColor [UI]    darken(10% autoInverse)
 InternalFrame.buttonPressedBackground #cccccc  HSL   0   0  80    com.formdev.flatlaf.util.DerivedColor [UI]    darken(20% autoInverse)
 InternalFrame.buttonSize       24,24    javax.swing.plaf.DimensionUIResource [UI]
@@ -385,7 +385,7 @@ InternalFrame.closePressedForeground #ffffff  HSL   0   0 100    javax.swing.pla
 InternalFrame.dropShadowPainted true
 InternalFrame.icon             [lazy] 16,16    sun.swing.ImageIconUIResource [UI]  (sun.awt.image.ToolkitImage)
 InternalFrame.iconifyIcon      [lazy] 24,24    com.formdev.flatlaf.icons.FlatInternalFrameIconifyIcon [UI]
-InternalFrame.inactiveBorderColor #c4c4c4  HSL   0   0  77    javax.swing.plaf.ColorUIResource [UI]
+InternalFrame.inactiveBorderColor #c2c2c2  HSL   0   0  76    javax.swing.plaf.ColorUIResource [UI]
 InternalFrame.inactiveDropShadowInsets 3,3,4,4    javax.swing.plaf.InsetsUIResource [UI]
 InternalFrame.inactiveDropShadowOpacity 0.5
 InternalFrame.inactiveTitleBackground #fafafa  HSL   0   0  98    javax.swing.plaf.ColorUIResource [UI]
@@ -445,7 +445,7 @@ JXMonthView.weekOfTheYearForeground #666666  HSL   0   0  40    javax.swing.plaf
 
 #---- JXTitledPanel ----
 
-JXTitledPanel.borderColor      #c4c4c4  HSL   0   0  77    javax.swing.plaf.ColorUIResource [UI]
+JXTitledPanel.borderColor      #c2c2c2  HSL   0   0  76    javax.swing.plaf.ColorUIResource [UI]
 JXTitledPanel.captionInsets    4,10,4,10    javax.swing.plaf.InsetsUIResource [UI]
 JXTitledPanel.titleBackground  #dfdfdf  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 JXTitledPanel.titleForeground  #222222  HSL   0   0  13    javax.swing.plaf.ColorUIResource [UI]
@@ -455,16 +455,16 @@ JXTitledPanel.titleForeground  #222222  HSL   0   0  13    javax.swing.plaf.Colo
 
 JideButton.background          #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
 JideButton.border              [lazy] 0,0,0,0  false    com.formdev.flatlaf.ui.FlatMarginBorder [UI]
-JideButton.borderColor         #c4c4c4  HSL   0   0  77    javax.swing.plaf.ColorUIResource [UI]
-JideButton.darkShadow          #c4c4c4  HSL   0   0  77    javax.swing.plaf.ColorUIResource [UI]
+JideButton.borderColor         #c2c2c2  HSL   0   0  76    javax.swing.plaf.ColorUIResource [UI]
+JideButton.darkShadow          #c2c2c2  HSL   0   0  76    javax.swing.plaf.ColorUIResource [UI]
 JideButton.focusedBackground   #e0e0e0  HSL   0   0  88    com.formdev.flatlaf.util.DerivedColor [UI]    darken(12% autoInverse)
 JideButton.foreground          #000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]
 JideButton.highlight           #cccccc  HSL   0   0  80    com.formdev.flatlaf.util.DerivedColor [UI]    darken(20% autoInverse)
-JideButton.light               #c4c4c4  HSL   0   0  77    javax.swing.plaf.ColorUIResource [UI]
+JideButton.light               #c2c2c2  HSL   0   0  76    javax.swing.plaf.ColorUIResource [UI]
 JideButton.margin              3,3,3,3    javax.swing.plaf.InsetsUIResource [UI]
 JideButton.selectedAndFocusedBackground #d9d9d9  HSL   0   0  85    com.formdev.flatlaf.util.DerivedColor [UI]    darken(15% autoInverse)
 JideButton.selectedBackground  #cccccc  HSL   0   0  80    com.formdev.flatlaf.util.DerivedColor [UI]    darken(20% autoInverse)
-JideButton.shadow              #c4c4c4  HSL   0   0  77    javax.swing.plaf.ColorUIResource [UI]
+JideButton.shadow              #c2c2c2  HSL   0   0  76    javax.swing.plaf.ColorUIResource [UI]
 JideButton.textIconGap         [active] 4
 JideButtonUI                   com.formdev.flatlaf.jideoss.ui.FlatJideButtonUI
 
@@ -516,7 +516,7 @@ JideTabbedPaneUI               com.formdev.flatlaf.jideoss.ui.FlatJideTabbedPane
 
 Label.background               #f2f2f2  HSL   0   0  95    javax.swing.plaf.ColorUIResource [UI]
 Label.disabledForeground       #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
-Label.disabledShadow           #c4c4c4  HSL   0   0  77    javax.swing.plaf.ColorUIResource [UI]
+Label.disabledShadow           #c2c2c2  HSL   0   0  76    javax.swing.plaf.ColorUIResource [UI]
 Label.font                     [active] $defaultFont [UI]
 Label.foreground               #000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]
 LabelUI                        com.formdev.flatlaf.ui.FlatLabelUI
@@ -540,7 +540,7 @@ List.foreground                #000000  HSL   0   0   0    javax.swing.plaf.Colo
 List.noFocusBorder             1,1,1,1  false    javax.swing.plaf.BorderUIResource$EmptyBorderUIResource [UI]
 List.selectionBackground       #2675bf  HSL 209  67  45    javax.swing.plaf.ColorUIResource [UI]
 List.selectionForeground       #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
-List.selectionInactiveBackground #d4d4d4  HSL   0   0  83    javax.swing.plaf.ColorUIResource [UI]
+List.selectionInactiveBackground #d3d3d3  HSL   0   0  83    javax.swing.plaf.ColorUIResource [UI]
 List.selectionInactiveForeground #000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]
 List.showCellFocusIndicator    false
 List.timeFactor                1000
@@ -562,7 +562,7 @@ Menu.disabledForeground        #8c8c8c  HSL   0   0  55    javax.swing.plaf.Colo
 Menu.font                      [active] $defaultFont [UI]
 Menu.foreground                #000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]
 Menu.icon.arrowColor           #666666  HSL   0   0  40    javax.swing.plaf.ColorUIResource [UI]
-Menu.icon.disabledArrowColor   #ababab  HSL   0   0  67    javax.swing.plaf.ColorUIResource [UI]
+Menu.icon.disabledArrowColor   #a6a6a6  HSL   0   0  65    javax.swing.plaf.ColorUIResource [UI]
 Menu.margin                    3,6,3,6    javax.swing.plaf.InsetsUIResource [UI]
 Menu.menuPopupOffsetX          0
 Menu.menuPopupOffsetY          0
@@ -580,13 +580,13 @@ Menu.submenuPopupOffsetY       [active] -4
 
 MenuBar.background             #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
 MenuBar.border                 [lazy] 0,0,1,0  false    com.formdev.flatlaf.ui.FlatMenuBarBorder [UI]
-MenuBar.borderColor            #cdcdcd  HSL   0   0  80    javax.swing.plaf.ColorUIResource [UI]
+MenuBar.borderColor            #cecece  HSL   0   0  81    javax.swing.plaf.ColorUIResource [UI]
 MenuBar.font                   [active] $defaultFont [UI]
 MenuBar.foreground             #000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]
 MenuBar.highlight              #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
 MenuBar.hoverBackground        #e6e6e6  HSL   0   0  90    com.formdev.flatlaf.util.DerivedColor [UI]    darken(10% autoInverse)
 MenuBar.itemMargins            3,8,3,8    javax.swing.plaf.InsetsUIResource [UI]
-MenuBar.shadow                 #c4c4c4  HSL   0   0  77    javax.swing.plaf.ColorUIResource [UI]
+MenuBar.shadow                 #c2c2c2  HSL   0   0  76    javax.swing.plaf.ColorUIResource [UI]
 MenuBar.windowBindings         length=2    [Ljava.lang.Object;
     [0] F10
     [1] takeFocus
@@ -627,7 +627,7 @@ MenuItem.underlineSelectionHeight 3
 #---- MenuItemCheckBox ----
 
 MenuItemCheckBox.icon.checkmarkColor #4e9de7  HSL 209  76  61    javax.swing.plaf.ColorUIResource [UI]
-MenuItemCheckBox.icon.disabledCheckmarkColor #ababab  HSL   0   0  67    javax.swing.plaf.ColorUIResource [UI]
+MenuItemCheckBox.icon.disabledCheckmarkColor #a6a6a6  HSL   0   0  65    javax.swing.plaf.ColorUIResource [UI]
 
 
 #---- MenuItem ----
@@ -730,8 +730,8 @@ Popup.dropShadowPainted        true
 #---- PopupMenu ----
 
 PopupMenu.background           #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
-PopupMenu.border               [lazy] 4,1,4,1  false    com.formdev.flatlaf.ui.FlatPopupMenuBorder [UI]    lineColor=#adadad  HSL   0   0  68    javax.swing.plaf.ColorUIResource [UI]    lineThickness=1.000000
-PopupMenu.borderColor          #adadad  HSL   0   0  68    javax.swing.plaf.ColorUIResource [UI]
+PopupMenu.border               [lazy] 4,1,4,1  false    com.formdev.flatlaf.ui.FlatPopupMenuBorder [UI]    lineColor=#aeaeae  HSL   0   0  68    javax.swing.plaf.ColorUIResource [UI]    lineThickness=1.000000
+PopupMenu.borderColor          #aeaeae  HSL   0   0  68    javax.swing.plaf.ColorUIResource [UI]
 PopupMenu.borderInsets         4,1,4,1    javax.swing.plaf.InsetsUIResource [UI]
 PopupMenu.consumeEventOnClose  false
 PopupMenu.font                 [active] $defaultFont [UI]
@@ -773,7 +773,7 @@ ProgressBarUI                  com.formdev.flatlaf.ui.FlatProgressBarUI
 
 RadioButton.background         #f2f2f2  HSL   0   0  95    javax.swing.plaf.ColorUIResource [UI]
 RadioButton.border             [lazy] 0,0,0,0  false    com.formdev.flatlaf.ui.FlatMarginBorder [UI]
-RadioButton.darkShadow         #9e9e9e  HSL   0   0  62    javax.swing.plaf.ColorUIResource [UI]
+RadioButton.darkShadow         #9c9c9c  HSL   0   0  61    javax.swing.plaf.ColorUIResource [UI]
 RadioButton.disabledText       #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
 RadioButton.font               [active] $defaultFont [UI]
 RadioButton.foreground         #000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]
@@ -782,10 +782,10 @@ RadioButton.icon.centerDiameter 8
 RadioButton.icon               [lazy] 15,15    com.formdev.flatlaf.icons.FlatRadioButtonIcon [UI]
 RadioButton.iconTextGap        4
 RadioButton.icon[filled].centerDiameter 5
-RadioButton.light              #e3e3e3  HSL   0   0  89    javax.swing.plaf.ColorUIResource [UI]
+RadioButton.light              #e1e1e1  HSL   0   0  88    javax.swing.plaf.ColorUIResource [UI]
 RadioButton.margin             2,2,2,2    javax.swing.plaf.InsetsUIResource [UI]
 RadioButton.rollover           true
-RadioButton.shadow             #c4c4c4  HSL   0   0  77    javax.swing.plaf.ColorUIResource [UI]
+RadioButton.shadow             #c2c2c2  HSL   0   0  76    javax.swing.plaf.ColorUIResource [UI]
 RadioButton.textIconGap        4
 RadioButton.textShiftOffset    0
 
@@ -822,7 +822,7 @@ RangeSliderUI                  com.formdev.flatlaf.jideoss.ui.FlatRangeSliderUI
 
 #---- Resizable ----
 
-Resizable.resizeBorder         [lazy] 4,4,4,4  false    com.formdev.flatlaf.ui.FlatLineBorder [UI]    lineColor=#adadad  HSL   0   0  68    javax.swing.plaf.ColorUIResource [UI]    lineThickness=1.000000
+Resizable.resizeBorder         [lazy] 4,4,4,4  false    com.formdev.flatlaf.ui.FlatLineBorder [UI]    lineColor=#aeaeae  HSL   0   0  68    javax.swing.plaf.ColorUIResource [UI]    lineThickness=1.000000
 
 
 #---- RootPane ----
@@ -866,13 +866,13 @@ ScrollBar.showButtons          false
 ScrollBar.squareButtons        false
 ScrollBar.thumb                #dcdcdc  HSL   0   0  86    com.formdev.flatlaf.util.DerivedColor [UI]    darken(10%)
 ScrollBar.thumbArc             0
-ScrollBar.thumbDarkShadow      #9e9e9e  HSL   0   0  62    javax.swing.plaf.ColorUIResource [UI]
+ScrollBar.thumbDarkShadow      #9c9c9c  HSL   0   0  61    javax.swing.plaf.ColorUIResource [UI]
 ScrollBar.thumbHighlight       #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
 ScrollBar.thumbInsets          0,0,0,0    javax.swing.plaf.InsetsUIResource [UI]
-ScrollBar.thumbShadow          #c4c4c4  HSL   0   0  77    javax.swing.plaf.ColorUIResource [UI]
+ScrollBar.thumbShadow          #c2c2c2  HSL   0   0  76    javax.swing.plaf.ColorUIResource [UI]
 ScrollBar.track                #f5f5f5  HSL   0   0  96    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(1%)
 ScrollBar.trackArc             0
-ScrollBar.trackHighlight       #9e9e9e  HSL   0   0  62    javax.swing.plaf.ColorUIResource [UI]
+ScrollBar.trackHighlight       #9c9c9c  HSL   0   0  61    javax.swing.plaf.ColorUIResource [UI]
 ScrollBar.trackInsets          0,0,0,0    javax.swing.plaf.InsetsUIResource [UI]
 ScrollBar.width                10
 ScrollBarUI                    com.formdev.flatlaf.ui.FlatScrollBarUI
@@ -911,10 +911,10 @@ SearchField.searchIconPressedColor [lazy] #7f8b9180  50%  HSLA 200   8  53 50   
 #---- Separator ----
 
 Separator.background           #f2f2f2  HSL   0   0  95    javax.swing.plaf.ColorUIResource [UI]
-Separator.foreground           #d1d1d1  HSL   0   0  82    javax.swing.plaf.ColorUIResource [UI]
+Separator.foreground           #cecece  HSL   0   0  81    javax.swing.plaf.ColorUIResource [UI]
 Separator.height               3
 Separator.highlight            #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
-Separator.shadow               #c4c4c4  HSL   0   0  77    javax.swing.plaf.ColorUIResource [UI]
+Separator.shadow               #c2c2c2  HSL   0   0  76    javax.swing.plaf.ColorUIResource [UI]
 Separator.stripeIndent         1
 Separator.stripeWidth          1
 SeparatorUI                    com.formdev.flatlaf.ui.FlatSeparatorUI
@@ -923,9 +923,9 @@ SeparatorUI                    com.formdev.flatlaf.ui.FlatSeparatorUI
 #---- Slider ----
 
 Slider.background              #f2f2f2  HSL   0   0  95    javax.swing.plaf.ColorUIResource [UI]
-Slider.disabledThumbColor      #c0c0c0  HSL   0   0  75    javax.swing.plaf.ColorUIResource [UI]
-Slider.disabledTrackColor      #c0c0c0  HSL   0   0  75    javax.swing.plaf.ColorUIResource [UI]
-Slider.focus                   #9e9e9e  HSL   0   0  62    javax.swing.plaf.ColorUIResource [UI]
+Slider.disabledThumbColor      #d1d1d1  HSL   0   0  82    javax.swing.plaf.ColorUIResource [UI]
+Slider.disabledTrackColor      #d1d1d1  HSL   0   0  82    javax.swing.plaf.ColorUIResource [UI]
+Slider.focus                   #9c9c9c  HSL   0   0  61    javax.swing.plaf.ColorUIResource [UI]
 Slider.focusInsets             0,0,0,0    javax.swing.plaf.InsetsUIResource [UI]
 Slider.focusWidth              4
 Slider.focusedColor            #98c3eb80  50%  HSLA 209  67  76 50    com.formdev.flatlaf.util.DerivedColor [UI]    fade(50%)
@@ -938,10 +938,10 @@ Slider.minimumHorizontalSize   36,21    java.awt.Dimension
 Slider.minimumVerticalSize     21,36    java.awt.Dimension
 Slider.onlyLeftMouseButtonDrag true
 Slider.pressedThumbColor       #1a70c0  HSL 209  76  43    com.formdev.flatlaf.util.DerivedColor [UI]    darken(8% autoInverse)
-Slider.shadow                  #c4c4c4  HSL   0   0  77    javax.swing.plaf.ColorUIResource [UI]
+Slider.shadow                  #c2c2c2  HSL   0   0  76    javax.swing.plaf.ColorUIResource [UI]
 Slider.thumbColor              #2285e1  HSL 209  76  51    javax.swing.plaf.ColorUIResource [UI]
 Slider.thumbSize               12,12    javax.swing.plaf.DimensionUIResource [UI]
-Slider.tickColor               #888888  HSL   0   0  53    javax.swing.plaf.ColorUIResource [UI]
+Slider.tickColor               #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
 Slider.trackColor              #c4c4c4  HSL   0   0  77    javax.swing.plaf.ColorUIResource [UI]
 Slider.trackValueColor         #2285e1  HSL 209  76  51    javax.swing.plaf.ColorUIResource [UI]
 Slider.trackWidth              2
@@ -960,7 +960,7 @@ Spinner.buttonDisabledArrowColor #a6a6a6  HSL   0   0  65    javax.swing.plaf.Co
 Spinner.buttonDisabledSeparatorColor #cecece  HSL   0   0  81    javax.swing.plaf.ColorUIResource [UI]
 Spinner.buttonHoverArrowColor  #999999  HSL   0   0  60    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(20%)
 Spinner.buttonPressedArrowColor #b3b3b3  HSL   0   0  70    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(30%)
-Spinner.buttonSeparatorColor   #c4c4c4  HSL   0   0  77    javax.swing.plaf.ColorUIResource [UI]
+Spinner.buttonSeparatorColor   #c2c2c2  HSL   0   0  76    javax.swing.plaf.ColorUIResource [UI]
 Spinner.buttonStyle            button
 Spinner.disabledBackground     #f2f2f2  HSL   0   0  95    javax.swing.plaf.ColorUIResource [UI]
 Spinner.disabledForeground     #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
@@ -977,18 +977,18 @@ SpinnerUI                      com.formdev.flatlaf.ui.FlatSpinnerUI
 SplitPane.background           #f2f2f2  HSL   0   0  95    javax.swing.plaf.ColorUIResource [UI]
 SplitPane.centerOneTouchButtons true
 SplitPane.continuousLayout     true
-SplitPane.darkShadow           #9e9e9e  HSL   0   0  62    javax.swing.plaf.ColorUIResource [UI]
+SplitPane.darkShadow           #9c9c9c  HSL   0   0  61    javax.swing.plaf.ColorUIResource [UI]
 SplitPane.dividerSize          5
 SplitPane.highlight            #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
 SplitPane.oneTouchButtonOffset [active] 2
 SplitPane.oneTouchButtonSize   [active] 6
-SplitPane.shadow               #c4c4c4  HSL   0   0  77    javax.swing.plaf.ColorUIResource [UI]
+SplitPane.shadow               #c2c2c2  HSL   0   0  76    javax.swing.plaf.ColorUIResource [UI]
 
 
 #---- SplitPaneDivider ----
 
-SplitPaneDivider.draggingColor #c4c4c4  HSL   0   0  77    javax.swing.plaf.ColorUIResource [UI]
-SplitPaneDivider.gripColor     #afafaf  HSL   0   0  69    javax.swing.plaf.ColorUIResource [UI]
+SplitPaneDivider.draggingColor #c2c2c2  HSL   0   0  76    javax.swing.plaf.ColorUIResource [UI]
+SplitPaneDivider.gripColor     #b1b1b1  HSL   0   0  69    javax.swing.plaf.ColorUIResource [UI]
 SplitPaneDivider.gripDotCount  3
 SplitPaneDivider.gripDotSize   3
 SplitPaneDivider.gripGap       2
@@ -1022,10 +1022,10 @@ TabbedPane.closeIcon           [lazy] 16,16    com.formdev.flatlaf.icons.FlatTab
 TabbedPane.closePressedBackground #b2b2b2  HSL   0   0  70    com.formdev.flatlaf.util.DerivedColor [UI]    darken(25% autoInverse)
 TabbedPane.closePressedForeground #000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]
 TabbedPane.closeSize           16,16    javax.swing.plaf.DimensionUIResource [UI]
-TabbedPane.contentAreaColor    #bfbfbf  HSL   0   0  75    javax.swing.plaf.ColorUIResource [UI]
+TabbedPane.contentAreaColor    #c2c2c2  HSL   0   0  76    javax.swing.plaf.ColorUIResource [UI]
 TabbedPane.contentOpaque       true
 TabbedPane.contentSeparatorHeight 1
-TabbedPane.darkShadow          #9e9e9e  HSL   0   0  62    javax.swing.plaf.ColorUIResource [UI]
+TabbedPane.darkShadow          #9c9c9c  HSL   0   0  61    javax.swing.plaf.ColorUIResource [UI]
 TabbedPane.disabledForeground  #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
 TabbedPane.disabledUnderlineColor #ababab  HSL   0   0  67    javax.swing.plaf.ColorUIResource [UI]
 TabbedPane.focus               #000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]
@@ -1037,7 +1037,7 @@ TabbedPane.hiddenTabsNavigation moreTabsButton
 TabbedPane.highlight           #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
 TabbedPane.hoverColor          #e0e0e0  HSL   0   0  88    com.formdev.flatlaf.util.DerivedColor [UI]    darken(7% autoInverse)
 TabbedPane.labelShift          1
-TabbedPane.light               #e3e3e3  HSL   0   0  89    javax.swing.plaf.ColorUIResource [UI]
+TabbedPane.light               #e1e1e1  HSL   0   0  88    javax.swing.plaf.ColorUIResource [UI]
 TabbedPane.scrollButtonsPlacement both
 TabbedPane.scrollButtonsPolicy asNeededSingle
 TabbedPane.selectedLabelShift  -1
@@ -1087,12 +1087,12 @@ Table.rowHeight                20
 Table.scrollPaneBorder         [lazy] 1,1,1,1  false    com.formdev.flatlaf.ui.FlatBorder [UI]
 Table.selectionBackground      #2675bf  HSL 209  67  45    javax.swing.plaf.ColorUIResource [UI]
 Table.selectionForeground      #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
-Table.selectionInactiveBackground #d4d4d4  HSL   0   0  83    javax.swing.plaf.ColorUIResource [UI]
+Table.selectionInactiveBackground #d3d3d3  HSL   0   0  83    javax.swing.plaf.ColorUIResource [UI]
 Table.selectionInactiveForeground #000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]
 Table.showHorizontalLines      false
 Table.showTrailingVerticalLine false
 Table.showVerticalLines        false
-Table.sortIconColor            #afafaf  HSL   0   0  69    javax.swing.plaf.ColorUIResource [UI]
+Table.sortIconColor            #b1b1b1  HSL   0   0  69    javax.swing.plaf.ColorUIResource [UI]
 
 
 #---- TableHeader ----
@@ -1118,7 +1118,7 @@ TableUI                        com.formdev.flatlaf.ui.FlatTableUI
 #---- TaskPane ----
 
 TaskPane.background            #f2f2f2  HSL   0   0  95    javax.swing.plaf.ColorUIResource [UI]
-TaskPane.borderColor           #c4c4c4  HSL   0   0  77    javax.swing.plaf.ColorUIResource [UI]
+TaskPane.borderColor           #c2c2c2  HSL   0   0  76    javax.swing.plaf.ColorUIResource [UI]
 TaskPane.contentInsets         10,10,10,10    javax.swing.plaf.InsetsUIResource [UI]
 TaskPane.specialTitleBackground #afafaf  HSL   0   0  69    javax.swing.plaf.ColorUIResource [UI]
 TaskPane.specialTitleForeground #222222  HSL   0   0  13    javax.swing.plaf.ColorUIResource [UI]
@@ -1164,7 +1164,7 @@ TextField.background           #ffffff  HSL   0   0 100    javax.swing.plaf.Colo
 TextField.border               [lazy] 1,1,1,1  false    com.formdev.flatlaf.ui.FlatTextBorder [UI]
 TextField.caretBlinkRate       500
 TextField.caretForeground      #000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]
-TextField.darkShadow           #9e9e9e  HSL   0   0  62    javax.swing.plaf.ColorUIResource [UI]
+TextField.darkShadow           #9c9c9c  HSL   0   0  61    javax.swing.plaf.ColorUIResource [UI]
 TextField.disabledBackground   #f2f2f2  HSL   0   0  95    javax.swing.plaf.ColorUIResource [UI]
 TextField.font                 [active] $defaultFont [UI]
 TextField.foreground           #000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]
@@ -1172,12 +1172,12 @@ TextField.highlight            #ffffff  HSL   0   0 100    javax.swing.plaf.Colo
 TextField.iconTextGap          4
 TextField.inactiveBackground   #f2f2f2  HSL   0   0  95    javax.swing.plaf.ColorUIResource [UI]
 TextField.inactiveForeground   #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
-TextField.light                #e3e3e3  HSL   0   0  89    javax.swing.plaf.ColorUIResource [UI]
+TextField.light                #e1e1e1  HSL   0   0  88    javax.swing.plaf.ColorUIResource [UI]
 TextField.margin               2,6,2,6    javax.swing.plaf.InsetsUIResource [UI]
 TextField.placeholderForeground #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
 TextField.selectionBackground  #2675bf  HSL 209  67  45    javax.swing.plaf.ColorUIResource [UI]
 TextField.selectionForeground  #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
-TextField.shadow               #c4c4c4  HSL   0   0  77    javax.swing.plaf.ColorUIResource [UI]
+TextField.shadow               #c2c2c2  HSL   0   0  76    javax.swing.plaf.ColorUIResource [UI]
 TextFieldUI                    com.formdev.flatlaf.ui.FlatTextFieldUI
 
 
@@ -1231,7 +1231,7 @@ TitlePane.useWindowDecorations true
 
 #---- TitledBorder ----
 
-TitledBorder.border            [lazy] 1,1,1,1  false    com.formdev.flatlaf.ui.FlatLineBorder [UI]    lineColor=#d1d1d1  HSL   0   0  82    javax.swing.plaf.ColorUIResource [UI]    lineThickness=1.000000
+TitledBorder.border            [lazy] 1,1,1,1  false    com.formdev.flatlaf.ui.FlatLineBorder [UI]    lineColor=#cecece  HSL   0   0  81    javax.swing.plaf.ColorUIResource [UI]    lineThickness=1.000000
 TitledBorder.font              [active] $defaultFont [UI]
 TitledBorder.titleColor        #000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]
 
@@ -1245,7 +1245,7 @@ TitledPanelUI                  com.formdev.flatlaf.swingx.ui.FlatTitledPanelUI
 
 ToggleButton.background        #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
 ToggleButton.border            [lazy] 1,1,1,1  false    com.formdev.flatlaf.ui.FlatButtonBorder [UI]
-ToggleButton.darkShadow        #9e9e9e  HSL   0   0  62    javax.swing.plaf.ColorUIResource [UI]
+ToggleButton.darkShadow        #9c9c9c  HSL   0   0  61    javax.swing.plaf.ColorUIResource [UI]
 ToggleButton.disabledBackground #f2f2f2  HSL   0   0  95    javax.swing.plaf.ColorUIResource [UI]
 ToggleButton.disabledSelectedBackground #dedede  HSL   0   0  87    com.formdev.flatlaf.util.DerivedColor [UI]    darken(13% autoInverse)
 ToggleButton.disabledText      #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
@@ -1253,13 +1253,13 @@ ToggleButton.font              [active] $defaultFont [UI]
 ToggleButton.foreground        #000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]
 ToggleButton.highlight         #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
 ToggleButton.iconTextGap       4
-ToggleButton.light             #e3e3e3  HSL   0   0  89    javax.swing.plaf.ColorUIResource [UI]
+ToggleButton.light             #e1e1e1  HSL   0   0  88    javax.swing.plaf.ColorUIResource [UI]
 ToggleButton.margin            2,14,2,14    javax.swing.plaf.InsetsUIResource [UI]
 ToggleButton.pressedBackground #e6e6e6  HSL   0   0  90    com.formdev.flatlaf.util.DerivedColor [UI]    darken(10% autoInverse)
 ToggleButton.rollover          true
 ToggleButton.selectedBackground #cccccc  HSL   0   0  80    com.formdev.flatlaf.util.DerivedColor [UI]    darken(20% autoInverse)
 ToggleButton.selectedForeground #000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]
-ToggleButton.shadow            #c4c4c4  HSL   0   0  77    javax.swing.plaf.ColorUIResource [UI]
+ToggleButton.shadow            #c2c2c2  HSL   0   0  76    javax.swing.plaf.ColorUIResource [UI]
 ToggleButton.tab.disabledUnderlineColor #ababab  HSL   0   0  67    javax.swing.plaf.ColorUIResource [UI]
 ToggleButton.tab.focusBackground #dee6ed  HSL 208  29  90    javax.swing.plaf.ColorUIResource [UI]
 ToggleButton.tab.hoverBackground #e0e0e0  HSL   0   0  88    com.formdev.flatlaf.util.DerivedColor [UI]    darken(7% autoInverse)
@@ -1278,21 +1278,21 @@ ToggleButtonUI                 com.formdev.flatlaf.ui.FlatToggleButtonUI
 ToolBar.background             #f2f2f2  HSL   0   0  95    javax.swing.plaf.ColorUIResource [UI]
 ToolBar.border                 [lazy] 2,2,2,2  false    com.formdev.flatlaf.ui.FlatToolBarBorder [UI]
 ToolBar.borderMargins          2,2,2,2    javax.swing.plaf.InsetsUIResource [UI]
-ToolBar.darkShadow             #9e9e9e  HSL   0   0  62    javax.swing.plaf.ColorUIResource [UI]
-ToolBar.dockingBackground      #f2f2f2  HSL   0   0  95    javax.swing.plaf.ColorUIResource [UI]
-ToolBar.dockingForeground      #000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]
+ToolBar.darkShadow             #9c9c9c  HSL   0   0  61    javax.swing.plaf.ColorUIResource [UI]
+ToolBar.dockingBackground      #e5e5e5  HSL   0   0  90    javax.swing.plaf.ColorUIResource [UI]
+ToolBar.dockingForeground      #c2c2c2  HSL   0   0  76    javax.swing.plaf.ColorUIResource [UI]
 ToolBar.floatingBackground     #f2f2f2  HSL   0   0  95    javax.swing.plaf.ColorUIResource [UI]
-ToolBar.floatingForeground     #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
+ToolBar.floatingForeground     #c2c2c2  HSL   0   0  76    javax.swing.plaf.ColorUIResource [UI]
 ToolBar.focusableButtons       false
 ToolBar.font                   [active] $defaultFont [UI]
 ToolBar.foreground             #000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]
-ToolBar.gripColor              #afafaf  HSL   0   0  69    javax.swing.plaf.ColorUIResource [UI]
+ToolBar.gripColor              #b1b1b1  HSL   0   0  69    javax.swing.plaf.ColorUIResource [UI]
 ToolBar.highlight              #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
 ToolBar.isRollover             true
-ToolBar.light                  #e3e3e3  HSL   0   0  89    javax.swing.plaf.ColorUIResource [UI]
-ToolBar.separatorColor         #d1d1d1  HSL   0   0  82    javax.swing.plaf.ColorUIResource [UI]
+ToolBar.light                  #e1e1e1  HSL   0   0  88    javax.swing.plaf.ColorUIResource [UI]
+ToolBar.separatorColor         #cecece  HSL   0   0  81    javax.swing.plaf.ColorUIResource [UI]
 ToolBar.separatorWidth         7
-ToolBar.shadow                 #c4c4c4  HSL   0   0  77    javax.swing.plaf.ColorUIResource [UI]
+ToolBar.shadow                 #c2c2c2  HSL   0   0  76    javax.swing.plaf.ColorUIResource [UI]
 ToolBar.spacingBorder          [lazy] 1,2,1,2  false    com.formdev.flatlaf.ui.FlatEmptyBorder [UI]
 
 
@@ -1340,11 +1340,11 @@ Tree.expandedIcon              [lazy] 11,11    com.formdev.flatlaf.icons.FlatTre
 Tree.font                      [active] $defaultFont [UI]
 Tree.foreground                #000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]
 Tree.hash                      #e6e6e6  HSL   0   0  90    javax.swing.plaf.ColorUIResource [UI]
-Tree.icon.closedColor          #afafaf  HSL   0   0  69    javax.swing.plaf.ColorUIResource [UI]
-Tree.icon.collapsedColor       #afafaf  HSL   0   0  69    javax.swing.plaf.ColorUIResource [UI]
-Tree.icon.expandedColor        #afafaf  HSL   0   0  69    javax.swing.plaf.ColorUIResource [UI]
-Tree.icon.leafColor            #afafaf  HSL   0   0  69    javax.swing.plaf.ColorUIResource [UI]
-Tree.icon.openColor            #afafaf  HSL   0   0  69    javax.swing.plaf.ColorUIResource [UI]
+Tree.icon.closedColor          #b1b1b1  HSL   0   0  69    javax.swing.plaf.ColorUIResource [UI]
+Tree.icon.collapsedColor       #b1b1b1  HSL   0   0  69    javax.swing.plaf.ColorUIResource [UI]
+Tree.icon.expandedColor        #b1b1b1  HSL   0   0  69    javax.swing.plaf.ColorUIResource [UI]
+Tree.icon.leafColor            #b1b1b1  HSL   0   0  69    javax.swing.plaf.ColorUIResource [UI]
+Tree.icon.openColor            #b1b1b1  HSL   0   0  69    javax.swing.plaf.ColorUIResource [UI]
 Tree.leafIcon                  [lazy] 16,16    com.formdev.flatlaf.icons.FlatTreeLeafIcon [UI]
 Tree.leftChildIndent           7
 Tree.lineTypeDashed            false
@@ -1359,7 +1359,7 @@ Tree.scrollsOnExpand           true
 Tree.selectionBackground       #2675bf  HSL 209  67  45    javax.swing.plaf.ColorUIResource [UI]
 Tree.selectionBorderColor      #000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]
 Tree.selectionForeground       #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
-Tree.selectionInactiveBackground #d4d4d4  HSL   0   0  83    javax.swing.plaf.ColorUIResource [UI]
+Tree.selectionInactiveBackground #d3d3d3  HSL   0   0  83    javax.swing.plaf.ColorUIResource [UI]
 Tree.selectionInactiveForeground #000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]
 Tree.showCellFocusIndicator    false
 Tree.textBackground            #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
@@ -1398,10 +1398,10 @@ activeCaption                  #99b4d1  HSL 211  38  71    javax.swing.plaf.Colo
 activeCaptionBorder            #99b4d1  HSL 211  38  71    javax.swing.plaf.ColorUIResource [UI]
 activeCaptionText              #000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]
 control                        #f2f2f2  HSL   0   0  95    javax.swing.plaf.ColorUIResource [UI]
-controlDkShadow                #9e9e9e  HSL   0   0  62    javax.swing.plaf.ColorUIResource [UI]
-controlHighlight               #e3e3e3  HSL   0   0  89    javax.swing.plaf.ColorUIResource [UI]
+controlDkShadow                #9c9c9c  HSL   0   0  61    javax.swing.plaf.ColorUIResource [UI]
+controlHighlight               #e1e1e1  HSL   0   0  88    javax.swing.plaf.ColorUIResource [UI]
 controlLtHighlight             #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
-controlShadow                  #c4c4c4  HSL   0   0  77    javax.swing.plaf.ColorUIResource [UI]
+controlShadow                  #c2c2c2  HSL   0   0  76    javax.swing.plaf.ColorUIResource [UI]
 controlText                    #000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]
 defaultFont                    Segoe UI plain 12    javax.swing.plaf.FontUIResource [UI]
 desktop                        #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]

--- a/flatlaf-testing/dumps/uidefaults/FlatTestLaf_1.8.0_202.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatTestLaf_1.8.0_202.txt
@@ -162,6 +162,8 @@ CheckBoxMenuItem.checkIcon     [lazy] 15,15    com.formdev.flatlaf.icons.FlatChe
 CheckBoxMenuItem.disabledForeground #000088  HSL 240 100  27    javax.swing.plaf.ColorUIResource [UI]
 CheckBoxMenuItem.font          [active] $defaultFont [UI]
 CheckBoxMenuItem.foreground    #ff0000  HSL   0 100  50    javax.swing.plaf.ColorUIResource [UI]
+CheckBoxMenuItem.icon.checkmarkColor #4d89c9  HSL 211  53  55    javax.swing.plaf.ColorUIResource [UI]
+CheckBoxMenuItem.icon.disabledCheckmarkColor #ababab  HSL   0   0  67    javax.swing.plaf.ColorUIResource [UI]
 CheckBoxMenuItem.margin        3,6,3,6    javax.swing.plaf.InsetsUIResource [UI]
 CheckBoxMenuItem.opaque        false
 CheckBoxMenuItem.selectionBackground #00aa00  HSL 120 100  33    javax.swing.plaf.ColorUIResource [UI]
@@ -620,16 +622,6 @@ MenuItem.underlineSelectionBackground #e6e6e6  HSL   0   0  90    javax.swing.pl
 MenuItem.underlineSelectionCheckBackground #ccccff  HSL 240 100  90    javax.swing.plaf.ColorUIResource [UI]
 MenuItem.underlineSelectionColor #ff0000  HSL   0 100  50    javax.swing.plaf.ColorUIResource [UI]
 MenuItem.underlineSelectionHeight 3
-
-
-#---- MenuItemCheckBox ----
-
-MenuItemCheckBox.icon.checkmarkColor #4d89c9  HSL 211  53  55    javax.swing.plaf.ColorUIResource [UI]
-MenuItemCheckBox.icon.disabledCheckmarkColor #ababab  HSL   0   0  67    javax.swing.plaf.ColorUIResource [UI]
-
-
-#---- MenuItem ----
-
 MenuItemUI                     com.formdev.flatlaf.ui.FlatMenuItemUI
 
 

--- a/flatlaf-testing/dumps/uidefaults/FlatTestLaf_1.8.0_202.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatTestLaf_1.8.0_202.txt
@@ -330,14 +330,14 @@ HeaderUI                       com.formdev.flatlaf.swingx.ui.FlatHeaderUI
 
 #---- HelpButton ----
 
-HelpButton.background          #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
-HelpButton.borderColor         #878787  HSL   0   0  53    javax.swing.plaf.ColorUIResource [UI]
+HelpButton.background          #ccffcc  HSL 120 100  90    javax.swing.plaf.ColorUIResource [UI]
+HelpButton.borderColor         #00ff00  HSL 120 100  50    javax.swing.plaf.ColorUIResource [UI]
 HelpButton.borderWidth         1
-HelpButton.disabledBackground  #f2f2f2  HSL   0   0  95    javax.swing.plaf.ColorUIResource [UI]
-HelpButton.disabledBorderColor #bdbdbd  HSL   0   0  74    javax.swing.plaf.ColorUIResource [UI]
-HelpButton.disabledQuestionMarkColor #ababab  HSL   0   0  67    javax.swing.plaf.ColorUIResource [UI]
+HelpButton.disabledBackground  #e0e0e0  HSL   0   0  88    javax.swing.plaf.ColorUIResource [UI]
+HelpButton.disabledBorderColor #000088  HSL 240 100  27    javax.swing.plaf.ColorUIResource [UI]
+HelpButton.disabledQuestionMarkColor #8888ff  HSL 240 100  77    javax.swing.plaf.ColorUIResource [UI]
 HelpButton.focusedBackground   #00ffff  HSL 180 100  50    javax.swing.plaf.ColorUIResource [UI]
-HelpButton.focusedBorderColor  #7b9fc7  HSL 212  40  63    javax.swing.plaf.ColorUIResource [UI]
+HelpButton.focusedBorderColor  #466d94  HSL 210  36  43    javax.swing.plaf.ColorUIResource [UI]
 HelpButton.hoverBackground     #ffff00  HSL  60 100  50    javax.swing.plaf.ColorUIResource [UI]
 HelpButton.hoverBorderColor    #ff0000  HSL   0 100  50    javax.swing.plaf.ColorUIResource [UI]
 HelpButton.icon                [lazy] 22,22    com.formdev.flatlaf.icons.FlatHelpButtonIcon [UI]
@@ -583,7 +583,7 @@ MenuBar.hoverBackground        #ffdddd  HSL   0 100  93    javax.swing.plaf.Colo
 MenuBar.itemMargins            3,8,3,8    javax.swing.plaf.InsetsUIResource [UI]
 MenuBar.shadow                 #a0a0a0  HSL   0   0  63    javax.swing.plaf.ColorUIResource [UI]
 MenuBar.underlineSelectionBackground #00ff00  HSL 120 100  50    javax.swing.plaf.ColorUIResource [UI]
-MenuBar.underlineSelectionColor #ff0000  HSL   0 100  50    javax.swing.plaf.ColorUIResource [UI]
+MenuBar.underlineSelectionColor #ffff00  HSL  60 100  50    javax.swing.plaf.ColorUIResource [UI]
 MenuBar.underlineSelectionHeight 5
 MenuBar.windowBindings         length=2    [Ljava.lang.Object;
     [0] F10
@@ -618,7 +618,7 @@ MenuItem.textAcceleratorGap    24
 MenuItem.textNoAcceleratorGap  6
 MenuItem.underlineSelectionBackground #e6e6e6  HSL   0   0  90    javax.swing.plaf.ColorUIResource [UI]
 MenuItem.underlineSelectionCheckBackground #ccccff  HSL 240 100  90    javax.swing.plaf.ColorUIResource [UI]
-MenuItem.underlineSelectionColor #ffff00  HSL  60 100  50    javax.swing.plaf.ColorUIResource [UI]
+MenuItem.underlineSelectionColor #ff0000  HSL   0 100  50    javax.swing.plaf.ColorUIResource [UI]
 MenuItem.underlineSelectionHeight 3
 
 
@@ -1079,7 +1079,7 @@ Table.dropCellBackground       #ff0000  HSL   0 100  50    javax.swing.plaf.Colo
 Table.dropCellForeground       #00ff00  HSL 120 100  50    javax.swing.plaf.ColorUIResource [UI]
 Table.dropLineColor            #0000ff  HSL 240 100  50    javax.swing.plaf.ColorUIResource [UI]
 Table.dropLineShortColor       #ffff00  HSL  60 100  50    javax.swing.plaf.ColorUIResource [UI]
-Table.focusCellBackground      #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+Table.focusCellBackground      #fffff0  HSL  60 100  97    javax.swing.plaf.ColorUIResource [UI]
 Table.focusCellForeground      #ff0000  HSL   0 100  50    javax.swing.plaf.ColorUIResource [UI]
 Table.focusCellHighlightBorder [lazy] 2,3,2,3  false    com.formdev.flatlaf.ui.FlatTableCellBorder$Focused [UI]    lineColor=#ff0000  HSL   0 100  50    javax.swing.plaf.ColorUIResource [UI]    lineThickness=1.000000
 Table.focusSelectedCellHighlightBorder [lazy] 2,3,2,3  false    com.formdev.flatlaf.ui.FlatTableCellBorder$Selected [UI]    lineColor=#ff0000  HSL   0 100  50    javax.swing.plaf.ColorUIResource [UI]    lineThickness=1.000000
@@ -1287,10 +1287,10 @@ ToolBar.background             #ccffcc  HSL 120 100  90    javax.swing.plaf.Colo
 ToolBar.border                 [lazy] 2,2,2,2  false    com.formdev.flatlaf.ui.FlatToolBarBorder [UI]
 ToolBar.borderMargins          2,2,2,2    javax.swing.plaf.InsetsUIResource [UI]
 ToolBar.darkShadow             #696969  HSL   0   0  41    javax.swing.plaf.ColorUIResource [UI]
-ToolBar.dockingBackground      #ccffcc  HSL 120 100  90    javax.swing.plaf.ColorUIResource [UI]
+ToolBar.dockingBackground      #b3ffb3  HSL 120 100  85    javax.swing.plaf.ColorUIResource [UI]
 ToolBar.dockingForeground      #ff0000  HSL   0 100  50    javax.swing.plaf.ColorUIResource [UI]
 ToolBar.floatingBackground     #ccffcc  HSL 120 100  90    javax.swing.plaf.ColorUIResource [UI]
-ToolBar.floatingForeground     #000088  HSL 240 100  27    javax.swing.plaf.ColorUIResource [UI]
+ToolBar.floatingForeground     #ff0000  HSL   0 100  50    javax.swing.plaf.ColorUIResource [UI]
 ToolBar.focusableButtons       true
 ToolBar.font                   [active] $defaultFont [UI]
 ToolBar.foreground             #ff0000  HSL   0 100  50    javax.swing.plaf.ColorUIResource [UI]

--- a/flatlaf-testing/src/main/resources/com/formdev/flatlaf/testing/FlatTestLaf.properties
+++ b/flatlaf-testing/src/main/resources/com/formdev/flatlaf/testing/FlatTestLaf.properties
@@ -135,6 +135,12 @@ CheckBox.icon.hoverBackground = #ff0
 CheckBox.icon.pressedBackground = #FFC800
 
 
+#---- CheckBoxMenuItem ----
+
+CheckBoxMenuItem.icon.checkmarkColor = #4D89C9
+CheckBoxMenuItem.icon.disabledCheckmarkColor = #ABABAB
+
+
 #---- ComboBox ----
 
 ComboBox.background = #fff
@@ -230,12 +236,6 @@ MenuBar.hoverBackground = #fdd
 MenuBar.underlineSelectionBackground = #0f0
 MenuBar.underlineSelectionColor = #ff0
 MenuBar.underlineSelectionHeight = 5
-
-#---- MenuItemCheckBox ----
-
-MenuItemCheckBox.icon.checkmarkColor = #4D89C9
-MenuItemCheckBox.icon.disabledCheckmarkColor = #ABABAB
-
 
 #---- OptionPane ----
 

--- a/flatlaf-testing/src/main/resources/com/formdev/flatlaf/testing/FlatTestLaf.properties
+++ b/flatlaf-testing/src/main/resources/com/formdev/flatlaf/testing/FlatTestLaf.properties
@@ -32,6 +32,8 @@
 @cellFocusColor = #f00
 @icon = #afafaf
 
+@accentUnderlineColor = #f00
+
 # for buttons within components (e.g. combobox or spinner)
 @buttonArrowColor = #666
 @buttonDisabledArrowColor = #ABABAB
@@ -170,6 +172,7 @@ FormattedTextField.focusedBackground = #ff8
 
 HelpButton.focusedBackground = #0ff
 HelpButton.questionMarkColor = #00f
+HelpButton.disabledQuestionMarkColor = #88f
 
 
 #---- InternalFrame ----
@@ -216,7 +219,7 @@ MenuBar.borderColor = #44f
 MenuBar.hoverBackground = #fdd
 
 MenuBar.underlineSelectionBackground = #0f0
-MenuBar.underlineSelectionColor = #f00
+MenuBar.underlineSelectionColor = #ff0
 MenuBar.underlineSelectionHeight = 5
 
 #---- MenuItemCheckBox ----
@@ -301,6 +304,7 @@ Slider.disabledThumbColor = #880
 
 #---- Spinner ----
 
+Spinner.buttonBackground = #cccccc
 Spinner.focusedBackground = #ff8
 
 

--- a/flatlaf-testing/src/main/resources/com/formdev/flatlaf/testing/FlatTestLaf.properties
+++ b/flatlaf-testing/src/main/resources/com/formdev/flatlaf/testing/FlatTestLaf.properties
@@ -16,19 +16,29 @@
 
 #---- variables ----
 
+# general background and foreground (text color)
 @background = #cfc
 @foreground = #f00
+@disabledBackground = #e0e0e0
+@disabledForeground = #008
+
+# component background
+@componentBackground = #fff
+@menuBackground = #fff
+
+# selection
 @selectionBackground = #0a0
 @selectionForeground = #ff0
 @selectionInactiveBackground = #888
 @selectionInactiveForeground = #fff
-@disabledText = #008
-@textComponentBackground = #fff
-@menuBackground = #fff
+
+# menu
 @menuHoverBackground = darken(@menuBackground,10%)
 @menuCheckBackground = #ccf
 @menuAcceleratorForeground = #f88
 @menuAcceleratorSelectionForeground = #fff
+
+# misc
 @cellFocusColor = #f00
 @icon = #afafaf
 
@@ -51,7 +61,6 @@
 *.caretForeground = #00f
 *.inactiveBackground = #f0f0f0
 *.inactiveForeground = #008
-*.disabledBackground = #e0e0e0
 
 
 #---- system colors ----

--- a/flatlaf-testing/src/main/resources/com/formdev/flatlaf/testing/swingx/FlatTestLaf.properties
+++ b/flatlaf-testing/src/main/resources/com/formdev/flatlaf/testing/swingx/FlatTestLaf.properties
@@ -37,7 +37,7 @@ Hyperlink.disabledText = #008
 
 #---- MonthView ----
 
-JXMonthView.background = @textComponentBackground
+JXMonthView.background = @componentBackground
 JXMonthView.monthStringBackground = #0f0
 JXMonthView.monthStringForeground = #00f
 JXMonthView.daysOfTheWeekForeground = #0f0

--- a/flatlaf-theme-editor/src/main/resources/com/formdev/flatlaf/themeeditor/FlatDarkLaf.properties
+++ b/flatlaf-theme-editor/src/main/resources/com/formdev/flatlaf/themeeditor/FlatDarkLaf.properties
@@ -52,7 +52,7 @@ FlatThemeEditorPane.style.comment.italic = true
 
 FlatThemeEditorPane.gutter.background = $FlatThemeEditorPane.background
 FlatThemeEditorPane.gutter.borderColor = $Component.borderColor
-FlatThemeEditorPane.gutter.lineNumberColor = @disabledText
+FlatThemeEditorPane.gutter.lineNumberColor = @disabledForeground
 
 
 #---- FlatThemeEditorPane.errorstrip ----

--- a/flatlaf-theme-editor/src/main/resources/com/formdev/flatlaf/themeeditor/FlatLafUIKeys.txt
+++ b/flatlaf-theme-editor/src/main/resources/com/formdev/flatlaf/themeeditor/FlatLafUIKeys.txt
@@ -129,6 +129,8 @@ CheckBoxMenuItem.checkIcon
 CheckBoxMenuItem.disabledForeground
 CheckBoxMenuItem.font
 CheckBoxMenuItem.foreground
+CheckBoxMenuItem.icon.checkmarkColor
+CheckBoxMenuItem.icon.disabledCheckmarkColor
 CheckBoxMenuItem.margin
 CheckBoxMenuItem.opaque
 CheckBoxMenuItem.selectionBackground
@@ -468,8 +470,6 @@ MenuItem.underlineSelectionBackground
 MenuItem.underlineSelectionCheckBackground
 MenuItem.underlineSelectionColor
 MenuItem.underlineSelectionHeight
-MenuItemCheckBox.icon.checkmarkColor
-MenuItemCheckBox.icon.disabledCheckmarkColor
 MenuItemUI
 MenuUI
 MonthViewUI

--- a/flatlaf-theme-editor/src/main/resources/com/formdev/flatlaf/themeeditor/FlatLightLaf.properties
+++ b/flatlaf-theme-editor/src/main/resources/com/formdev/flatlaf/themeeditor/FlatLightLaf.properties
@@ -52,7 +52,7 @@ FlatThemeEditorPane.style.comment.italic = true
 
 FlatThemeEditorPane.gutter.background = $FlatThemeEditorPane.background
 FlatThemeEditorPane.gutter.borderColor = $Component.borderColor
-FlatThemeEditorPane.gutter.lineNumberColor = @disabledText
+FlatThemeEditorPane.gutter.lineNumberColor = @disabledForeground
 
 
 #---- FlatThemeEditorPane.errorstrip ----


### PR DESCRIPTION
This PR reworks core themes to:

- make it easier to create new themes
- reduce explicit colors by using color functions
- avoid using colors from one component type for another component type
  (except when useful; e.g. `Separator.foreground` is also used for other separators)
- HelpButton: use colors from Button (instead of from CheckBox.icon)
- ToolBar: improved "docking" and "floating" colors
- added `@disabledBackground` and `@buttonBackground`

Because of using color functions for more UI defaults, some colors has slightly changed,
but there is no visual difference. The changes are so small, you will not recognize them.

### Incompatible changes

If you use one of the following variables or keys in your FlatLaf properties files, then you have to rename them too.

- renamed `@disabledText` to `@disabledForeground`
- renamed `@textComponentBackground` to `@componentBackground`
- renamed `@textComponentMargin` to `@componentMargin`
- renamed `MenuItemCheckBox.icon.checkmarkColor` to `CheckBoxMenuItem.icon.checkmarkColor`
- renamed `MenuItemCheckBox.icon.disabledCheckmarkColor` to `CheckBoxMenuItem.icon.disabledCheckmarkColor`
