### PR TITLE
File chooser shortcuts panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 FlatLaf Change Log
 ==================
 
+## 2.3-SNAPSHOT
+
+#### New features and improvements
+
+- FileChooser: Added (optional) shortcuts panel. On Windows it contains "Recent
+  Items", "Desktop", "Documents", "This PC" and "Network". On macOS and Linux it
+  is empty/hidden. (issue #100)
+
+
 ## 2.2
 
 #### New features and improvements

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatFileChooserUI.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatFileChooserUI.java
@@ -22,6 +22,7 @@ import java.awt.Dimension;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
 import java.awt.Insets;
+import java.awt.LayoutManager;
 import java.awt.RenderingHints;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
@@ -231,6 +232,25 @@ public class FlatFileChooserUI
 			}
 		} catch( ArrayIndexOutOfBoundsException ex ) {
 			// ignore
+		}
+
+		// put north, center and south components into a new panel so that
+		// the shortcuts panel (at west) gets full height
+		LayoutManager layout = fc.getLayout();
+		if( layout instanceof BorderLayout ) {
+			BorderLayout borderLayout = (BorderLayout) layout;
+			borderLayout.setHgap( 8 );
+
+			Component north = borderLayout.getLayoutComponent( BorderLayout.NORTH );
+			Component center = borderLayout.getLayoutComponent( BorderLayout.CENTER );
+			Component south = borderLayout.getLayoutComponent( BorderLayout.SOUTH );
+			if( north != null && center != null && south != null ) {
+				JPanel p = new JPanel( new BorderLayout( 0, 11 ) );
+				p.add( north, BorderLayout.NORTH );
+				p.add( center, BorderLayout.CENTER );
+				p.add( south, BorderLayout.SOUTH );
+				fc.add( p, BorderLayout.CENTER );
+			}
 		}
 	}
 

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatFileChooserUI.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatFileChooserUI.java
@@ -19,11 +19,19 @@ package com.formdev.flatlaf.ui;
 import java.awt.BorderLayout;
 import java.awt.Component;
 import java.awt.Dimension;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
 import java.awt.Insets;
+import java.awt.RenderingHints;
+import java.beans.PropertyChangeEvent;
+import java.beans.PropertyChangeListener;
 import java.io.File;
+import java.lang.reflect.Method;
+import java.util.function.Function;
 import javax.swing.AbstractButton;
 import javax.swing.Box;
 import javax.swing.BoxLayout;
+import javax.swing.ButtonGroup;
 import javax.swing.Icon;
 import javax.swing.ImageIcon;
 import javax.swing.JButton;
@@ -34,12 +42,16 @@ import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JTable;
 import javax.swing.JToggleButton;
+import javax.swing.JToolBar;
+import javax.swing.SwingConstants;
 import javax.swing.UIManager;
+import javax.swing.filechooser.FileSystemView;
 import javax.swing.filechooser.FileView;
 import javax.swing.plaf.ComponentUI;
 import javax.swing.plaf.metal.MetalFileChooserUI;
 import javax.swing.table.TableCellRenderer;
 import com.formdev.flatlaf.FlatClientProperties;
+import com.formdev.flatlaf.util.LoggingFacade;
 import com.formdev.flatlaf.util.ScaledImageIcon;
 import com.formdev.flatlaf.util.SystemInfo;
 import com.formdev.flatlaf.util.UIScale;
@@ -133,12 +145,21 @@ import com.formdev.flatlaf.util.UIScale;
  * @uiDefault FileChooser.listViewActionLabelText				String
  * @uiDefault FileChooser.detailsViewActionLabelText			String
  *
+ * <!-- FlatFileChooserUI -->
+ *
+ * @uiDefault FileChooser.shortcuts.buttonSize					Dimension	optional; default is 84,64
+ * @uiDefault FileChooser.shortcuts.iconSize					Dimension	optional; default is 32,32
+ * @uiDefault FileChooser.shortcuts.filesFunction				Function<File[], File[]>
+ * @uiDefault FileChooser.shortcuts.displayNameFunction			Function<File, String>
+ * @uiDefault FileChooser.shortcuts.iconFunction				Function<File, Icon>
+ *
  * @author Karl Tauber
  */
 public class FlatFileChooserUI
 	extends MetalFileChooserUI
 {
 	private final FlatFileView fileView = new FlatFileView();
+	private FlatShortcutsPanel shortcutsPanel;
 
 	public static ComponentUI createUI( JComponent c ) {
 		return new FlatFileChooserUI( (JFileChooser) c );
@@ -153,6 +174,25 @@ public class FlatFileChooserUI
 		super.installComponents( fc );
 
 		patchUI( fc );
+
+		if( !UIManager.getBoolean( "FileChooser.noPlacesBar" ) ) { // same as in Windows L&F
+			FlatShortcutsPanel panel = createShortcutsPanel( fc );
+			if( panel.getComponentCount() > 0 ) {
+				shortcutsPanel = panel;
+				fc.add( shortcutsPanel, BorderLayout.LINE_START );
+				fc.addPropertyChangeListener( shortcutsPanel );
+			}
+		}
+	}
+
+	@Override
+	public void uninstallComponents( JFileChooser fc ) {
+		super.uninstallComponents( fc );
+
+		if( shortcutsPanel != null ) {
+			fc.removePropertyChangeListener( shortcutsPanel );
+			shortcutsPanel = null;
+		}
 	}
 
 	private void patchUI( JFileChooser fc ) {
@@ -250,9 +290,19 @@ public class FlatFileChooserUI
 		return p;
 	}
 
+	/** @since 2.3 */
+	protected FlatShortcutsPanel createShortcutsPanel( JFileChooser fc ) {
+		return new FlatShortcutsPanel( fc );
+	}
+
 	@Override
 	public Dimension getPreferredSize( JComponent c ) {
-		return UIScale.scale( super.getPreferredSize( c ) );
+		Dimension prefSize = super.getPreferredSize( c );
+		Dimension minSize = getMinimumSize( c );
+		int shortcutsPanelWidth = (shortcutsPanel != null) ? shortcutsPanel.getPreferredSize().width : 0;
+		return new Dimension(
+			Math.max( prefSize.width, minSize.width + shortcutsPanelWidth ),
+			Math.max( prefSize.height, minSize.height ) );
 	}
 
 	@Override
@@ -314,6 +364,223 @@ public class FlatFileChooserUI
 			}
 
 			return icon;
+		}
+	}
+
+	//---- class FlatShortcutsPanel -------------------------------------------
+
+	/** @since 2.3 */
+	public static class FlatShortcutsPanel
+		extends JToolBar
+		implements PropertyChangeListener
+	{
+		private final JFileChooser fc;
+
+		private final Dimension buttonSize;
+		private final Dimension iconSize;
+		private final Function<File[], File[]> filesFunction;
+		private final Function<File, String> displayNameFunction;
+		private final Function<File, Icon> iconFunction;
+
+		protected final File[] files;
+		protected final JToggleButton[] buttons;
+		protected final ButtonGroup buttonGroup;
+
+		@SuppressWarnings( "unchecked" )
+		public FlatShortcutsPanel( JFileChooser fc ) {
+			super( JToolBar.VERTICAL );
+			this.fc = fc;
+			setFloatable( false );
+
+			buttonSize = UIScale.scale( getUIDimension( "FileChooser.shortcuts.buttonSize", 84, 64 ) );
+			iconSize = getUIDimension( "FileChooser.shortcuts.iconSize", 32, 32 );
+
+			filesFunction = (Function<File[], File[]>) UIManager.get( "FileChooser.shortcuts.filesFunction" );
+			displayNameFunction = (Function<File, String>) UIManager.get( "FileChooser.shortcuts.displayNameFunction" );
+			iconFunction = (Function<File, Icon>) UIManager.get( "FileChooser.shortcuts.iconFunction" );
+
+			FileSystemView fsv = fc.getFileSystemView();
+			File[] files = getChooserShortcutPanelFiles( fsv );
+			if( filesFunction != null )
+				files = filesFunction.apply( files );
+			this.files = files;
+
+			// create toolbar buttons
+			buttons = new JToggleButton[files.length];
+			buttonGroup = new ButtonGroup();
+			for( int i = 0; i < files.length; i++ ) {
+				// wrap drive path
+				if( fsv.isFileSystemRoot( files[i] ) )
+					files[i] = fsv.createFileObject( files[i].getAbsolutePath() );
+
+				File file = files[i];
+				String name = getDisplayName( fsv, file );
+				Icon icon = getIcon( fsv, file );
+
+				// remove path from name
+				int lastSepIndex = name.lastIndexOf( File.separatorChar );
+				if( lastSepIndex >= 0 && lastSepIndex < name.length() - 1 )
+					name = name.substring( lastSepIndex + 1 );
+
+				// scale icon (if necessary)
+				if( icon instanceof ImageIcon )
+					icon = new ScaledImageIcon( (ImageIcon) icon, iconSize.width, iconSize.height );
+				else if( icon != null )
+					icon = new ShortcutIcon( icon, iconSize.width, iconSize.height );
+
+				// create button
+				JToggleButton button = createButton( name, icon );
+				button.addActionListener( e -> {
+					fc.setCurrentDirectory( file );
+				} );
+
+				add( button );
+				buttonGroup.add( button );
+				buttons[i] = button;
+			}
+
+			directoryChanged( fc.getCurrentDirectory() );
+		}
+
+		private Dimension getUIDimension( String key, int defaultWidth, int defaultHeight ) {
+			Dimension size = UIManager.getDimension( key );
+			if( size == null )
+				size = new Dimension( defaultWidth, defaultHeight );
+			return size;
+		}
+
+		protected JToggleButton createButton( String name, Icon icon ) {
+			JToggleButton button = new JToggleButton( name, icon );
+			button.setVerticalTextPosition( SwingConstants.BOTTOM );
+			button.setHorizontalTextPosition( SwingConstants.CENTER );
+			button.setAlignmentX( Component.CENTER_ALIGNMENT );
+			button.setIconTextGap( 0 );
+			button.setPreferredSize( buttonSize );
+			button.setMaximumSize( buttonSize );
+			return button;
+		}
+
+		protected File[] getChooserShortcutPanelFiles( FileSystemView fsv ) {
+			try {
+				if( SystemInfo.isJava_12_orLater ) {
+					Method m = fsv.getClass().getMethod( "getChooserShortcutPanelFiles" );
+					File[] files = (File[]) m.invoke( fsv );
+
+					// on macOS and Linux, files consists only of the user home directory
+					if( files.length == 1 && files[0].equals( new File( System.getProperty( "user.home" ) ) ) )
+						files = new File[0];
+
+					return files;
+				} else if( SystemInfo.isWindows ) {
+					Class<?> cls = Class.forName( "sun.awt.shell.ShellFolder" );
+					Method m = cls.getMethod( "get", String.class );
+					return (File[]) m.invoke( null, "fileChooserShortcutPanelFolders" );
+				}
+			} catch( Exception ex ) {
+				LoggingFacade.INSTANCE.logSevere( null, ex );
+			}
+
+			// fallback
+			return new File[0];
+		}
+
+		protected String getDisplayName( FileSystemView fsv, File file ) {
+			if( displayNameFunction != null ) {
+				String name = displayNameFunction.apply( file );
+				if( name != null )
+					return name;
+			}
+
+			return fsv.getSystemDisplayName( file );
+		}
+
+		protected Icon getIcon( FileSystemView fsv, File file ) {
+			if( iconFunction != null ) {
+				Icon icon = iconFunction.apply( file );
+				if( icon != null )
+					return icon;
+			}
+
+			// Java 17+ supports getting larger system icons
+			if( SystemInfo.isJava_17_orLater ) {
+				try {
+					Method m = fsv.getClass().getMethod( "getSystemIcon", File.class, int.class, int.class );
+					return (Icon) m.invoke( fsv, file, iconSize.width, iconSize.height );
+				} catch( Exception ex ) {
+					LoggingFacade.INSTANCE.logSevere( null, ex );
+				}
+			}
+
+			// get system icon in default size 16x16
+			return fsv.getSystemIcon( file );
+		}
+
+		protected void directoryChanged( File file ) {
+			if( file != null ) {
+				String absolutePath = file.getAbsolutePath();
+				for( int i = 0; i < files.length; i++ ) {
+					// also compare path because otherwise selecting "Documents"
+					// in "Look in" combobox would not select "Documents" shortcut item
+					if( files[i].equals( file ) || files[i].getAbsolutePath().equals( absolutePath ) ) {
+						buttons[i].setSelected( true );
+						return;
+					}
+				}
+			}
+
+			buttonGroup.clearSelection();
+		}
+
+		@Override
+		public void propertyChange( PropertyChangeEvent e ) {
+			switch( e.getPropertyName() ) {
+				case JFileChooser.DIRECTORY_CHANGED_PROPERTY:
+					directoryChanged( fc.getCurrentDirectory() );
+					break;
+			}
+		}
+	}
+
+	//---- class ShortcutIcon -------------------------------------------------
+
+	private static class ShortcutIcon
+		implements Icon
+	{
+		private final Icon icon;
+		private final int iconWidth;
+		private final int iconHeight;
+
+		ShortcutIcon( Icon icon, int iconWidth, int iconHeight ) {
+			this.icon = icon;
+			this.iconWidth = iconWidth;
+			this.iconHeight = iconHeight;
+		}
+
+		@Override
+		public void paintIcon( Component c, Graphics g, int x, int y ) {
+			Graphics2D g2 = (Graphics2D) g.create();
+			try {
+				// set rendering hint for the case that the icon is a bitmap (not used for vector icons)
+				g2.setRenderingHint( RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BICUBIC );
+
+				double scale = (double) getIconWidth() / (double) icon.getIconWidth();
+				g2.translate( x, y );
+				g2.scale( scale, scale );
+
+				icon.paintIcon( c, g2, 0, 0 );
+			} finally {
+				g2.dispose();
+			}
+		}
+
+		@Override
+		public int getIconWidth() {
+			return UIScale.scale( iconWidth );
+		}
+
+		@Override
+		public int getIconHeight() {
+			return UIScale.scale( iconHeight );
 		}
 	}
 }

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/util/SystemInfo.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/util/SystemInfo.java
@@ -50,6 +50,7 @@ public class SystemInfo
 	public static final long javaVersion;
 	public static final boolean isJava_9_orLater;
 	public static final boolean isJava_11_orLater;
+	/** @since 2.3 */ public static final boolean isJava_12_orLater;
 	public static final boolean isJava_15_orLater;
 	/** @since 2 */ public static final boolean isJava_17_orLater;
 	/** @since 2 */ public static final boolean isJava_18_orLater;
@@ -92,6 +93,7 @@ public class SystemInfo
 		javaVersion = scanVersion( System.getProperty( "java.version" ) );
 		isJava_9_orLater = (javaVersion >= toVersion( 9, 0, 0, 0 ));
 		isJava_11_orLater = (javaVersion >= toVersion( 11, 0, 0, 0 ));
+		isJava_12_orLater = (javaVersion >= toVersion( 12, 0, 0, 0 ));
 		isJava_15_orLater = (javaVersion >= toVersion( 15, 0, 0, 0 ));
 		isJava_17_orLater = (javaVersion >= toVersion( 17, 0, 0, 0 ));
 		isJava_18_orLater = (javaVersion >= toVersion( 18, 0, 0, 0 ));

--- a/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatChooserTest.java
+++ b/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatChooserTest.java
@@ -16,7 +16,12 @@
 
 package com.formdev.flatlaf.testing;
 
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.function.Function;
 import javax.swing.*;
+import com.formdev.flatlaf.icons.FlatFileChooserHomeFolderIcon;
 import net.miginfocom.swing.*;
 
 /**
@@ -28,6 +33,24 @@ public class FlatChooserTest
 	public static void main( String[] args ) {
 		SwingUtilities.invokeLater( () -> {
 			FlatTestFrame frame = FlatTestFrame.create( args, "FlatChooserTest" );
+
+			UIManager.put( "FileChooser.shortcuts.filesFunction", (Function<File[], File[]>) files -> {
+				ArrayList<File> list = new ArrayList<>( Arrays.asList( files ) );
+				list.add( 0, new File( System.getProperty( "user.home" ) ) );
+				return list.toArray( new File[list.size()] );
+			} );
+
+			UIManager.put( "FileChooser.shortcuts.displayNameFunction", (Function<File, String>) file -> {
+				if( file.getAbsolutePath().equals( System.getProperty( "user.home" ) ) )
+					return "Home";
+				return null;
+			} );
+			UIManager.put( "FileChooser.shortcuts.iconFunction", (Function<File, Icon>) file -> {
+				if( file.getAbsolutePath().equals( System.getProperty( "user.home" ) ) )
+					return new FlatFileChooserHomeFolderIcon();
+				return null;
+			} );
+
 			frame.showFrame( FlatChooserTest::new );
 		} );
 	}

--- a/flatlaf-theme-editor/src/main/resources/com/formdev/flatlaf/themeeditor/FlatLafUIKeys.txt
+++ b/flatlaf-theme-editor/src/main/resources/com/formdev/flatlaf/themeeditor/FlatLafUIKeys.txt
@@ -252,6 +252,8 @@ FileChooser.homeFolderIcon
 FileChooser.listViewIcon
 FileChooser.newFolderIcon
 FileChooser.readOnly
+FileChooser.shortcuts.buttonSize
+FileChooser.shortcuts.iconSize
 FileChooser.upFolderIcon
 FileChooser.useSystemExtensionHiding
 FileChooser.usesSingleFilePane


### PR DESCRIPTION
This PR adds a shortcuts panel to the left side of all file choosers (class `JFileChooser`):

![image](https://user-images.githubusercontent.com/5604048/165567283-cfc30f8a-c4e6-4724-bc8d-e822472e1f53.png)

![image](https://user-images.githubusercontent.com/5604048/165567306-fb95af5c-3d54-4c4c-b37a-63dc6bd86d8b.png)

On Windows, the content of the shortcuts panel is the same as in the Java Windows L&F.
On macOS and Linux the shortcuts panel is empty and hidden.

However you can customize the content. E.g.

~~~java
UIManager.put( "FileChooser.shortcuts.filesFunction", (Function<File[], File[]>) files -> {
    ArrayList<File> list = new ArrayList<>( Arrays.asList( files ) );
    list.add( 0, new File( System.getProperty( "user.home" ) ) );
    return list.toArray( new File[list.size()] );
} );

UIManager.put( "FileChooser.shortcuts.displayNameFunction", (Function<File, String>) file -> {
    if( file.getAbsolutePath().equals( System.getProperty( "user.home" ) ) )
        return "Home";
    return null;
} );
UIManager.put( "FileChooser.shortcuts.iconFunction", (Function<File, Icon>) file -> {
    if( file.getAbsolutePath().equals( System.getProperty( "user.home" ) ) )
        return new FlatFileChooserHomeFolderIcon();
    return null;
} );
~~~

![image](https://user-images.githubusercontent.com/5604048/165568209-0bf3ab28-fed4-4dd7-8fb2-e463d50ebd32.png)

### Downsides

The get the list of shortcut folders and to get the large icons, FlatLaf uses API that is not available in all Java versions.

- the Java API to get list of shortcut folders is available since Java 12; reflection is used for older Java versions
- the Java API to get large icons is available since Java 17; reflection is used for older Java versions

So for Java 9 to 16 you'll get following warning on stdout when a file chooser is opened.

~~~
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by com.formdev.flatlaf.ui.FlatFileChooserUI$FlatShortcutsPanel (file:...) to method sun.awt.shell.ShellFolder.get(java.lang.String)
WARNING: Please consider reporting this to the maintainers of com.formdev.flatlaf.ui.FlatFileChooserUI$FlatShortcutsPanel
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
~~~

If you use `--illegal-access=deny`, then the shortcuts panel will be empty (Java 9 to 11),
and small icons are scaled up (Java 9 to 18).

CC @Chrriis 