### PR TITLE
Restored default constructors for UIs

### DIFF
--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatButtonUI.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatButtonUI.java
@@ -158,6 +158,10 @@ public class FlatButtonUI
 			: new FlatButtonUI( false );
 	}
 
+	public FlatButtonUI() {
+		this( false );
+	}
+
 	/** @since 2 */
 	protected FlatButtonUI( boolean shared ) {
 		this.shared = shared;

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatCheckBoxUI.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatCheckBoxUI.java
@@ -48,6 +48,10 @@ public class FlatCheckBoxUI
 			: new FlatCheckBoxUI( false );
 	}
 
+	public FlatCheckBoxUI() {
+		this( false );
+	}
+
 	/** @since 2 */
 	protected FlatCheckBoxUI( boolean shared ) {
 		super( shared );

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatLabelUI.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatLabelUI.java
@@ -73,6 +73,10 @@ public class FlatLabelUI
 			: new FlatLabelUI( false );
 	}
 
+	public FlatLabelUI() {
+		this( false );
+	}
+
 	/** @since 2 */
 	protected FlatLabelUI( boolean shared ) {
 		this.shared = shared;

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatPanelUI.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatPanelUI.java
@@ -58,6 +58,10 @@ public class FlatPanelUI
 			: new FlatPanelUI( false );
 	}
 
+	public FlatPanelUI() {
+		this( false );
+	}
+
 	/** @since 2 */
 	protected FlatPanelUI( boolean shared ) {
 		this.shared = shared;

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatPopupMenuSeparatorUI.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatPopupMenuSeparatorUI.java
@@ -44,6 +44,10 @@ public class FlatPopupMenuSeparatorUI
 			: new FlatPopupMenuSeparatorUI( false );
 	}
 
+	public FlatPopupMenuSeparatorUI() {
+		this( false );
+	}
+
 	/** @since 2 */
 	protected FlatPopupMenuSeparatorUI( boolean shared ) {
 		super( shared );

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatRadioButtonUI.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatRadioButtonUI.java
@@ -83,6 +83,10 @@ public class FlatRadioButtonUI
 			: new FlatRadioButtonUI( false );
 	}
 
+	public FlatRadioButtonUI() {
+		this( false );
+	}
+
 	/** @since 2 */
 	protected FlatRadioButtonUI( boolean shared ) {
 		this.shared = shared;

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatSeparatorUI.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatSeparatorUI.java
@@ -67,6 +67,10 @@ public class FlatSeparatorUI
 			: new FlatSeparatorUI( false );
 	}
 
+	public FlatSeparatorUI() {
+		this( false );
+	}
+
 	/** @since 2 */
 	protected FlatSeparatorUI( boolean shared ) {
 		this.shared = shared;

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatToggleButtonUI.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatToggleButtonUI.java
@@ -92,6 +92,10 @@ public class FlatToggleButtonUI
 			: new FlatToggleButtonUI( false );
 	}
 
+	public FlatToggleButtonUI() {
+		this( false );
+	}
+
 	protected FlatToggleButtonUI( boolean shared ) {
 		super( shared );
 	}

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatToolBarSeparatorUI.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatToolBarSeparatorUI.java
@@ -65,6 +65,10 @@ public class FlatToolBarSeparatorUI
 			: new FlatToolBarSeparatorUI( false );
 	}
 
+	public FlatToolBarSeparatorUI() {
+		this( false );
+	}
+
 	/** @since 2 */
 	protected FlatToolBarSeparatorUI( boolean shared ) {
 		this.shared = shared;


### PR DESCRIPTION
The introduction of the UI constructors with a `shared` boolean flag has removed the implicit default constructors. That change broke backwards compatibility for derived classes.