### PR TITLE
MenuItem: paint the selected icon when the item is selected

### DIFF
--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatMenuItemRenderer.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatMenuItemRenderer.java
@@ -35,6 +35,8 @@ import javax.swing.Icon;
 import javax.swing.JMenu;
 import javax.swing.JMenuItem;
 import javax.swing.KeyStroke;
+import javax.swing.MenuElement;
+import javax.swing.MenuSelectionManager;
 import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
 import javax.swing.plaf.basic.BasicHTML;
@@ -467,6 +469,17 @@ debug*/
 
 		if( !menuItem.isEnabled() )
 			return menuItem.getDisabledIcon();
+
+		MenuSelectionManager msm = MenuSelectionManager.defaultManager();
+		if( msm != null ) {
+			MenuElement[] path = msm.getSelectedPath();
+			MenuElement selectedElement = path.length > 0 ? path[path.length - 1] : null;
+			if( menuItem == selectedElement ) {
+				Icon selectedIcon = menuItem.getSelectedIcon();
+				if( selectedIcon != null )
+					return selectedIcon;
+			}
+		}
 
 		if( menuItem.getModel().isPressed() && menuItem.isArmed() ) {
 			Icon pressedIcon = menuItem.getPressedIcon();

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatMenuItemRenderer.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatMenuItemRenderer.java
@@ -35,8 +35,6 @@ import javax.swing.Icon;
 import javax.swing.JMenu;
 import javax.swing.JMenuItem;
 import javax.swing.KeyStroke;
-import javax.swing.MenuElement;
-import javax.swing.MenuSelectionManager;
 import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
 import javax.swing.plaf.basic.BasicHTML;
@@ -446,6 +444,10 @@ debug*/
 		htmlView.paint( HiDPIUtils.createGraphicsTextYCorrection( (Graphics2D) g ), textRect );
 	}
 
+	/**
+	 * Returns {@code true} if either the menu item is armed (mouse over item)
+	 * or it is a {@code JMenu} and selected (shows submenu).
+	 */
 	protected static boolean isArmedOrSelected( JMenuItem menuItem ) {
 		return menuItem.isArmed() || (menuItem instanceof JMenu && menuItem.isSelected());
 	}
@@ -470,21 +472,16 @@ debug*/
 		if( !menuItem.isEnabled() )
 			return menuItem.getDisabledIcon();
 
-		MenuSelectionManager msm = MenuSelectionManager.defaultManager();
-		if( msm != null ) {
-			MenuElement[] path = msm.getSelectedPath();
-			MenuElement selectedElement = path.length > 0 ? path[path.length - 1] : null;
-			if( menuItem == selectedElement ) {
-				Icon selectedIcon = menuItem.getSelectedIcon();
-				if( selectedIcon != null )
-					return selectedIcon;
-			}
-		}
-
 		if( menuItem.getModel().isPressed() && menuItem.isArmed() ) {
 			Icon pressedIcon = menuItem.getPressedIcon();
 			if( pressedIcon != null )
 				return pressedIcon;
+		}
+
+		if( isArmedOrSelected( menuItem ) ) {
+			Icon selectedIcon = menuItem.getSelectedIcon();
+			if( selectedIcon != null )
+				return selectedIcon;
 		}
 
 		return icon;

--- a/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatMenusTest.java
+++ b/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatMenusTest.java
@@ -162,6 +162,9 @@ public class FlatMenusTest
 		FlatMenusTest.MenuWithAccelerator menuWithAccelerator2 = new FlatMenusTest.MenuWithAccelerator();
 		JMenuItem menuItem40 = new JMenuItem();
 		JMenuItem menuItem39 = new JMenuItem();
+		JMenu menu12 = new JMenu();
+		JMenuItem menuItem41 = new JMenuItem();
+		JMenuItem menuItem42 = new JMenuItem();
 		menuBar2 = new JMenuBar();
 		JMenu menu8 = new JMenu();
 		FlatMenusTest.LargerMenuItem menuItem13 = new FlatMenusTest.LargerMenuItem();
@@ -377,6 +380,25 @@ public class FlatMenusTest
 				menuWithAccelerator1.add(menuItem39);
 			}
 			menuBar1.add(menuWithAccelerator1);
+
+			//======== menu12 ========
+			{
+				menu12.setText("icons");
+
+				//---- menuItem41 ----
+				menuItem41.setText("selected icon");
+				menuItem41.setIcon(new ImageIcon(getClass().getResource("/com/formdev/flatlaf/testing/disabled_icons_test/intellij-menu-cut.png")));
+				menuItem41.setSelectedIcon(new ImageIcon(getClass().getResource("/com/formdev/flatlaf/testing/disabled_icons_test/intellij-show_dark.png")));
+				menu12.add(menuItem41);
+
+				//---- menuItem42 ----
+				menuItem42.setText("disabled icon");
+				menuItem42.setIcon(new ImageIcon(getClass().getResource("/com/formdev/flatlaf/testing/disabled_icons_test/intellij-menu-cut.png")));
+				menuItem42.setDisabledIcon(new ImageIcon(getClass().getResource("/com/formdev/flatlaf/testing/disabled_icons_test/intellij-menu-paste.png")));
+				menuItem42.setEnabled(false);
+				menu12.add(menuItem42);
+			}
+			menuBar1.add(menu12);
 		}
 		add(menuBar1, "cell 1 0 2 1,growx");
 

--- a/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatMenusTest.jfd
+++ b/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatMenusTest.jfd
@@ -1,4 +1,4 @@
-JFDML JFormDesigner: "7.0.3.1.342" Java: "15" encoding: "UTF-8"
+JFDML JFormDesigner: "7.0.5.0.404" Java: "16" encoding: "UTF-8"
 
 new FormModel {
 	contentType: "form/swing"
@@ -147,6 +147,23 @@ new FormModel {
 						name: "menuItem39"
 						"text": "text"
 						"accelerator": #KeyStroke0
+					} )
+				} )
+				add( new FormContainer( "javax.swing.JMenu", new FormLayoutManager( class javax.swing.JMenu ) ) {
+					name: "menu12"
+					"text": "icons"
+					add( new FormComponent( "javax.swing.JMenuItem" ) {
+						name: "menuItem41"
+						"text": "selected icon"
+						"icon": new com.jformdesigner.model.SwingIcon( 0, "/com/formdev/flatlaf/testing/disabled_icons_test/intellij-menu-cut.png" )
+						"selectedIcon": new com.jformdesigner.model.SwingIcon( 0, "/com/formdev/flatlaf/testing/disabled_icons_test/intellij-show_dark.png" )
+					} )
+					add( new FormComponent( "javax.swing.JMenuItem" ) {
+						name: "menuItem42"
+						"text": "disabled icon"
+						"icon": new com.jformdesigner.model.SwingIcon( 0, "/com/formdev/flatlaf/testing/disabled_icons_test/intellij-menu-cut.png" )
+						"disabledIcon": new com.jformdesigner.model.SwingIcon( 0, "/com/formdev/flatlaf/testing/disabled_icons_test/intellij-menu-paste.png" )
+						"enabled": false
 					} )
 				} )
 			}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {


### PR DESCRIPTION
I'd like to suggest this change to paint a different icon when a menu item is highlighted. The idea is to provide an alternative icon that has a better contrast with the selection background. This behavior can be seen for example on some menus of IntelliJ where the icons are painted with a different shade of gray when an item is selected:


**Open icon not selected (color #6E6E6E)**

![2021-11-03 18_25_30-](https://user-images.githubusercontent.com/54304/140156904-08678f84-c956-4131-82bd-fe325030706d.png)

**Open icon selected (color #AFB1B3)**

![2021-11-03 18_26_11-](https://user-images.githubusercontent.com/54304/140157139-2d1d055a-ad1d-4220-8dce-c441c2d0cc86.png)

