### PR TITLE
Add a system property to load pre-extracted native libraries from a directory

### DIFF
--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/FlatSystemProperties.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/FlatSystemProperties.java
@@ -140,6 +140,12 @@ public interface FlatSystemProperties
 	String USE_TEXT_Y_CORRECTION = "flatlaf.useTextYCorrection";
 
 	/**
+	 * Specifies a directory in which the native FlatLaf library have been extracted.
+	 * This can be used to avoid extraction of the native libraries to the temporary directory at runtime.
+	 */
+	String NATIVE_LIBRARY_PATH = "flatlaf.nativeLibraryPath";
+
+	/**
 	 * Checks whether a system property is set and returns {@code true} if its value
 	 * is {@code "true"} (case-insensitive), otherwise it returns {@code false}.
 	 * If the system property is not set, {@code defaultValue} is returned.

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatWindowsNativeWindowBorder.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatWindowsNativeWindowBorder.java
@@ -27,6 +27,7 @@ import java.awt.Window;
 import java.awt.geom.AffineTransform;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
+import java.io.File;
 import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.List;
@@ -37,6 +38,7 @@ import javax.swing.Timer;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import javax.swing.event.EventListenerList;
+import com.formdev.flatlaf.FlatSystemProperties;
 import com.formdev.flatlaf.util.LoggingFacade;
 import com.formdev.flatlaf.util.NativeLibrary;
 import com.formdev.flatlaf.util.SystemInfo;
@@ -114,11 +116,7 @@ class FlatWindowsNativeWindowBorder
 				}
 			}
 
-			String libraryName = "com/formdev/flatlaf/natives/flatlaf-windows-x86";
-			if( SystemInfo.isX86_64 )
-				libraryName += "_64";
-
-			nativeLibrary = new NativeLibrary( libraryName, null, true );
+			nativeLibrary = createNativeLibrary();
 		}
 
 		// check whether native library was successfully loaded
@@ -129,6 +127,24 @@ class FlatWindowsNativeWindowBorder
 		if( instance == null )
 			instance = new FlatWindowsNativeWindowBorder();
 		return instance;
+	}
+
+	private static NativeLibrary createNativeLibrary() {
+		String libraryName = "flatlaf-windows-x86";
+		if( SystemInfo.isX86_64 )
+			libraryName += "_64";
+
+		String libraryPath = System.getProperty( FlatSystemProperties.NATIVE_LIBRARY_PATH );
+		if( libraryPath != null ) {
+			File libraryFile = new File( libraryPath, libraryName + ".dll" );
+			if( libraryFile.exists() ) {
+				return new NativeLibrary( libraryFile, true );
+			} else {
+				LoggingFacade.INSTANCE.logSevere( "Did not find external library " + libraryFile + ", using extracted library instead", null );
+			}
+		}
+
+		return new NativeLibrary( "com/formdev/flatlaf/natives/" + libraryName, null, true );
 	}
 
 	private FlatWindowsNativeWindowBorder() {

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/util/NativeLibrary.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/util/NativeLibrary.java
@@ -61,6 +61,17 @@ public class NativeLibrary
 	}
 
 	/**
+	 * Load native library from given file.
+	 * @param libraryFile the file of the native library
+	 * @param supported whether the native library is supported on the current platform
+	 */
+	public NativeLibrary( File libraryFile, boolean supported ) {
+		this.loaded = supported
+			? loadLibraryFromFile( libraryFile )
+			: false;
+	}
+
+	/**
 	 * Returns whether the native library is loaded.
 	 * <p>
 	 * Returns {@code false} if not supported on current platform as specified in constructor
@@ -116,6 +127,16 @@ public class NativeLibrary
 
 			if( tempFile != null )
 				deleteOrMarkForDeletion( tempFile );
+			return false;
+		}
+	}
+
+	private boolean loadLibraryFromFile( File libraryFile ) {
+		try {
+			System.load( libraryFile.getPath() );
+			return true;
+		} catch( Throwable ex ) {
+			log( null, ex );
 			return false;
 		}
 	}


### PR DESCRIPTION
Added the system property flatlaf.nativeLibraryPath to specify a directory where the native libraries have been extracted.

Avoiding extraction at runtime to the temporary directory is useful in order to prevent anti-virus software from blocking the library loading.