### PR TITLE
ToggleButton: made underline placement configurable

### DIFF
--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/FlatClientProperties.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/FlatClientProperties.java
@@ -992,7 +992,28 @@ public interface FlatClientProperties
 	//---- JToggleButton ------------------------------------------------------
 
 	/**
-	 * Height of underline if toggle button type is {@link #BUTTON_TYPE_TAB}.
+	 * Placement of underline if toggle button type is {@link #BUTTON_TYPE_TAB}
+	 * <p>
+	 * <strong>Component</strong> {@link javax.swing.JToggleButton}<br>
+	 * <strong>Value type</strong> {@link java.lang.Integer}<br>
+	 * <strong>Default value</strong> {@link SwingConstants#BOTTOM}<br>
+	 * <strong>SupportedValues:</strong>
+	 * <table>
+	 * <thead>
+	 *     <tr><td>Placement</td><td>Constant</td><td>Value</td></tr>
+	 * </thead>
+	 * <tbody>
+	 *     <tr><td>TOP</td><td>{@link SwingConstants#TOP}</td><td>{@value SwingConstants#TOP}</td></tr>
+	 *     <tr><td>LEFT</td><td>{@link SwingConstants#LEFT}</td><td>{@value SwingConstants#LEFT}</td></tr>
+	 *     <tr><td>BOTTOM</td><td>{@link SwingConstants#BOTTOM}</td><td>{@value SwingConstants#BOTTOM}</td></tr>
+	 *     <tr><td>RIGHT</td><td>{@link SwingConstants#RIGHT}</td><td>{@value SwingConstants#RIGHT}</td></tr>
+	 * </tbody>
+	 * </table>
+	 */
+	String TAB_BUTTON_UNDERLINE_PLACEMENT = "JToggleButton.tab.underlinePlacement";
+
+	/**
+	 * Thickness of underline if toggle button type is {@link #BUTTON_TYPE_TAB}.
 	 * <p>
 	 * <strong>Component</strong> {@link javax.swing.JToggleButton}<br>
 	 * <strong>Value type</strong> {@link java.lang.Integer}

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatToggleButtonUI.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatToggleButtonUI.java
@@ -22,10 +22,7 @@ import java.awt.Component;
 import java.awt.Graphics;
 import java.beans.PropertyChangeEvent;
 import java.util.Map;
-import javax.swing.AbstractButton;
-import javax.swing.JComponent;
-import javax.swing.JToggleButton;
-import javax.swing.UIManager;
+import javax.swing.*;
 import javax.swing.plaf.ComponentUI;
 import com.formdev.flatlaf.ui.FlatStylingSupport.Styleable;
 import com.formdev.flatlaf.ui.FlatStylingSupport.UnknownStyleException;
@@ -142,6 +139,7 @@ public class FlatToggleButtonUI
 				b.repaint();
 				break;
 
+			case TAB_BUTTON_UNDERLINE_PLACEMENT:
 			case TAB_BUTTON_UNDERLINE_HEIGHT:
 			case TAB_BUTTON_UNDERLINE_COLOR:
 			case TAB_BUTTON_SELECTED_BACKGROUND:
@@ -196,11 +194,25 @@ public class FlatToggleButtonUI
 
 			// paint underline if selected
 			if( selected ) {
-				int underlineHeight = UIScale.scale( clientPropertyInt( c, TAB_BUTTON_UNDERLINE_HEIGHT, tabUnderlineHeight ) );
+				int underlineThickness = UIScale.scale( clientPropertyInt( c, TAB_BUTTON_UNDERLINE_HEIGHT, tabUnderlineHeight ) );
 				g.setColor( c.isEnabled()
 					? clientPropertyColor( c, TAB_BUTTON_UNDERLINE_COLOR, tabUnderlineColor )
 					: tabDisabledUnderlineColor );
-				g.fillRect( 0, height - underlineHeight, width, underlineHeight );
+				int placement = clientPropertyInt( c, TAB_BUTTON_UNDERLINE_PLACEMENT, SwingConstants.BOTTOM );
+				switch (placement) {
+					case SwingConstants.TOP:
+						g.fillRect( 0, 0, width, underlineThickness );
+						break;
+					case SwingConstants.LEFT:
+						g.fillRect( 0, 0, underlineThickness, height );
+						break;
+					case SwingConstants.RIGHT:
+						g.fillRect( width - underlineThickness, 0, underlineThickness, height );
+						break;
+					case SwingConstants.BOTTOM:
+					default:
+						g.fillRect( 0, height - underlineThickness, width, underlineThickness );
+				}
 			}
 		} else
 			super.paintBackground( g, c );

--- a/flatlaf-extras/src/main/java/com/formdev/flatlaf/extras/components/FlatToggleButton.java
+++ b/flatlaf-extras/src/main/java/com/formdev/flatlaf/extras/components/FlatToggleButton.java
@@ -18,7 +18,7 @@ package com.formdev.flatlaf.extras.components;
 
 import static com.formdev.flatlaf.FlatClientProperties.*;
 import java.awt.Color;
-import javax.swing.JToggleButton;
+import javax.swing.*;
 import com.formdev.flatlaf.extras.components.FlatButton.ButtonType;
 
 /**
@@ -116,6 +116,24 @@ public class FlatToggleButton
 		putClientProperty( OUTLINE, outline );
 	}
 
+	/**
+	 * Returns placement of underline if toggle button type is {@link ButtonType#tab}.
+	 * If underline placement is not specified, returns {@link #BOTTOM} as the default
+	 * value.
+	 */
+	public int getTabUnderlinePlacement() {
+		return getClientPropertyInt( TAB_BUTTON_UNDERLINE_PLACEMENT, BOTTOM );
+	}
+
+	/**
+	 * Specifies placement of underline if toggle button type is {@link ButtonType#tab}.
+	 *
+	 * @param placement  One of the following constants defined in SwingConstants:
+	 *                   {@link #TOP}, {@link #LEFT}, {@link #BOTTOM}, or {@link #RIGHT}.
+	 */
+	public void setTabUnderlinePlacement( int placement ) {
+		putClientProperty( TAB_BUTTON_UNDERLINE_PLACEMENT, (placement < 0 || placement >= RIGHT) ? null : placement);
+	}
 
 	/**
 	 * Returns height of underline if toggle button type is {@link ButtonType#tab}.


### PR DESCRIPTION
Addresses issue #529 - Make the underline placement of tab-style toggle buttons configurable

This PR allows to paint the underline of tab-style toggle buttons on different sides of the button:
Supported values: `TOP`, `LEFT`, `BOTTOM`, or `RIGHT`

I have updated the wording of the FlatClientProperties#TAB_BUTTON_UNDERLINE_HEIGHT javadoc to reflect the changes in this contribution. In this comment, `Height of underline` has been replaced by `Thickness of underline`.

The property `TAB_BUTTON_UNDERLINE_HEIGHT` itself has not be renamed as to not introduce a breaking change in the API.