### PR TITLE
macOS light and dark themes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,7 @@ out/
 *.iml
 *.ipr
 *.iws
+*.xcuserstate
+*.xcworkspacedata
 .vs/
 .vscode/

--- a/flatlaf-core/build.gradle.kts
+++ b/flatlaf-core/build.gradle.kts
@@ -87,7 +87,7 @@ tasks {
 					"action" to "generate",
 					"fileName" to "${project.name}-sigtest.txt",
 					"classpath" to jar.get().outputs.files.asPath,
-					"packages" to "com.formdev.flatlaf,com.formdev.flatlaf.util",
+					"packages" to "com.formdev.flatlaf,com.formdev.flatlaf.themes,com.formdev.flatlaf.util",
 					"version" to version,
 					"release" to "1.8", // Java version
 					"failonerror" to "true" )

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/themes/FlatMacDarkLaf.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/themes/FlatMacDarkLaf.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2022 FormDev Software GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.formdev.flatlaf.themes;
+
+import javax.swing.UIManager;
+import com.formdev.flatlaf.FlatDarkLaf;
+
+/**
+ * A Flat LaF that imitates macOS dark look.
+ * <p>
+ * The UI defaults are loaded from {@code FlatMacDarkLaf.properties},
+ * {@code FlatDarkLaf.properties} and {@code FlatLaf.properties}.
+ *
+ * @author Karl Tauber
+ * @since 3
+ */
+public class FlatMacDarkLaf
+	extends FlatDarkLaf
+{
+	public static final String NAME = "FlatLaf macOS Dark";
+
+	/**
+	 * Sets the application look and feel to this LaF
+	 * using {@link UIManager#setLookAndFeel(javax.swing.LookAndFeel)}.
+	 */
+	public static boolean setup() {
+		return setup( new FlatMacDarkLaf() );
+	}
+
+	/**
+	 * Adds this look and feel to the set of available look and feels.
+	 * <p>
+	 * Useful if your application uses {@link UIManager#getInstalledLookAndFeels()}
+	 * to query available LaFs and display them to the user in a combobox.
+	 */
+	public static void installLafInfo() {
+		installLafInfo( NAME, FlatMacDarkLaf.class );
+	}
+
+	@Override
+	public String getName() {
+		return NAME;
+	}
+
+	@Override
+	public String getDescription() {
+		return "FlatLaf macOS Dark Look and Feel";
+	}
+
+	@Override
+	public boolean isDark() {
+		return true;
+	}
+}

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/themes/FlatMacLightLaf.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/themes/FlatMacLightLaf.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2022 FormDev Software GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.formdev.flatlaf.themes;
+
+import javax.swing.UIManager;
+import com.formdev.flatlaf.FlatLightLaf;
+
+/**
+ * A Flat LaF that imitates macOS light look.
+ * <p>
+ * The UI defaults are loaded from {@code FlatMacLightLaf.properties},
+ * {@code FlatLightLaf.properties} and {@code FlatLaf.properties}.
+ *
+ * @author Karl Tauber
+ * @since 3
+ */
+public class FlatMacLightLaf
+	extends FlatLightLaf
+{
+	public static final String NAME = "FlatLaf macOS Light";
+
+	/**
+	 * Sets the application look and feel to this LaF
+	 * using {@link UIManager#setLookAndFeel(javax.swing.LookAndFeel)}.
+	 */
+	public static boolean setup() {
+		return setup( new FlatMacLightLaf() );
+	}
+
+	/**
+	 * Adds this look and feel to the set of available look and feels.
+	 * <p>
+	 * Useful if your application uses {@link UIManager#getInstalledLookAndFeels()}
+	 * to query available LaFs and display them to the user in a combobox.
+	 */
+	public static void installLafInfo() {
+		installLafInfo( NAME, FlatMacLightLaf.class );
+	}
+
+	@Override
+	public String getName() {
+		return NAME;
+	}
+
+	@Override
+	public String getDescription() {
+		return "FlatLaf macOS Light Look and Feel";
+	}
+
+	@Override
+	public boolean isDark() {
+		return false;
+	}
+}

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatArrowButton.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatArrowButton.java
@@ -49,8 +49,10 @@ public class FlatArrowButton
 	protected Color pressedBackground;
 
 	private int arrowWidth = DEFAULT_ARROW_WIDTH;
+	private float arrowThickness = 1;
 	private float xOffset = 0;
 	private float yOffset = 0;
+	private boolean roundBorderAutoXOffset = true;
 
 	private boolean hover;
 	private boolean pressed;
@@ -121,6 +123,16 @@ public class FlatArrowButton
 		this.arrowWidth = arrowWidth;
 	}
 
+	/** @since 3 */
+	public float getArrowThickness() {
+		return arrowThickness;
+	}
+
+	/** @since 3 */
+	public void setArrowThickness( float arrowThickness ) {
+		this.arrowThickness = arrowThickness;
+	}
+
 	protected boolean isHover() {
 		return hover;
 	}
@@ -143,6 +155,16 @@ public class FlatArrowButton
 
 	public void setYOffset( float yOffset ) {
 		this.yOffset = yOffset;
+	}
+
+	/** @since 3 */
+	public boolean isRoundBorderAutoXOffset() {
+		return roundBorderAutoXOffset;
+	}
+
+	/** @since 3 */
+	public void setRoundBorderAutoXOffset( boolean roundBorderAutoXOffset ) {
+		this.roundBorderAutoXOffset = roundBorderAutoXOffset;
 	}
 
 	protected Color deriveBackground( Color background ) {
@@ -208,14 +230,17 @@ public class FlatArrowButton
 	}
 
 	protected void paintArrow( Graphics2D g ) {
-		boolean vert = (direction == NORTH || direction == SOUTH);
 		int x = 0;
 
 		// move arrow for round borders
-		Container parent = getParent();
-		if( vert && parent instanceof JComponent && FlatUIUtils.hasRoundBorder( (JComponent) parent ) )
-			x -= scale( parent.getComponentOrientation().isLeftToRight() ? 1 : -1 );
+		if( isRoundBorderAutoXOffset() ) {
+			Container parent = getParent();
+			boolean vert = (direction == NORTH || direction == SOUTH);
+			if( vert && parent instanceof JComponent && FlatUIUtils.hasRoundBorder( (JComponent) parent ) )
+				x -= scale( parent.getComponentOrientation().isLeftToRight() ? 1 : -1 );
+		}
 
-		FlatUIUtils.paintArrow( g, x, 0, getWidth(), getHeight(), getDirection(), chevron, getArrowWidth(), getXOffset(), getYOffset() );
+		FlatUIUtils.paintArrow( g, x, 0, getWidth(), getHeight(), getDirection(), chevron,
+			getArrowWidth(), getArrowThickness(), getXOffset(), getYOffset() );
 	}
 }

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatComboBoxUI.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatComboBoxUI.java
@@ -70,6 +70,7 @@ import javax.swing.plaf.basic.BasicComboBoxUI;
 import javax.swing.plaf.basic.BasicComboPopup;
 import javax.swing.plaf.basic.ComboPopup;
 import javax.swing.text.JTextComponent;
+import com.formdev.flatlaf.icons.FlatCheckBoxMenuItemIcon;
 import com.formdev.flatlaf.ui.FlatStylingSupport.Styleable;
 import com.formdev.flatlaf.ui.FlatStylingSupport.StyleableField;
 import com.formdev.flatlaf.ui.FlatStylingSupport.StyleableLookupProvider;
@@ -850,12 +851,19 @@ public class FlatComboBoxUI
 				}
 			}
 
+			// for style "mac", add width of "checked item" icon
+			boolean isPopupOverComboBox = isPopupOverComboBox();
+			int selectedIndex = -1;
+			if( isPopupOverComboBox && (selectedIndex = comboBox.getSelectedIndex()) >= 0 )
+				displayWidth += MacCheckedItemIcon.INSTANCE.getIconWidth() + scale( CellPaddingBorder.MAC_STYLE_GAP );
+
 			// add width of vertical scroll bar
 			JScrollBar verticalScrollBar = scroller.getVerticalScrollBar();
 			if( verticalScrollBar != null )
 				displayWidth += verticalScrollBar.getPreferredSize().width;
 
 			// make popup wider if necessary
+			int pw0 = pw;
 			if( displayWidth > pw ) {
 				// limit popup width to screen width
 				GraphicsConfiguration gc = comboBox.getGraphicsConfiguration();
@@ -873,6 +881,30 @@ public class FlatComboBoxUI
 
 				if( !comboBox.getComponentOrientation().isLeftToRight() )
 					px -= diff;
+			}
+
+			// for style "mac", place popup over combobox
+			Rectangle cellBounds;
+			if( isPopupOverComboBox && selectedIndex >= 0 &&
+				(cellBounds = list.getCellBounds( 0, 0 )) != null )
+			{
+				Insets comboBoxInsets = comboBox.getInsets();
+				Insets listInsets = list.getInsets();
+				Insets popupInsets = getInsets();
+
+				// position popup so that selected item is at same Y position as combobox
+				py -= (cellBounds.height * (selectedIndex + 1)) + comboBoxInsets.top + listInsets.top + popupInsets.top;
+
+				// position popup slightly to the left so that a small part of the right side of the combobox stays visible
+				int offset = Math.min( pw - pw0, MacCheckedItemIcon.INSTANCE.getIconWidth() ) + scale( 4 );
+				if( comboBox.getComponentOrientation().isLeftToRight() )
+					px -= offset + comboBoxInsets.right + listInsets.right;
+				else
+					px += offset + comboBoxInsets.left + listInsets.left;
+
+				// not invoking super.computePopupBounds() here to let
+				// JPopupMenu.adjustPopupLocationToFitScreen() fix the location if necessary
+				return new Rectangle( px, py, pw, ph );
 			}
 
 			return super.computePopupBounds( px, py, pw, ph );
@@ -954,6 +986,15 @@ public class FlatComboBoxUI
 			paddingBorder.uninstall();
 		}
 
+		private boolean isPopupOverComboBox() {
+			return isMacStyle() &&
+				!comboBox.isEditable() &&
+				comboBox.getItemCount() > 0 &&
+				comboBox.getItemCount() <= comboBox.getMaximumRowCount() &&
+				// for compatibility with Aqua Laf
+				!clientPropertyBoolean( comboBox, "JComboBox.isPopDown", false );
+		}
+
 		//---- class PopupListCellRenderer -----
 
 		private class PopupListCellRenderer
@@ -971,6 +1012,13 @@ public class FlatComboBoxUI
 				Component c = renderer.getListCellRendererComponent( list, value, index, isSelected, cellHasFocus );
 				c.applyComponentOrientation( comboBox.getComponentOrientation() );
 
+				// style "mac"
+				if( isPopupOverComboBox() && c instanceof JComponent ) {
+					int selectedIndex = comboBox.getSelectedIndex();
+					((JComponent)c).putClientProperty( CellPaddingBorder.KEY_MAC_STYLE_HINT,
+						(selectedIndex >= 0) ? (index == selectedIndex) : null );
+				}
+
 				paddingBorder.install( c, Math.round( FlatUIUtils.getBorderFocusWidth( comboBox ) ) );
 
 				return c;
@@ -987,10 +1035,16 @@ public class FlatComboBoxUI
 	 * which vertically aligns text in popup list with text in combobox.
 	 * <p>
 	 * The renderer border is painted on the outer side of this border.
+	 * <p>
+	 * For button style "mac", also used to increase insets on left side for
+	 * "checked item" icon and to paint "checked item" icon for selected combobox item.
 	 */
 	private static class CellPaddingBorder
 		extends AbstractBorder
 	{
+		static final String KEY_MAC_STYLE_HINT = "FlatLaf.internal.FlatComboBoxUI.macStyleHint";
+		static final int MAC_STYLE_GAP = 4;
+
 		private Insets padding;
 		private JComponent rendererComponent;
 		private Border rendererBorder;
@@ -1040,6 +1094,8 @@ public class FlatComboBoxUI
 			if( rendererComponent == null )
 				return;
 
+			rendererComponent.putClientProperty( KEY_MAC_STYLE_HINT, null );
+
 			if( rendererComponent.getBorder() == this )
 				rendererComponent.setBorder( rendererBorder );
 			rendererComponent = null;
@@ -1067,6 +1123,18 @@ public class FlatComboBoxUI
 			insets.left += focusWidth;
 			insets.right += focusWidth;
 
+			// style "mac"
+			if( c instanceof JComponent ) {
+				Boolean macStyleHint = clientPropertyBooleanStrict( (JComponent) c, KEY_MAC_STYLE_HINT, null );
+				if( macStyleHint != null ) {
+					int indent = MacCheckedItemIcon.INSTANCE.getIconWidth() + scale( MAC_STYLE_GAP );
+					if( c.getComponentOrientation().isLeftToRight() )
+						insets.left += indent;
+					else
+						insets.right += indent;
+				}
+			}
+
 			return insets;
 		}
 
@@ -1074,6 +1142,35 @@ public class FlatComboBoxUI
 		public void paintBorder( Component c, Graphics g, int x, int y, int width, int height ) {
 			if( rendererBorder != null )
 				rendererBorder.paintBorder( c, g, x, y, width, height );
+
+			// style "mac"
+			if( c instanceof JComponent ) {
+				Boolean macStyleHint = clientPropertyBooleanStrict( (JComponent) c, KEY_MAC_STYLE_HINT, null );
+				if( macStyleHint == Boolean.TRUE ) {
+					// paint "checked item" icon
+					int ix = c.getComponentOrientation().isLeftToRight()
+						? x + scale( padding.left )
+						: x + width - scale( padding.right ) - MacCheckedItemIcon.INSTANCE.getIconWidth();
+					MacCheckedItemIcon.INSTANCE.paintIcon( c, g, ix, y + ((height - MacCheckedItemIcon.INSTANCE.getIconHeight()) / 2) );
+				}
+			}
+		}
+	}
+
+	//---- class MacCheckedItemIcon -------------------------------------------
+
+	/**
+	 * Use for style "mac" to mark checked item.
+	 */
+	private static class MacCheckedItemIcon
+		extends FlatCheckBoxMenuItemIcon
+	{
+		static MacCheckedItemIcon INSTANCE = new MacCheckedItemIcon();
+
+		@Override
+		protected void paintIcon( Component c, Graphics2D g2 ) {
+			g2.setColor( c.getForeground() );
+			paintCheckmark( g2 );
 		}
 	}
 

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatSpinnerUI.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatSpinnerUI.java
@@ -65,7 +65,7 @@ import com.formdev.flatlaf.util.LoggingFacade;
  * <!-- FlatSpinnerUI -->
  *
  * @uiDefault Component.minimumWidth			int
- * @uiDefault Spinner.buttonStyle				String	button (default) or none
+ * @uiDefault Spinner.buttonStyle				String	button (default), mac or none
  * @uiDefault Component.arrowType				String	chevron (default) or triangle
  * @uiDefault Component.isIntelliJTheme			boolean
  * @uiDefault Spinner.disabledBackground		Color
@@ -347,6 +347,13 @@ public class FlatSpinnerUI
 			installNextButtonListeners( button );
 		else
 			installPreviousButtonListeners( button );
+
+		if( "mac".equals( buttonStyle ) ) {
+			button.setArrowWidth( 7 );
+			button.setArrowThickness( 1.5f );
+			button.setYOffset( (direction == SwingConstants.NORTH) ? 0.75f : -0.75f );
+			button.setRoundBorderAutoXOffset( false );
+		}
 		return button;
 	}
 
@@ -387,26 +394,50 @@ public class FlatSpinnerUI
 			int arrowX = button.getX();
 			int arrowWidth = button.getWidth();
 			boolean isLeftToRight = spinner.getComponentOrientation().isLeftToRight();
-
-			// paint arrow buttons background
-			if( enabled && buttonBackground != null ) {
-				g2.setColor( buttonBackground );
-				Shape oldClip = g2.getClip();
-				if( isLeftToRight )
-					g2.clipRect( arrowX, 0, width - arrowX, height );
-				else
-					g2.clipRect( 0, 0, arrowX + arrowWidth, height );
-				FlatUIUtils.paintComponentBackground( g2, 0, 0, width, height, focusWidth, arc );
-				g2.setClip( oldClip );
-			}
-
-			// paint vertical line between value and arrow buttons
 			Color separatorColor = enabled ? buttonSeparatorColor : buttonDisabledSeparatorColor;
-			if( separatorColor != null && buttonSeparatorWidth > 0 ) {
-				g2.setColor( separatorColor );
+
+			if( "mac".equals( buttonStyle ) ) {
+				Insets insets = spinner.getInsets();
+				int gapX = scale( 3 );
+				int gapY = scale( 1 );
+				int bx = arrowX + gapX;
+				int by = insets.top + gapY;
+				int bw = arrowWidth - (gapX * 2);
+				int bh = height - insets.top - insets.bottom - (gapY * 2);
 				float lw = scale( buttonSeparatorWidth );
-				float lx = isLeftToRight ? arrowX : arrowX + arrowWidth - lw;
-				g2.fill( new Rectangle2D.Float( lx, focusWidth, lw, height - 1 - (focusWidth * 2) ) );
+
+				// buttons border
+				FlatUIUtils.paintOutlinedComponent( g2, bx, by, bw, bh,
+					0, 0, 0, lw, arc - focusWidth,
+					null, separatorColor, buttonBackground );
+
+				// separator between buttons
+				if( separatorColor != null ) {
+					int thickness = scale( 1 );
+					g2.setColor( separatorColor );
+					g2.fill( new Rectangle2D.Float( bx + lw, by + ((bh - thickness) / 2f),
+						bw - (lw * 2), thickness ) );
+				}
+			} else {
+				// paint arrow buttons background
+				if( enabled && buttonBackground != null ) {
+					g2.setColor( buttonBackground );
+					Shape oldClip = g2.getClip();
+					if( isLeftToRight )
+						g2.clipRect( arrowX, 0, width - arrowX, height );
+					else
+						g2.clipRect( 0, 0, arrowX + arrowWidth, height );
+					FlatUIUtils.paintComponentBackground( g2, 0, 0, width, height, focusWidth, arc );
+					g2.setClip( oldClip );
+				}
+
+				// paint vertical line between value and arrow buttons
+				if( separatorColor != null && buttonSeparatorWidth > 0 ) {
+					g2.setColor( separatorColor );
+					float lw = scale( buttonSeparatorWidth );
+					float lx = isLeftToRight ? arrowX : arrowX + arrowWidth - lw;
+					g2.fill( new Rectangle2D.Float( lx, focusWidth, lw, height - 1 - (focusWidth * 2) ) );
+				}
 			}
 		}
 

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatUIUtils.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatUIUtils.java
@@ -904,13 +904,15 @@ public class FlatUIUtils
 	 *        {@link SwingConstants#WEST} or {@link SwingConstants#EAST})
 	 * @param chevron {@code true} for chevron arrow, {@code false} for triangle arrow
 	 * @param arrowSize the width of the painted arrow (for vertical direction) (will be scaled)
+	 * @param arrowThickness the thickness of the painted chevron arrow (will be scaled)
 	 * @param xOffset an offset added to the x coordinate of the arrow to paint it out-of-center. Usually zero. (will be scaled)
 	 * @param yOffset an offset added to the y coordinate of the arrow to paint it out-of-center. Usually zero. (will be scaled)
 	 *
-	 * @since 1.1
+	 * @since 3
 	 */
 	public static void paintArrow( Graphics2D g, int x, int y, int width, int height,
-		int direction, boolean chevron, int arrowSize, float xOffset, float yOffset )
+		int direction, boolean chevron, int arrowSize, float arrowThickness,
+		float xOffset, float yOffset )
 	{
 		// compute arrow width/height
 		// - make chevron arrows one pixel smaller because coordinates are based on center of pixels (0.5/0.5)
@@ -944,7 +946,7 @@ debug*/
 		Shape arrowShape = createArrowShape( direction, chevron, aw, ah );
 		if( chevron ) {
 			Stroke oldStroke = g.getStroke();
-			g.setStroke( new BasicStroke( UIScale.scale( 1f ) ) );
+			g.setStroke( new BasicStroke( UIScale.scale( arrowThickness ) ) );
 			drawShapePure( g, arrowShape );
 			g.setStroke( oldStroke );
 		} else {

--- a/flatlaf-core/src/main/module-info/module-info.java
+++ b/flatlaf-core/src/main/module-info/module-info.java
@@ -22,6 +22,7 @@ module com.formdev.flatlaf {
 
 	exports com.formdev.flatlaf;
 	exports com.formdev.flatlaf.icons;
+	exports com.formdev.flatlaf.themes;
 	exports com.formdev.flatlaf.ui;
 	exports com.formdev.flatlaf.util;
 

--- a/flatlaf-core/src/main/resources/com/formdev/flatlaf/FlatDarkLaf.properties
+++ b/flatlaf-core/src/main/resources/com/formdev/flatlaf/FlatDarkLaf.properties
@@ -50,8 +50,9 @@
 @selectionInactiveForeground = @foreground
 
 # menu
+@menuSelectionBackground = @selectionBackground
 @menuHoverBackground = lighten(@menuBackground,10%,derived)
-@menuCheckBackground = darken(@selectionBackground,10%,derived noAutoInverse)
+@menuCheckBackground = darken(@menuSelectionBackground,10%,derived noAutoInverse)
 @menuAcceleratorForeground = darken(@foreground,15%)
 @menuAcceleratorSelectionForeground = @selectionForeground
 

--- a/flatlaf-core/src/main/resources/com/formdev/flatlaf/FlatLightLaf.properties
+++ b/flatlaf-core/src/main/resources/com/formdev/flatlaf/FlatLightLaf.properties
@@ -50,8 +50,9 @@
 @selectionInactiveForeground = @foreground
 
 # menu
+@menuSelectionBackground = @selectionBackground
 @menuHoverBackground = darken(@menuBackground,10%,derived)
-@menuCheckBackground = lighten(@selectionBackground,40%,derived noAutoInverse)
+@menuCheckBackground = lighten(@menuSelectionBackground,40%,derived noAutoInverse)
 @menuAcceleratorForeground = lighten(@foreground,30%)
 @menuAcceleratorSelectionForeground = @selectionForeground
 

--- a/flatlaf-core/src/main/resources/com/formdev/flatlaf/themes/FlatMacDarkLaf.properties
+++ b/flatlaf-core/src/main/resources/com/formdev/flatlaf/themes/FlatMacDarkLaf.properties
@@ -1,0 +1,246 @@
+#
+# Copyright 2022 FormDev Software GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# base theme (light, dark, intellij or darcula); only used by theme editor
+@baseTheme = dark
+
+
+#---- macOS NSColor system colors (in NSColorSpace.deviceRGB) ----
+# generated on macOS 12.2 using Xcode and flatlaf-testing/misc/MacOSColorDump.playground
+
+@nsLabelColor = #ffffffd8
+@nsSecondaryLabelColor = #ffffff8c
+@nsTertiaryLabelColor = #ffffff3f
+@nsQuaternaryLabelColor = #ffffff19
+@nsSystemRedColor = #ff453a
+@nsSystemGreenColor = #32d74b
+@nsSystemBlueColor = #0a84ff
+@nsSystemOrangeColor = #ff9f0a
+@nsSystemYellowColor = #ffd60a
+@nsSystemBrownColor = #ac8e68
+@nsSystemPinkColor = #ff375f
+@nsSystemPurpleColor = #bf5af2
+@nsSystemTealColor = #6ac4dc
+@nsSystemIndigoColor = #5e5ce6
+@nsSystemMintColor = #63e6e2
+@nsSystemCyanColor = #5ac8f5
+@nsSystemGrayColor = #98989d
+@nsLinkColor = #419cff
+@nsPlaceholderTextColor = #ffffff3f
+@nsWindowFrameTextColor = #ffffffd8
+@nsSelectedMenuItemTextColor = #ffffff
+@nsAlternateSelectedControlTextColor = #ffffff
+@nsHeaderTextColor = #ffffff
+@nsSeparatorColor = #ffffff19
+@nsGridColor = #1a1a1a
+@nsTextColor = #ffffff
+@nsTextBackgroundColor = #1e1e1e
+@nsSelectedTextColor = #ffffff
+@nsSelectedTextBackgroundColor = #3f638b
+@nsUnemphasizedSelectedTextBackgroundColor = #464646
+@nsUnemphasizedSelectedTextColor = #ffffff
+@nsWindowBackgroundColor = #323232
+@nsUnderPageBackgroundColor = #282828
+@nsControlBackgroundColor = #1e1e1e
+@nsSelectedContentBackgroundColor = #0058d0
+@nsUnemphasizedSelectedContentBackgroundColor = #464646
+@nsFindHighlightColor = #ffff00
+@nsControlColor = #ffffff3f
+@nsControlTextColor = #ffffffd8
+@nsSelectedControlColor = #3f638b
+@nsSelectedControlTextColor = #ffffffd8
+@nsDisabledControlTextColor = #ffffff3f
+@nsKeyboardFocusIndicatorColor = #1aa9ff7f
+@nsControlAccentColor = #007aff
+
+# accent colors are:
+#    @nsSelectedTextBackgroundColor
+#    @nsSelectedContentBackgroundColor
+#    @nsSelectedControlColor
+#    @nsKeyboardFocusIndicatorColor
+#    @nsControlAccentColor
+
+
+#---- variables ----
+
+# general background and foreground (text color)
+@background = @nsControlBackgroundColor
+@foreground = over(@nsControlTextColor,@background)
+@disabledForeground = over(@nsSecondaryLabelColor,@background)
+
+# component background
+@buttonBackground = over(@nsControlColor,@background)
+@componentBackground = darken(over(@nsControlColor,@background),18%)
+@disabledComponentBackground = darken(@componentBackground,2%)
+@menuBackground = lighten(@background,8%)
+
+# selection
+@selectionBackground = @nsSelectedContentBackgroundColor
+@selectionForeground = @nsSelectedMenuItemTextColor
+@selectionInactiveBackground = @nsUnemphasizedSelectedContentBackgroundColor
+
+# text selection
+@textSelectionBackground = @nsSelectedTextBackgroundColor
+@textSelectionForeground = @nsSelectedTextColor
+
+# accent colors (blueish)
+@accentColor = @nsControlAccentColor
+@accentFocusColor = @nsKeyboardFocusIndicatorColor
+
+
+#---- Button ----
+
+Button.arc = 12
+Button.borderWidth = 0
+Button.disabledBackground = darken($Button.background,10%)
+
+Button.default.borderWidth = 0
+
+Button.toolbar.hoverBackground = #fff1
+Button.toolbar.pressedBackground = #fff2
+Button.toolbar.selectedBackground = #fff3
+
+
+#---- CheckBox ----
+
+CheckBox.iconTextGap = 6
+CheckBox.arc = 7
+CheckBox.icon.focusWidth = null
+CheckBox.icon.style = filled
+CheckBox.icon[filled].borderWidth = 0
+CheckBox.icon[filled].selectedBorderWidth = 0
+CheckBox.icon[filled].background = darken(over(@nsControlColor,@background),3%)
+CheckBox.icon[filled].disabledBackground = darken($CheckBox.icon[filled].background,10%)
+CheckBox.icon[filled].selectedBackground = @accentColor
+CheckBox.icon[filled].checkmarkColor = fadeout(@nsSelectedMenuItemTextColor,15%)
+CheckBox.icon[filled].disabledCheckmarkColor = darken($CheckBox.icon[filled].checkmarkColor,45%)
+CheckBox.icon.focusedBackground = null
+
+
+#---- ComboBox ----
+
+ComboBox.buttonStyle = mac
+ComboBox.background = over(@nsControlColor,@background)
+ComboBox.editableBackground = @componentBackground
+ComboBox.disabledBackground = @disabledComponentBackground
+ComboBox.buttonBackground = @accentColor
+ComboBox.buttonArrowColor = @nsSelectedMenuItemTextColor
+ComboBox.buttonHoverArrowColor = darken($ComboBox.buttonArrowColor,15%,derived noAutoInverse)
+ComboBox.buttonPressedArrowColor = darken($ComboBox.buttonArrowColor,25%,derived noAutoInverse)
+ComboBox.popupBackground = @menuBackground
+
+
+#---- Component ----
+
+Component.focusWidth = 2
+Component.innerFocusWidth = 0
+Component.innerOutlineWidth = 0
+Component.arc = 12
+Component.borderColor = @nsSeparatorColor
+Component.disabledBorderColor = fadeout(@nsSeparatorColor,5%)
+
+
+#---- EditorPane ---
+
+EditorPane.disabledBackground = @disabledComponentBackground
+EditorPane.selectionBackground = @textSelectionBackground
+EditorPane.selectionForeground = @textSelectionForeground
+
+
+#---- FormattedTextField ---
+
+FormattedTextField.disabledBackground = @disabledComponentBackground
+FormattedTextField.selectionBackground = @textSelectionBackground
+FormattedTextField.selectionForeground = @textSelectionForeground
+
+
+#---- PasswordField ---
+
+PasswordField.disabledBackground = @disabledComponentBackground
+PasswordField.selectionBackground = @textSelectionBackground
+PasswordField.selectionForeground = @textSelectionForeground
+
+
+#---- ProgressBar ----
+
+ProgressBar.background = lighten(@background,8%)
+
+
+#---- RadioButton ----
+
+RadioButton.iconTextGap = 6
+RadioButton.icon.style = filled
+RadioButton.icon[filled].centerDiameter = 6
+
+
+#---- ScrollBar ----
+
+ScrollBar.width = 12
+ScrollBar.track = @componentBackground
+ScrollBar.thumb = @buttonBackground
+
+
+#---- Separator ----
+
+Separator.foreground = @nsSeparatorColor
+
+
+#---- Slider ----
+
+Slider.trackWidth = 3
+Slider.thumbSize = 14,14
+Slider.trackColor = lighten(@background,8%)
+Slider.thumbColor = lighten($Slider.trackColor,35%)
+Slider.disabledTrackColor = darken($Slider.trackColor,4%)
+Slider.disabledThumbColor = darken($Slider.thumbColor,32%)
+Slider.focusedColor = $Component.focusColor
+
+
+#---- Spinner ----
+
+Spinner.buttonStyle = mac
+Spinner.disabledBackground = @disabledComponentBackground
+Spinner.buttonBackground = @buttonBackground
+Spinner.buttonSeparatorWidth = 0
+
+
+#---- TextArea ---
+
+TextArea.disabledBackground = @disabledComponentBackground
+TextArea.selectionBackground = @textSelectionBackground
+TextArea.selectionForeground = @textSelectionForeground
+
+
+#---- TextField ----
+
+TextField.disabledBackground = @disabledComponentBackground
+TextField.selectionBackground = @textSelectionBackground
+TextField.selectionForeground = @textSelectionForeground
+
+
+#---- TextPane ---
+
+TextPane.disabledBackground = @disabledComponentBackground
+TextPane.selectionBackground = @textSelectionBackground
+TextPane.selectionForeground = @textSelectionForeground
+
+
+#---- ToggleButton ----
+
+ToggleButton.disabledBackground = $Button.disabledBackground
+ToggleButton.selectedBackground = lighten($ToggleButton.background,20%,derived)
+
+ToggleButton.toolbar.selectedBackground = #fff3

--- a/flatlaf-core/src/main/resources/com/formdev/flatlaf/themes/FlatMacDarkLaf.properties
+++ b/flatlaf-core/src/main/resources/com/formdev/flatlaf/themes/FlatMacDarkLaf.properties
@@ -192,6 +192,12 @@ ScrollBar.width = 12
 ScrollBar.track = @componentBackground
 ScrollBar.thumb = @buttonBackground
 
+# from FlatLaf.properties (when using not on macOS)
+ScrollBar.minimumThumbSize = 18,18
+ScrollBar.thumbInsets = 2,2,2,2
+ScrollBar.thumbArc = 999
+ScrollBar.hoverThumbWithTrack = true
+
 
 #---- Separator ----
 

--- a/flatlaf-core/src/main/resources/com/formdev/flatlaf/themes/FlatMacDarkLaf.properties
+++ b/flatlaf-core/src/main/resources/com/formdev/flatlaf/themes/FlatMacDarkLaf.properties
@@ -96,6 +96,10 @@
 @textSelectionBackground = @nsSelectedTextBackgroundColor
 @textSelectionForeground = @nsSelectedTextColor
 
+# menu
+@menuSelectionBackground = desaturate(@selectionBackground,20%)
+@menuItemMargin = 3,11,3,11
+
 # accent colors (blueish)
 @accentColor = @nsControlAccentColor
 @accentFocusColor = @nsKeyboardFocusIndicatorColor
@@ -141,6 +145,10 @@ ComboBox.buttonArrowColor = @nsSelectedMenuItemTextColor
 ComboBox.buttonHoverArrowColor = darken($ComboBox.buttonArrowColor,15%,derived noAutoInverse)
 ComboBox.buttonPressedArrowColor = darken($ComboBox.buttonArrowColor,25%,derived noAutoInverse)
 ComboBox.popupBackground = @menuBackground
+ComboBox.selectionBackground = @menuSelectionBackground
+ComboBox.popupInsets = 5,0,5,0
+ComboBox.selectionInsets = 0,5,0,5
+ComboBox.selectionArc = 8
 
 
 #---- Component ----
@@ -167,11 +175,36 @@ FormattedTextField.selectionBackground = @textSelectionBackground
 FormattedTextField.selectionForeground = @textSelectionForeground
 
 
+#---- MenuBar ----
+
+MenuBar.selectionInsets = 0,0,0,0
+MenuBar.selectionEmbeddedInsets = 3,0,3,0
+MenuBar.selectionArc = 8
+MenuBar.selectionBackground = lighten(@menuBackground,15%,derived)
+MenuBar.selectionForeground = @foreground
+
+
+#---- MenuItem ----
+
+MenuItem.selectionInsets = 0,5,0,5
+MenuItem.selectionArc = 8
+
+Menu.selectionBackground = @menuSelectionBackground
+MenuItem.selectionBackground = @menuSelectionBackground
+CheckBoxMenuItem.selectionBackground = @menuSelectionBackground
+RadioButtonMenuItem.selectionBackground = @menuSelectionBackground
+
+
 #---- PasswordField ---
 
 PasswordField.disabledBackground = @disabledComponentBackground
 PasswordField.selectionBackground = @textSelectionBackground
 PasswordField.selectionForeground = @textSelectionForeground
+
+
+#---- PopupMenu ----
+
+PopupMenu.borderInsets = 6,1,6,1
 
 
 #---- ProgressBar ----

--- a/flatlaf-core/src/main/resources/com/formdev/flatlaf/themes/FlatMacLightLaf.properties
+++ b/flatlaf-core/src/main/resources/com/formdev/flatlaf/themes/FlatMacLightLaf.properties
@@ -192,6 +192,12 @@ ScrollBar.width = 12
 ScrollBar.track = darken(@componentBackground,2%)
 ScrollBar.thumb = darken(@componentBackground,24%)
 
+# from FlatLaf.properties (when using not on macOS)
+ScrollBar.minimumThumbSize = 18,18
+ScrollBar.thumbInsets = 2,2,2,2
+ScrollBar.thumbArc = 999
+ScrollBar.hoverThumbWithTrack = true
+
 
 #---- Separator ----
 

--- a/flatlaf-core/src/main/resources/com/formdev/flatlaf/themes/FlatMacLightLaf.properties
+++ b/flatlaf-core/src/main/resources/com/formdev/flatlaf/themes/FlatMacLightLaf.properties
@@ -1,0 +1,244 @@
+#
+# Copyright 2022 FormDev Software GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# base theme (light, dark, intellij or darcula); only used by theme editor
+@baseTheme = light
+
+
+#---- macOS NSColor system colors (in NSColorSpace.deviceRGB) ----
+# generated on macOS 12.2 using Xcode and flatlaf-testing/misc/MacOSColorDump.playground
+
+@nsLabelColor = #000000d8
+@nsSecondaryLabelColor = #0000007f
+@nsTertiaryLabelColor = #00000042
+@nsQuaternaryLabelColor = #00000019
+@nsSystemRedColor = #ff3b30
+@nsSystemGreenColor = #28cd41
+@nsSystemBlueColor = #007aff
+@nsSystemOrangeColor = #ff9500
+@nsSystemYellowColor = #ffcc00
+@nsSystemBrownColor = #a2845e
+@nsSystemPinkColor = #ff2d55
+@nsSystemPurpleColor = #af52de
+@nsSystemTealColor = #59adc4
+@nsSystemIndigoColor = #5856d6
+@nsSystemMintColor = #00c7be
+@nsSystemCyanColor = #55bef0
+@nsSystemGrayColor = #8e8e93
+@nsLinkColor = #0068da
+@nsPlaceholderTextColor = #0000003f
+@nsWindowFrameTextColor = #000000d8
+@nsSelectedMenuItemTextColor = #ffffff
+@nsAlternateSelectedControlTextColor = #ffffff
+@nsHeaderTextColor = #000000d8
+@nsSeparatorColor = #00000019
+@nsGridColor = #e6e6e6
+@nsTextColor = #000000
+@nsTextBackgroundColor = #ffffff
+@nsSelectedTextColor = #000000
+@nsSelectedTextBackgroundColor = #b3d7ff
+@nsUnemphasizedSelectedTextBackgroundColor = #dcdcdc
+@nsUnemphasizedSelectedTextColor = #000000
+@nsWindowBackgroundColor = #ececec
+@nsUnderPageBackgroundColor = #969696e5
+@nsControlBackgroundColor = #ffffff
+@nsSelectedContentBackgroundColor = #0063e1
+@nsUnemphasizedSelectedContentBackgroundColor = #dcdcdc
+@nsFindHighlightColor = #ffff00
+@nsControlColor = #ffffff
+@nsControlTextColor = #000000d8
+@nsSelectedControlColor = #b3d7ff
+@nsSelectedControlTextColor = #000000d8
+@nsDisabledControlTextColor = #0000003f
+@nsKeyboardFocusIndicatorColor = #0067f47f
+@nsControlAccentColor = #007aff
+
+# accent colors are:
+#    @nsSelectedTextBackgroundColor
+#    @nsSelectedContentBackgroundColor
+#    @nsSelectedControlColor
+#    @nsKeyboardFocusIndicatorColor
+#    @nsControlAccentColor
+
+
+#---- variables ----
+
+# general background and foreground (text color)
+@background = #f6f6f6
+@foreground = over(@nsControlTextColor,@background)
+@disabledForeground = over(@nsTertiaryLabelColor,@background)
+
+# component background
+@buttonBackground = @nsControlColor
+@componentBackground = @nsControlColor
+@disabledComponentBackground = darken(@componentBackground,2%)
+@menuBackground = darken(@background,4%)
+
+# selection
+@selectionBackground = @nsSelectedContentBackgroundColor
+@selectionForeground = @nsSelectedMenuItemTextColor
+@selectionInactiveBackground = @nsUnemphasizedSelectedContentBackgroundColor
+
+# text selection
+@textSelectionBackground = @nsSelectedTextBackgroundColor
+@textSelectionForeground = @foreground
+
+# accent colors (blueish)
+@accentColor = @nsControlAccentColor
+@accentFocusColor = @nsKeyboardFocusIndicatorColor
+
+
+#---- Button ----
+
+Button.arc = 12
+Button.disabledBackground = @disabledComponentBackground
+Button.focusedBackground = null
+
+Button.default.borderWidth = 1
+Button.default.boldText = true
+Button.default.background = @accentColor
+Button.default.foreground = contrast($Button.default.background, @background, $Button.foreground, 20%)
+
+
+#---- CheckBox ----
+
+CheckBox.iconTextGap = 6
+CheckBox.arc = 7
+CheckBox.icon.focusWidth = null
+CheckBox.icon.style = filled
+CheckBox.icon[filled].borderWidth = 1
+CheckBox.icon[filled].selectedBorderWidth = 0
+CheckBox.icon[filled].disabledSelectedBorderWidth = 1
+CheckBox.icon[filled].background = @nsControlColor
+CheckBox.icon[filled].disabledBackground = @disabledComponentBackground
+CheckBox.icon[filled].selectedBackground = @accentColor
+CheckBox.icon[filled].borderColor = $Component.borderColor
+CheckBox.icon[filled].disabledBorderColor = $Component.disabledBorderColor
+CheckBox.icon[filled].checkmarkColor = @nsSelectedMenuItemTextColor
+CheckBox.icon[filled].disabledCheckmarkColor = darken($CheckBox.icon[filled].checkmarkColor,25%)
+CheckBox.icon.focusedBackground = null
+
+
+#---- ComboBox ----
+
+ComboBox.buttonStyle = mac
+ComboBox.disabledBackground = @disabledComponentBackground
+ComboBox.buttonBackground = @accentColor
+ComboBox.buttonArrowColor = @nsSelectedMenuItemTextColor
+ComboBox.buttonHoverArrowColor = darken($ComboBox.buttonArrowColor,15%,derived noAutoInverse)
+ComboBox.buttonPressedArrowColor = darken($ComboBox.buttonArrowColor,25%,derived noAutoInverse)
+ComboBox.popupBackground = @menuBackground
+
+
+#---- Component ----
+
+Component.focusWidth = 2
+Component.innerFocusWidth = 0
+Component.innerOutlineWidth = 0
+Component.arc = 12
+Component.borderColor = fadein(@nsSeparatorColor,5%)
+Component.disabledBorderColor = @nsSeparatorColor
+
+
+#---- EditorPane ---
+
+EditorPane.disabledBackground = @disabledComponentBackground
+EditorPane.selectionBackground = @textSelectionBackground
+EditorPane.selectionForeground = @textSelectionForeground
+
+
+#---- FormattedTextField ---
+
+FormattedTextField.disabledBackground = @disabledComponentBackground
+FormattedTextField.selectionBackground = @textSelectionBackground
+FormattedTextField.selectionForeground = @textSelectionForeground
+
+
+#---- PasswordField ---
+
+PasswordField.disabledBackground = @disabledComponentBackground
+PasswordField.selectionBackground = @textSelectionBackground
+PasswordField.selectionForeground = @textSelectionForeground
+
+
+#---- ProgressBar ----
+
+ProgressBar.background = darken(@background,5%)
+
+
+#---- RadioButton ----
+
+RadioButton.iconTextGap = 6
+RadioButton.icon.style = filled
+RadioButton.icon[filled].centerDiameter = 6
+
+
+#---- ScrollBar ----
+
+ScrollBar.width = 12
+ScrollBar.track = darken(@componentBackground,2%)
+ScrollBar.thumb = darken(@componentBackground,24%)
+
+
+#---- Separator ----
+
+Separator.foreground = @nsSeparatorColor
+
+
+#---- Slider ----
+
+Slider.trackWidth = 3
+Slider.thumbSize = 14,14
+Slider.trackColor = darken(@background,7%)
+Slider.thumbColor = @componentBackground
+Slider.thumbBorderColor = $Component.borderColor
+Slider.disabledTrackColor = lighten($Slider.trackColor,3%)
+Slider.disabledThumbColor = darken($Slider.thumbColor,3%)
+
+
+#---- Spinner ----
+
+Spinner.buttonStyle = mac
+Spinner.disabledBackground = @disabledComponentBackground
+Spinner.buttonArrowColor = @foreground
+Spinner.buttonHoverArrowColor = lighten($Spinner.buttonArrowColor,20%,derived noAutoInverse)
+Spinner.buttonPressedArrowColor = lighten($Spinner.buttonArrowColor,30%,derived noAutoInverse)
+
+
+#---- TextArea ---
+
+TextArea.disabledBackground = @disabledComponentBackground
+TextArea.selectionBackground = @textSelectionBackground
+TextArea.selectionForeground = @textSelectionForeground
+
+
+#---- TextField ----
+
+TextField.disabledBackground = @disabledComponentBackground
+TextField.selectionBackground = @textSelectionBackground
+TextField.selectionForeground = @textSelectionForeground
+
+
+#---- TextPane ---
+
+TextPane.disabledBackground = @disabledComponentBackground
+TextPane.selectionBackground = @textSelectionBackground
+TextPane.selectionForeground = @textSelectionForeground
+
+
+#---- ToggleButton ----
+
+ToggleButton.disabledBackground = $Button.disabledBackground

--- a/flatlaf-core/src/main/resources/com/formdev/flatlaf/themes/FlatMacLightLaf.properties
+++ b/flatlaf-core/src/main/resources/com/formdev/flatlaf/themes/FlatMacLightLaf.properties
@@ -96,6 +96,11 @@
 @textSelectionBackground = @nsSelectedTextBackgroundColor
 @textSelectionForeground = @foreground
 
+# menu
+@menuSelectionBackground = lighten(@accentColor,12%)
+@menuCheckBackground = lighten(@menuSelectionBackground,25%,derived noAutoInverse)
+@menuItemMargin = 3,11,3,11
+
 # accent colors (blueish)
 @accentColor = @nsControlAccentColor
 @accentFocusColor = @nsKeyboardFocusIndicatorColor
@@ -141,6 +146,10 @@ ComboBox.buttonArrowColor = @nsSelectedMenuItemTextColor
 ComboBox.buttonHoverArrowColor = darken($ComboBox.buttonArrowColor,15%,derived noAutoInverse)
 ComboBox.buttonPressedArrowColor = darken($ComboBox.buttonArrowColor,25%,derived noAutoInverse)
 ComboBox.popupBackground = @menuBackground
+ComboBox.selectionBackground = @menuSelectionBackground
+ComboBox.popupInsets = 5,0,5,0
+ComboBox.selectionInsets = 0,5,0,5
+ComboBox.selectionArc = 8
 
 
 #---- Component ----
@@ -167,11 +176,36 @@ FormattedTextField.selectionBackground = @textSelectionBackground
 FormattedTextField.selectionForeground = @textSelectionForeground
 
 
+#---- MenuBar ----
+
+MenuBar.selectionInsets = 0,0,0,0
+MenuBar.selectionEmbeddedInsets = 3,0,3,0
+MenuBar.selectionArc = 8
+MenuBar.selectionBackground = darken(@menuBackground,15%,derived)
+MenuBar.selectionForeground = @foreground
+
+
+#---- MenuItem ----
+
+MenuItem.selectionInsets = 0,5,0,5
+MenuItem.selectionArc = 8
+
+Menu.selectionBackground = @menuSelectionBackground
+MenuItem.selectionBackground = @menuSelectionBackground
+CheckBoxMenuItem.selectionBackground = @menuSelectionBackground
+RadioButtonMenuItem.selectionBackground = @menuSelectionBackground
+
+
 #---- PasswordField ---
 
 PasswordField.disabledBackground = @disabledComponentBackground
 PasswordField.selectionBackground = @textSelectionBackground
 PasswordField.selectionForeground = @textSelectionForeground
+
+
+#---- PopupMenu ----
+
+PopupMenu.borderInsets = 6,1,6,1
 
 
 #---- ProgressBar ----

--- a/flatlaf-demo/src/main/java/com/formdev/flatlaf/demo/intellijthemes/IJThemesPanel.java
+++ b/flatlaf-demo/src/main/java/com/formdev/flatlaf/demo/intellijthemes/IJThemesPanel.java
@@ -54,6 +54,7 @@ import com.formdev.flatlaf.IntelliJTheme;
 import com.formdev.flatlaf.demo.DemoPrefs;
 import com.formdev.flatlaf.extras.FlatAnimatedLafChange;
 import com.formdev.flatlaf.extras.FlatSVGIcon;
+import com.formdev.flatlaf.themes.*;
 import com.formdev.flatlaf.ui.FlatListUI;
 import com.formdev.flatlaf.util.LoggingFacade;
 import com.formdev.flatlaf.util.StringUtils;
@@ -184,6 +185,11 @@ public class IJThemesPanel
 			themes.add( new IJThemeInfo( "FlatLaf IntelliJ", null, false, null, null, null, null, null, FlatIntelliJLaf.class.getName() ) );
 		if( showDark )
 			themes.add( new IJThemeInfo( "FlatLaf Darcula", null, true, null, null, null, null, null, FlatDarculaLaf.class.getName() ) );
+
+		if( showLight )
+			themes.add( new IJThemeInfo( "FlatLaf macOS Light", null, false, null, null, null, null, null, FlatMacLightLaf.class.getName() ) );
+		if( showDark )
+			themes.add( new IJThemeInfo( "FlatLaf macOS Dark", null, true, null, null, null, null, null, FlatMacDarkLaf.class.getName() ) );
 
 		// add themes from directory
 		categories.put( themes.size(), "Current Directory" );

--- a/flatlaf-extras/src/main/resources/com/formdev/flatlaf/extras/resources/DerivedColorKeys.properties
+++ b/flatlaf-extras/src/main/resources/com/formdev/flatlaf/extras/resources/DerivedColorKeys.properties
@@ -117,6 +117,7 @@ Menu.selectionBackground = Menu.background
 
 MenuBar.hoverBackground = Menu.background
 MenuBar.underlineSelectionBackground = Menu.background
+MenuBar.selectionBackground = Menu.background
 
 
 #---- MenuItem ----

--- a/flatlaf-jide-oss/src/main/java/com/formdev/flatlaf/jideoss/ui/FlatJideSplitButtonUI.java
+++ b/flatlaf-jide-oss/src/main/java/com/formdev/flatlaf/jideoss/ui/FlatJideSplitButtonUI.java
@@ -121,7 +121,7 @@ public class FlatJideSplitButtonUI
 
 		Object[] oldRenderingHints = FlatUIUtils.setRenderingHints( g );
 		FlatUIUtils.paintArrow( (Graphics2D) g, r.x, r.y, r.width, r.height,
-			SwingConstants.SOUTH, FlatUIUtils.isChevron( arrowType ), 6, 0, 0 );
+			SwingConstants.SOUTH, FlatUIUtils.isChevron( arrowType ), 6, 1, 0, 0 );
 		FlatUIUtils.resetRenderingHints( g, oldRenderingHints );
 	}
 }

--- a/flatlaf-jide-oss/src/main/java/com/formdev/flatlaf/jideoss/ui/FlatJideTabbedPaneUI.java
+++ b/flatlaf-jide-oss/src/main/java/com/formdev/flatlaf/jideoss/ui/FlatJideTabbedPaneUI.java
@@ -891,7 +891,7 @@ public class FlatJideTabbedPaneUI
 			g.setColor( button.isEnabled() ? foreground : disabledForeground );
 			FlatUIUtils.paintArrow( (Graphics2D) g,
 				0, 0, button.getWidth(), button.getHeight(),
-				direction, FlatUIUtils.isChevron( arrowType ), 10, 0, 0 );
+				direction, FlatUIUtils.isChevron( arrowType ), 10, 1, 0, 0 );
 
 			FlatUIUtils.resetRenderingHints( g, oldRenderingHints );
 		}

--- a/flatlaf-testing/dumps/uidefaults/FlatMacDarkLaf_1.8.0.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatMacDarkLaf_1.8.0.txt
@@ -869,21 +869,21 @@ ScrollBar.buttonDisabledArrowColor #777777  HSL   0   0  47    javax.swing.plaf.
 ScrollBar.foreground           #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 ScrollBar.hoverButtonBackground #2b2b2b  HSL   0   0  17    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(5%)
 ScrollBar.hoverThumbColor      #707070  HSL   0   0  44    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(10%)
-ScrollBar.hoverThumbWithTrack  false
+ScrollBar.hoverThumbWithTrack  true
 ScrollBar.hoverTrackColor      #323232  HSL   0   0  20    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(4%)
 ScrollBar.maximumThumbSize     100000,100000    javax.swing.plaf.DimensionUIResource [UI]
 ScrollBar.minimumButtonSize    12,12    javax.swing.plaf.DimensionUIResource [UI]
-ScrollBar.minimumThumbSize     10,10    javax.swing.plaf.DimensionUIResource [UI]
+ScrollBar.minimumThumbSize     18,18    javax.swing.plaf.DimensionUIResource [UI]
 ScrollBar.pressedButtonBackground #383838  HSL   0   0  22    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(10%)
 ScrollBar.pressedThumbColor    #7c7c7c  HSL   0   0  49    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(15%)
 ScrollBar.pressedThumbWithTrack false
 ScrollBar.showButtons          false
 ScrollBar.squareButtons        false
 ScrollBar.thumb                #565656  HSL   0   0  34    javax.swing.plaf.ColorUIResource [UI]
-ScrollBar.thumbArc             0
+ScrollBar.thumbArc             999
 ScrollBar.thumbDarkShadow      #ffffff19  10%  HSLA   0   0 100 10    javax.swing.plaf.ColorUIResource [UI]
 ScrollBar.thumbHighlight       #bfbfbf19  10%  HSLA   0   0  75 10    javax.swing.plaf.ColorUIResource [UI]
-ScrollBar.thumbInsets          0,0,0,0    javax.swing.plaf.InsetsUIResource [UI]
+ScrollBar.thumbInsets          2,2,2,2    javax.swing.plaf.InsetsUIResource [UI]
 ScrollBar.thumbShadow          #ffffff19  10%  HSLA   0   0 100 10    javax.swing.plaf.ColorUIResource [UI]
 ScrollBar.track                #282828  HSL   0   0  16    javax.swing.plaf.ColorUIResource [UI]
 ScrollBar.trackArc             0

--- a/flatlaf-testing/dumps/uidefaults/FlatMacDarkLaf_1.8.0.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatMacDarkLaf_1.8.0.txt
@@ -169,9 +169,9 @@ CheckBoxMenuItem.font          [active] $defaultFont [UI]
 CheckBoxMenuItem.foreground    #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 CheckBoxMenuItem.icon.checkmarkColor #b7b7b7  HSL   0   0  72    javax.swing.plaf.ColorUIResource [UI]
 CheckBoxMenuItem.icon.disabledCheckmarkColor #777777  HSL   0   0  47    javax.swing.plaf.ColorUIResource [UI]
-CheckBoxMenuItem.margin        3,6,3,6    javax.swing.plaf.InsetsUIResource [UI]
+CheckBoxMenuItem.margin        3,11,3,11    javax.swing.plaf.InsetsUIResource [UI]
 CheckBoxMenuItem.opaque        false
-CheckBoxMenuItem.selectionBackground #0058d0  HSL 215 100  41    javax.swing.plaf.ColorUIResource [UI]
+CheckBoxMenuItem.selectionBackground #155bbb  HSL 215  80  41    javax.swing.plaf.ColorUIResource [UI]
 CheckBoxMenuItem.selectionForeground #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
 CheckBoxMenuItemUI             com.formdev.flatlaf.ui.FlatCheckBoxMenuItemUI
 
@@ -226,8 +226,11 @@ ComboBox.minimumWidth          72
 ComboBox.noActionOnKeyNavigation false
 ComboBox.padding               2,6,2,6    javax.swing.plaf.InsetsUIResource [UI]
 ComboBox.popupBackground       #323232  HSL   0   0  20    javax.swing.plaf.ColorUIResource [UI]
-ComboBox.selectionBackground   #0058d0  HSL 215 100  41    javax.swing.plaf.ColorUIResource [UI]
+ComboBox.popupInsets           5,0,5,0    javax.swing.plaf.InsetsUIResource [UI]
+ComboBox.selectionArc          8
+ComboBox.selectionBackground   #155bbb  HSL 215  80  41    javax.swing.plaf.ColorUIResource [UI]
 ComboBox.selectionForeground   #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+ComboBox.selectionInsets       0,5,0,5    javax.swing.plaf.InsetsUIResource [UI]
 ComboBox.timeFactor            1000
 ComboBoxUI                     com.formdev.flatlaf.ui.FlatComboBoxUI
 
@@ -551,10 +554,12 @@ List.focusSelectedCellHighlightBorder [lazy] 1,6,1,6  false    com.formdev.flatl
 List.font                      [active] $defaultFont [UI]
 List.foreground                #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 List.noFocusBorder             1,1,1,1  false    javax.swing.plaf.BorderUIResource$EmptyBorderUIResource [UI]
+List.selectionArc              0
 List.selectionBackground       #0058d0  HSL 215 100  41    javax.swing.plaf.ColorUIResource [UI]
 List.selectionForeground       #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
 List.selectionInactiveBackground #464646  HSL   0   0  27    javax.swing.plaf.ColorUIResource [UI]
 List.selectionInactiveForeground #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+List.selectionInsets           0,0,0,0    javax.swing.plaf.InsetsUIResource [UI]
 List.showCellFocusIndicator    false
 List.timeFactor                1000
 ListUI                         com.formdev.flatlaf.ui.FlatListUI
@@ -576,12 +581,12 @@ Menu.font                      [active] $defaultFont [UI]
 Menu.foreground                #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 Menu.icon.arrowColor           #b7b7b7  HSL   0   0  72    javax.swing.plaf.ColorUIResource [UI]
 Menu.icon.disabledArrowColor   #777777  HSL   0   0  47    javax.swing.plaf.ColorUIResource [UI]
-Menu.margin                    3,6,3,6    javax.swing.plaf.InsetsUIResource [UI]
+Menu.margin                    3,11,3,11    javax.swing.plaf.InsetsUIResource [UI]
 Menu.menuPopupOffsetX          0
 Menu.menuPopupOffsetY          0
 Menu.opaque                    false
 Menu.preserveTopLevelSelection false
-Menu.selectionBackground       #0058d0  HSL 215 100  41    javax.swing.plaf.ColorUIResource [UI]
+Menu.selectionBackground       #155bbb  HSL 215  80  41    javax.swing.plaf.ColorUIResource [UI]
 Menu.selectionForeground       #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
 Menu.shortcutKeys              length=1    [I
     [0] 8
@@ -599,6 +604,11 @@ MenuBar.foreground             #dddddd  HSL   0   0  87    javax.swing.plaf.Colo
 MenuBar.highlight              #bfbfbf19  10%  HSLA   0   0  75 10    javax.swing.plaf.ColorUIResource [UI]
 MenuBar.hoverBackground        #4c4c4c  HSL   0   0  30    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(10% autoInverse)
 MenuBar.itemMargins            3,8,3,8    javax.swing.plaf.InsetsUIResource [UI]
+MenuBar.selectionArc           8
+MenuBar.selectionBackground    #585858  HSL   0   0  35    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(15% autoInverse)
+MenuBar.selectionEmbeddedInsets 3,0,3,0    javax.swing.plaf.InsetsUIResource [UI]
+MenuBar.selectionForeground    #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+MenuBar.selectionInsets        0,0,0,0    javax.swing.plaf.InsetsUIResource [UI]
 MenuBar.shadow                 #ffffff19  10%  HSLA   0   0 100 10    javax.swing.plaf.ColorUIResource [UI]
 MenuBar.windowBindings         length=2    [Ljava.lang.Object;
     [0] F10
@@ -617,22 +627,24 @@ MenuItem.arrowIcon             [lazy] 6,10    com.formdev.flatlaf.icons.FlatMenu
 MenuItem.background            #323232  HSL   0   0  20    javax.swing.plaf.ColorUIResource [UI]
 MenuItem.border                [lazy] 0,0,0,0  false    com.formdev.flatlaf.ui.FlatMenuItemBorder [UI]
 MenuItem.borderPainted         true
-MenuItem.checkBackground       #00429d  HSL 215 100  31    com.formdev.flatlaf.util.DerivedColor [UI]    darken(10%)
+MenuItem.checkBackground       #10458d  HSL 215  80  31    com.formdev.flatlaf.util.DerivedColor [UI]    darken(10%)
 MenuItem.checkMargins          2,2,2,2    javax.swing.plaf.InsetsUIResource [UI]
 MenuItem.disabledForeground    #9a9a9a  HSL   0   0  60    javax.swing.plaf.ColorUIResource [UI]
 MenuItem.font                  [active] $defaultFont [UI]
 MenuItem.foreground            #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 MenuItem.iconTextGap           6
-MenuItem.margin                3,6,3,6    javax.swing.plaf.InsetsUIResource [UI]
+MenuItem.margin                3,11,3,11    javax.swing.plaf.InsetsUIResource [UI]
 MenuItem.minimumIconSize       16,16    javax.swing.plaf.DimensionUIResource [UI]
 MenuItem.minimumWidth          72
 MenuItem.opaque                false
-MenuItem.selectionBackground   #0058d0  HSL 215 100  41    javax.swing.plaf.ColorUIResource [UI]
+MenuItem.selectionArc          8
+MenuItem.selectionBackground   #155bbb  HSL 215  80  41    javax.swing.plaf.ColorUIResource [UI]
 MenuItem.selectionForeground   #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+MenuItem.selectionInsets       0,5,0,5    javax.swing.plaf.InsetsUIResource [UI]
 MenuItem.textAcceleratorGap    24
 MenuItem.textNoAcceleratorGap  6
 MenuItem.underlineSelectionBackground #4c4c4c  HSL   0   0  30    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(10% autoInverse)
-MenuItem.underlineSelectionCheckBackground #00429d  HSL 215 100  31    com.formdev.flatlaf.util.DerivedColor [UI]    darken(10%)
+MenuItem.underlineSelectionCheckBackground #10458d  HSL 215  80  31    com.formdev.flatlaf.util.DerivedColor [UI]    darken(10%)
 MenuItem.underlineSelectionColor #007aff  HSL 211 100  50    javax.swing.plaf.ColorUIResource [UI]
 MenuItem.underlineSelectionHeight 3
 MenuItem.verticallyAlignText   true
@@ -738,9 +750,9 @@ Popup.dropShadowPainted        true
 #---- PopupMenu ----
 
 PopupMenu.background           #323232  HSL   0   0  20    javax.swing.plaf.ColorUIResource [UI]
-PopupMenu.border               [lazy] 4,1,4,1  false    com.formdev.flatlaf.ui.FlatPopupMenuBorder [UI]    lineColor=#444444  HSL   0   0  27    javax.swing.plaf.ColorUIResource [UI]    lineThickness=1.000000
+PopupMenu.border               [lazy] 6,1,6,1  false    com.formdev.flatlaf.ui.FlatPopupMenuBorder [UI]    lineColor=#444444  HSL   0   0  27    javax.swing.plaf.ColorUIResource [UI]    lineThickness=1.000000
 PopupMenu.borderColor          #444444  HSL   0   0  27    javax.swing.plaf.ColorUIResource [UI]
-PopupMenu.borderInsets         4,1,4,1    javax.swing.plaf.InsetsUIResource [UI]
+PopupMenu.borderInsets         6,1,6,1    javax.swing.plaf.InsetsUIResource [UI]
 PopupMenu.consumeEventOnClose  false
 PopupMenu.font                 [active] $defaultFont [UI]
 PopupMenu.foreground           #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
@@ -814,9 +826,9 @@ RadioButtonMenuItem.checkIcon  [lazy] 15,15    com.formdev.flatlaf.icons.FlatRad
 RadioButtonMenuItem.disabledForeground #9a9a9a  HSL   0   0  60    javax.swing.plaf.ColorUIResource [UI]
 RadioButtonMenuItem.font       [active] $defaultFont [UI]
 RadioButtonMenuItem.foreground #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
-RadioButtonMenuItem.margin     3,6,3,6    javax.swing.plaf.InsetsUIResource [UI]
+RadioButtonMenuItem.margin     3,11,3,11    javax.swing.plaf.InsetsUIResource [UI]
 RadioButtonMenuItem.opaque     false
-RadioButtonMenuItem.selectionBackground #0058d0  HSL 215 100  41    javax.swing.plaf.ColorUIResource [UI]
+RadioButtonMenuItem.selectionBackground #155bbb  HSL 215  80  41    javax.swing.plaf.ColorUIResource [UI]
 RadioButtonMenuItem.selectionForeground #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
 RadioButtonMenuItemUI          com.formdev.flatlaf.ui.FlatRadioButtonMenuItemUI
 
@@ -1311,6 +1323,8 @@ ToolBar.font                   [active] $defaultFont [UI]
 ToolBar.foreground             #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 ToolBar.gripColor              #cecece  HSL   0   0  81    javax.swing.plaf.ColorUIResource [UI]
 ToolBar.highlight              #bfbfbf19  10%  HSLA   0   0  75 10    javax.swing.plaf.ColorUIResource [UI]
+ToolBar.hoverButtonGroupArc    8
+ToolBar.hoverButtonGroupBackground #262626  HSL   0   0  15    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(3% autoInverse)
 ToolBar.isRollover             true
 ToolBar.light                  #cccccc19  10%  HSLA   0   0  80 10    javax.swing.plaf.ColorUIResource [UI]
 ToolBar.separatorColor         #ffffff19  10%  HSLA   0   0 100 10    javax.swing.plaf.ColorUIResource [UI]
@@ -1379,11 +1393,13 @@ Tree.repaintWholeRow           true
 Tree.rightChildIndent          11
 Tree.rowHeight                 0
 Tree.scrollsOnExpand           true
+Tree.selectionArc              0
 Tree.selectionBackground       #0058d0  HSL 215 100  41    javax.swing.plaf.ColorUIResource [UI]
 Tree.selectionBorderColor      #000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]
 Tree.selectionForeground       #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
 Tree.selectionInactiveBackground #464646  HSL   0   0  27    javax.swing.plaf.ColorUIResource [UI]
 Tree.selectionInactiveForeground #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+Tree.selectionInsets           0,0,0,0    javax.swing.plaf.InsetsUIResource [UI]
 Tree.showCellFocusIndicator    false
 Tree.textBackground            #282828  HSL   0   0  16    javax.swing.plaf.ColorUIResource [UI]
 Tree.textForeground            #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]

--- a/flatlaf-testing/dumps/uidefaults/FlatMacDarkLaf_1.8.0.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatMacDarkLaf_1.8.0.txt
@@ -1,0 +1,1588 @@
+Class  com.formdev.flatlaf.themes.FlatMacDarkLaf
+ID     FlatLaf - FlatLaf macOS Dark
+Name   FlatLaf macOS Dark
+Java   1.8.0_202
+OS     Windows 10
+
+
+#----  ----
+
+AATextInfoPropertyKey          [unknown type] sun.swing.SwingUtilities2$AATextInfo
+
+
+#---- Actions ----
+
+Actions.Blue                   #3592c4  HSL 201  57  49    javax.swing.plaf.ColorUIResource [UI]
+Actions.Green                  #499c54  HSL 128  36  45    javax.swing.plaf.ColorUIResource [UI]
+Actions.Grey                   #afb1b3  HSL 210   3  69    javax.swing.plaf.ColorUIResource [UI]
+Actions.GreyInline             #7f8b91  HSL 200   8  53    javax.swing.plaf.ColorUIResource [UI]
+Actions.Red                    #c75450  HSL   2  52  55    javax.swing.plaf.ColorUIResource [UI]
+Actions.Yellow                 #f0a732  HSL  37  86  57    javax.swing.plaf.ColorUIResource [UI]
+
+
+#---- AuditoryCues ----
+
+AuditoryCues.allAuditoryCues   length=13    [Ljava.lang.Object;
+    [0] CheckBoxMenuItem.commandSound
+    [1] InternalFrame.closeSound
+    [2] InternalFrame.maximizeSound
+    [3] InternalFrame.minimizeSound
+    [4] InternalFrame.restoreDownSound
+    [5] InternalFrame.restoreUpSound
+    [6] MenuItem.commandSound
+    [7] OptionPane.errorSound
+    [8] OptionPane.informationSound
+    [9] OptionPane.questionSound
+    [10] OptionPane.warningSound
+    [11] PopupMenu.popupSound
+    [12] RadioButtonMenuItem.commandSound
+AuditoryCues.cueList           length=13    [Ljava.lang.Object;
+    [0] CheckBoxMenuItem.commandSound
+    [1] InternalFrame.closeSound
+    [2] InternalFrame.maximizeSound
+    [3] InternalFrame.minimizeSound
+    [4] InternalFrame.restoreDownSound
+    [5] InternalFrame.restoreUpSound
+    [6] MenuItem.commandSound
+    [7] OptionPane.errorSound
+    [8] OptionPane.informationSound
+    [9] OptionPane.questionSound
+    [10] OptionPane.warningSound
+    [11] PopupMenu.popupSound
+    [12] RadioButtonMenuItem.commandSound
+AuditoryCues.noAuditoryCues    length=1    [Ljava.lang.Object;
+    [0] mute
+
+
+#---- BusyLabel ----
+
+BusyLabelUI                    com.formdev.flatlaf.swingx.ui.FlatBusyLabelUI
+
+
+#---- Button ----
+
+Button.arc                     12
+Button.background              #565656  HSL   0   0  34    javax.swing.plaf.ColorUIResource [UI]
+Button.border                  [lazy] 3,3,3,3  false    com.formdev.flatlaf.ui.FlatButtonBorder [UI]
+Button.borderColor             #676767  HSL   0   0  40    javax.swing.plaf.ColorUIResource [UI]
+Button.borderWidth             0
+Button.darkShadow              #ffffff19  10%  HSLA   0   0 100 10    javax.swing.plaf.ColorUIResource [UI]
+Button.default.background      #007aff  HSL 211 100  50    javax.swing.plaf.ColorUIResource [UI]
+Button.default.boldText        true
+Button.default.borderColor     #268eff  HSL 211 100  57    javax.swing.plaf.ColorUIResource [UI]
+Button.default.borderWidth     0
+Button.default.focusColor      #29afff7f  50%  HSLA 202 100  58 50    javax.swing.plaf.ColorUIResource [UI]
+Button.default.focusedBorderColor #2e92ff  HSL 211 100  59    javax.swing.plaf.ColorUIResource [UI]
+Button.default.foreground      #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+Button.default.hoverBackground #0f82ff  HSL 211 100  53    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(3% autoInverse)
+Button.default.hoverBorderColor #2e92ff  HSL 211 100  59    javax.swing.plaf.ColorUIResource [UI]
+Button.default.pressedBackground #1f8aff  HSL 211 100  56    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(6% autoInverse)
+Button.defaultButtonFollowsFocus false
+Button.disabledBackground      #3d3d3d  HSL   0   0  24    javax.swing.plaf.ColorUIResource [UI]
+Button.disabledBorderColor     #676767  HSL   0   0  40    javax.swing.plaf.ColorUIResource [UI]
+Button.disabledForeground      #9a9a9a  HSL   0   0  60    javax.swing.plaf.ColorUIResource [UI]
+Button.disabledSelectedBackground #5e5e5e  HSL   0   0  37    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(3% autoInverse)
+Button.disabledText            #9a9a9a  HSL   0   0  60    javax.swing.plaf.ColorUIResource [UI]
+Button.focusedBorderColor      #34b3ff7f  50%  HSLA 202 100  60 50    javax.swing.plaf.ColorUIResource [UI]
+Button.font                    [active] $defaultFont [UI]
+Button.foreground              #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+Button.highlight               #bfbfbf19  10%  HSLA   0   0  75 10    javax.swing.plaf.ColorUIResource [UI]
+Button.hoverBackground         #5e5e5e  HSL   0   0  37    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(3% autoInverse)
+Button.hoverBorderColor        #34b3ff7f  50%  HSLA 202 100  60 50    javax.swing.plaf.ColorUIResource [UI]
+Button.iconTextGap             4
+Button.innerFocusWidth         1
+Button.light                   #cccccc19  10%  HSLA   0   0  80 10    javax.swing.plaf.ColorUIResource [UI]
+Button.margin                  2,14,2,14    javax.swing.plaf.InsetsUIResource [UI]
+Button.minimumWidth            72
+Button.pressedBackground       #656565  HSL   0   0  40    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(6% autoInverse)
+Button.rollover                true
+Button.selectedBackground      #707070  HSL   0   0  44    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(10% autoInverse)
+Button.selectedForeground      #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+Button.shadow                  #ffffff19  10%  HSLA   0   0 100 10    javax.swing.plaf.ColorUIResource [UI]
+Button.textIconGap             4
+Button.textShiftOffset         0
+Button.toolbar.hoverBackground #ffffff11  7%  HSLA   0   0 100  7    javax.swing.plaf.ColorUIResource [UI]
+Button.toolbar.margin          3,3,3,3    javax.swing.plaf.InsetsUIResource [UI]
+Button.toolbar.pressedBackground #ffffff22  13%  HSLA   0   0 100 13    javax.swing.plaf.ColorUIResource [UI]
+Button.toolbar.selectedBackground #ffffff33  20%  HSLA   0   0 100 20    javax.swing.plaf.ColorUIResource [UI]
+Button.toolbar.spacingInsets   1,2,1,2    javax.swing.plaf.InsetsUIResource [UI]
+ButtonUI                       com.formdev.flatlaf.ui.FlatButtonUI
+
+
+#---- Caret ----
+
+Caret.width                    [active] 1
+
+
+#---- CheckBox ----
+
+CheckBox.arc                   7
+CheckBox.background            #1e1e1e  HSL   0   0  12    javax.swing.plaf.ColorUIResource [UI]
+CheckBox.border                [lazy] 0,0,0,0  false    com.formdev.flatlaf.ui.FlatMarginBorder [UI]
+CheckBox.disabledText          #9a9a9a  HSL   0   0  60    javax.swing.plaf.ColorUIResource [UI]
+CheckBox.font                  [active] $defaultFont [UI]
+CheckBox.foreground            #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+CheckBox.icon.background       #292929  HSL   0   0  16    javax.swing.plaf.ColorUIResource [UI]
+CheckBox.icon.borderColor      #ffffff25  15%  HSLA   0   0 100 15    javax.swing.plaf.ColorUIResource [UI]
+CheckBox.icon.checkmarkColor   #c7c7c7  HSL   0   0  78    javax.swing.plaf.ColorUIResource [UI]
+CheckBox.icon.disabledBackground #1e1e1e  HSL   0   0  12    javax.swing.plaf.ColorUIResource [UI]
+CheckBox.icon.disabledBorderColor #cccccc51  32%  HSLA   0   0  80 32    javax.swing.plaf.ColorUIResource [UI]
+CheckBox.icon.disabledCheckmarkColor #878787  HSL   0   0  53    javax.swing.plaf.ColorUIResource [UI]
+CheckBox.icon.focusedBorderColor #34b3ff7f  50%  HSLA 202 100  60 50    javax.swing.plaf.ColorUIResource [UI]
+CheckBox.icon.hoverBackground  #313131  HSL   0   0  19    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(3% autoInverse)
+CheckBox.icon.hoverBorderColor #34b3ff7f  50%  HSLA 202 100  60 50    javax.swing.plaf.ColorUIResource [UI]
+CheckBox.icon.pressedBackground #383838  HSL   0   0  22    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(6% autoInverse)
+CheckBox.icon.pressedBorderColor #34b3ff7f  50%  HSLA 202 100  60 50    javax.swing.plaf.ColorUIResource [UI]
+CheckBox.icon.selectedBackground #292929  HSL   0   0  16    javax.swing.plaf.ColorUIResource [UI]
+CheckBox.icon.selectedBorderColor #ffffff51  32%  HSLA   0   0 100 32    javax.swing.plaf.ColorUIResource [UI]
+CheckBox.icon.style            filled
+CheckBox.icon                  [lazy] 15,15    com.formdev.flatlaf.icons.FlatCheckBoxIcon [UI]
+CheckBox.iconTextGap           6
+CheckBox.icon[filled].background #4e4e4e  HSL   0   0  31    javax.swing.plaf.ColorUIResource [UI]
+CheckBox.icon[filled].borderWidth 0
+CheckBox.icon[filled].checkmarkColor #ffffffd9  85%  HSLA   0   0 100 85    javax.swing.plaf.ColorUIResource [UI]
+CheckBox.icon[filled].disabledBackground #353535  HSL   0   0  21    javax.swing.plaf.ColorUIResource [UI]
+CheckBox.icon[filled].disabledCheckmarkColor #8c8c8cd9  85%  HSLA   0   0  55 85    javax.swing.plaf.ColorUIResource [UI]
+CheckBox.icon[filled].hoverSelectedBackground #0073f0  HSL 211 100  47    com.formdev.flatlaf.util.DerivedColor [UI]    darken(3% autoInverse)
+CheckBox.icon[filled].pressedSelectedBackground #006be0  HSL 211 100  44    com.formdev.flatlaf.util.DerivedColor [UI]    darken(6% autoInverse)
+CheckBox.icon[filled].selectedBackground #007aff  HSL 211 100  50    javax.swing.plaf.ColorUIResource [UI]
+CheckBox.icon[filled].selectedBorderColor #c7c7c7  HSL   0   0  78    javax.swing.plaf.ColorUIResource [UI]
+CheckBox.icon[filled].selectedBorderWidth 0
+CheckBox.margin                2,2,2,2    javax.swing.plaf.InsetsUIResource [UI]
+CheckBox.rollover              true
+CheckBox.textIconGap           4
+CheckBox.textShiftOffset       0
+
+
+#---- CheckBoxMenuItem ----
+
+CheckBoxMenuItem.acceleratorFont [active] $defaultFont [UI]
+CheckBoxMenuItem.acceleratorForeground #b7b7b7  HSL   0   0  72    javax.swing.plaf.ColorUIResource [UI]
+CheckBoxMenuItem.acceleratorSelectionForeground #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+CheckBoxMenuItem.arrowIcon     [lazy] 6,10    com.formdev.flatlaf.icons.FlatMenuItemArrowIcon [UI]
+CheckBoxMenuItem.background    #323232  HSL   0   0  20    javax.swing.plaf.ColorUIResource [UI]
+CheckBoxMenuItem.border        [lazy] 0,0,0,0  false    com.formdev.flatlaf.ui.FlatMenuItemBorder [UI]
+CheckBoxMenuItem.borderPainted true
+CheckBoxMenuItem.checkIcon     [lazy] 15,15    com.formdev.flatlaf.icons.FlatCheckBoxMenuItemIcon [UI]
+CheckBoxMenuItem.disabledForeground #9a9a9a  HSL   0   0  60    javax.swing.plaf.ColorUIResource [UI]
+CheckBoxMenuItem.font          [active] $defaultFont [UI]
+CheckBoxMenuItem.foreground    #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+CheckBoxMenuItem.icon.checkmarkColor #b7b7b7  HSL   0   0  72    javax.swing.plaf.ColorUIResource [UI]
+CheckBoxMenuItem.icon.disabledCheckmarkColor #777777  HSL   0   0  47    javax.swing.plaf.ColorUIResource [UI]
+CheckBoxMenuItem.margin        3,6,3,6    javax.swing.plaf.InsetsUIResource [UI]
+CheckBoxMenuItem.opaque        false
+CheckBoxMenuItem.selectionBackground #0058d0  HSL 215 100  41    javax.swing.plaf.ColorUIResource [UI]
+CheckBoxMenuItem.selectionForeground #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+CheckBoxMenuItemUI             com.formdev.flatlaf.ui.FlatCheckBoxMenuItemUI
+
+
+#---- CheckBox ----
+
+CheckBoxUI                     com.formdev.flatlaf.ui.FlatCheckBoxUI
+
+
+#---- ColorChooser ----
+
+ColorChooser.background        #1e1e1e  HSL   0   0  12    javax.swing.plaf.ColorUIResource [UI]
+ColorChooser.font              [active] $defaultFont [UI]
+ColorChooser.foreground        #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+ColorChooser.swatchesDefaultRecentColor #1e1e1e  HSL   0   0  12    javax.swing.plaf.ColorUIResource [UI]
+ColorChooser.swatchesRecentSwatchSize [active] 16,16    javax.swing.plaf.DimensionUIResource [UI]
+ColorChooser.swatchesSwatchSize [active] 16,16    javax.swing.plaf.DimensionUIResource [UI]
+ColorChooserUI                 com.formdev.flatlaf.ui.FlatColorChooserUI
+
+
+#---- ColumnControlButton ----
+
+ColumnControlButton.actionIcon [lazy] 10,10    com.formdev.flatlaf.swingx.icons.FlatColumnControlIcon [UI]
+ColumnControlButton.iconColor  #c7c7c7  HSL   0   0  78    javax.swing.plaf.ColorUIResource [UI]
+
+
+#---- ComboBox ----
+
+ComboBox.background            #565656  HSL   0   0  34    javax.swing.plaf.ColorUIResource [UI]
+ComboBox.border                [lazy] 3,3,3,3  false    com.formdev.flatlaf.ui.FlatRoundBorder [UI]
+ComboBox.buttonArrowColor      #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+ComboBox.buttonBackground      #007aff  HSL 211 100  50    javax.swing.plaf.ColorUIResource [UI]
+ComboBox.buttonDarkShadow      #ffffff19  10%  HSLA   0   0 100 10    javax.swing.plaf.ColorUIResource [UI]
+ComboBox.buttonDisabledArrowColor #777777  HSL   0   0  47    javax.swing.plaf.ColorUIResource [UI]
+ComboBox.buttonDisabledSeparatorColor #ffffff0c  5%  HSLA   0   0 100  5    javax.swing.plaf.ColorUIResource [UI]
+ComboBox.buttonEditableBackground #515151  HSL   0   0  32    javax.swing.plaf.ColorUIResource [UI]
+ComboBox.buttonHighlight       #bfbfbf19  10%  HSLA   0   0  75 10    javax.swing.plaf.ColorUIResource [UI]
+ComboBox.buttonHoverArrowColor #d9d9d9  HSL   0   0  85    com.formdev.flatlaf.util.DerivedColor [UI]    darken(15%)
+ComboBox.buttonPressedArrowColor #bfbfbf  HSL   0   0  75    com.formdev.flatlaf.util.DerivedColor [UI]    darken(25%)
+ComboBox.buttonSeparatorColor  #ffffff19  10%  HSLA   0   0 100 10    javax.swing.plaf.ColorUIResource [UI]
+ComboBox.buttonShadow          #ffffff19  10%  HSLA   0   0 100 10    javax.swing.plaf.ColorUIResource [UI]
+ComboBox.buttonStyle           mac
+ComboBox.disabledBackground    #232323  HSL   0   0  14    javax.swing.plaf.ColorUIResource [UI]
+ComboBox.disabledForeground    #9a9a9a  HSL   0   0  60    javax.swing.plaf.ColorUIResource [UI]
+ComboBox.editableBackground    #282828  HSL   0   0  16    javax.swing.plaf.ColorUIResource [UI]
+ComboBox.editorColumns         0
+ComboBox.font                  [active] $defaultFont [UI]
+ComboBox.foreground            #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+ComboBox.isEnterSelectablePopup false
+ComboBox.maximumRowCount       15
+ComboBox.minimumWidth          72
+ComboBox.noActionOnKeyNavigation false
+ComboBox.padding               2,6,2,6    javax.swing.plaf.InsetsUIResource [UI]
+ComboBox.popupBackground       #323232  HSL   0   0  20    javax.swing.plaf.ColorUIResource [UI]
+ComboBox.selectionBackground   #0058d0  HSL 215 100  41    javax.swing.plaf.ColorUIResource [UI]
+ComboBox.selectionForeground   #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+ComboBox.timeFactor            1000
+ComboBoxUI                     com.formdev.flatlaf.ui.FlatComboBoxUI
+
+
+#---- Component ----
+
+Component.accentColor          #007aff  HSL 211 100  50    javax.swing.plaf.ColorUIResource [UI]
+Component.arc                  12
+Component.arrowType            chevron
+Component.borderColor          #ffffff19  10%  HSLA   0   0 100 10    javax.swing.plaf.ColorUIResource [UI]
+Component.borderWidth          1
+Component.custom.borderColor   #bf4040  HSL   0  50  50    com.formdev.flatlaf.util.DerivedColor [UI]    desaturate(50% relative)
+Component.disabledBorderColor  #ffffff0c  5%  HSLA   0   0 100  5    javax.swing.plaf.ColorUIResource [UI]
+Component.error.borderColor    #725555  HSL   0  15  39    javax.swing.plaf.ColorUIResource [UI]
+Component.error.focusedBorderColor #8b3c3c  HSL   0  40  39    javax.swing.plaf.ColorUIResource [UI]
+Component.focusColor           #1aa9ff7f  50%  HSLA 203 100  55 50    javax.swing.plaf.ColorUIResource [UI]
+Component.focusWidth           2
+Component.focusedBorderColor   #34b3ff7f  50%  HSLA 202 100  60 50    javax.swing.plaf.ColorUIResource [UI]
+Component.grayFilter           [lazy] [unknown type] com.formdev.flatlaf.util.GrayFilter
+Component.hideMnemonics        true
+Component.innerFocusWidth      0
+Component.innerOutlineWidth    0
+Component.linkColor            #007aff  HSL 211 100  50    javax.swing.plaf.ColorUIResource [UI]
+Component.minimumWidth         64
+Component.warning.borderColor  #725627  HSL  38  49  30    javax.swing.plaf.ColorUIResource [UI]
+Component.warning.focusedBorderColor #ac7920  HSL  38  69  40    javax.swing.plaf.ColorUIResource [UI]
+
+
+#---- DatePicker ----
+
+DatePickerUI                   com.formdev.flatlaf.swingx.ui.FlatDatePickerUI
+
+
+#---- Desktop ----
+
+Desktop.background             #3e434c  HSL 219  10  27    javax.swing.plaf.ColorUIResource [UI]
+Desktop.minOnScreenInsets      3,3,3,3    javax.swing.plaf.InsetsUIResource [UI]
+
+
+#---- DesktopIcon ----
+
+DesktopIcon.background         #555c68  HSL 218  10  37    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(10% autoInverse)
+DesktopIcon.border             [lazy] 4,4,4,4  false    com.formdev.flatlaf.ui.FlatEmptyBorder [UI]
+DesktopIcon.closeIcon          [lazy] 24,24    com.formdev.flatlaf.icons.FlatInternalFrameCloseIcon [UI]
+DesktopIcon.closeSize          20,20    javax.swing.plaf.DimensionUIResource [UI]
+DesktopIcon.foreground         #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+DesktopIcon.iconSize           64,64    javax.swing.plaf.DimensionUIResource [UI]
+DesktopIconUI                  com.formdev.flatlaf.ui.FlatDesktopIconUI
+
+
+#---- DesktopPane ----
+
+DesktopPaneUI                  com.formdev.flatlaf.ui.FlatDesktopPaneUI
+
+
+#---- EditorPane ----
+
+EditorPane.background          #282828  HSL   0   0  16    javax.swing.plaf.ColorUIResource [UI]
+EditorPane.border              [lazy] 0,0,0,0  false    com.formdev.flatlaf.ui.FlatMarginBorder [UI]
+EditorPane.caretBlinkRate      500
+EditorPane.caretForeground     #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+EditorPane.disabledBackground  #232323  HSL   0   0  14    javax.swing.plaf.ColorUIResource [UI]
+EditorPane.font                [active] $defaultFont [UI]
+EditorPane.foreground          #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+EditorPane.inactiveBackground  #1e1e1e  HSL   0   0  12    javax.swing.plaf.ColorUIResource [UI]
+EditorPane.inactiveForeground  #9a9a9a  HSL   0   0  60    javax.swing.plaf.ColorUIResource [UI]
+EditorPane.margin              2,6,2,6    javax.swing.plaf.InsetsUIResource [UI]
+EditorPane.selectionBackground #3f638b  HSL 212  38  40    javax.swing.plaf.ColorUIResource [UI]
+EditorPane.selectionForeground #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+EditorPaneUI                   com.formdev.flatlaf.ui.FlatEditorPaneUI
+
+
+#---- FileChooser ----
+
+FileChooser.detailsViewIcon    [lazy] 16,16    com.formdev.flatlaf.icons.FlatFileChooserDetailsViewIcon [UI]
+FileChooser.homeFolderIcon     [lazy] 16,16    com.formdev.flatlaf.icons.FlatFileChooserHomeFolderIcon [UI]
+FileChooser.listViewIcon       [lazy] 16,16    com.formdev.flatlaf.icons.FlatFileChooserListViewIcon [UI]
+FileChooser.newFolderIcon      [lazy] 16,16    com.formdev.flatlaf.icons.FlatFileChooserNewFolderIcon [UI]
+FileChooser.readOnly           false
+FileChooser.upFolderIcon       [lazy] 16,16    com.formdev.flatlaf.icons.FlatFileChooserUpFolderIcon [UI]
+FileChooser.useSystemExtensionHiding true
+FileChooser.usesSingleFilePane true
+FileChooserUI                  com.formdev.flatlaf.ui.FlatFileChooserUI
+
+
+#---- FileView ----
+
+FileView.computerIcon          [lazy] 16,16    com.formdev.flatlaf.icons.FlatFileViewComputerIcon [UI]
+FileView.directoryIcon         [lazy] 16,16    com.formdev.flatlaf.icons.FlatFileViewDirectoryIcon [UI]
+FileView.fileIcon              [lazy] 16,16    com.formdev.flatlaf.icons.FlatFileViewFileIcon [UI]
+FileView.floppyDriveIcon       [lazy] 16,16    com.formdev.flatlaf.icons.FlatFileViewFloppyDriveIcon [UI]
+FileView.fullRowSelection      true
+FileView.hardDriveIcon         [lazy] 16,16    com.formdev.flatlaf.icons.FlatFileViewHardDriveIcon [UI]
+
+
+#---- FormattedTextField ----
+
+FormattedTextField.background  #282828  HSL   0   0  16    javax.swing.plaf.ColorUIResource [UI]
+FormattedTextField.border      [lazy] 3,3,3,3  false    com.formdev.flatlaf.ui.FlatTextBorder [UI]
+FormattedTextField.caretBlinkRate 500
+FormattedTextField.caretForeground #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+FormattedTextField.disabledBackground #232323  HSL   0   0  14    javax.swing.plaf.ColorUIResource [UI]
+FormattedTextField.font        [active] $defaultFont [UI]
+FormattedTextField.foreground  #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+FormattedTextField.iconTextGap 4
+FormattedTextField.inactiveBackground #1e1e1e  HSL   0   0  12    javax.swing.plaf.ColorUIResource [UI]
+FormattedTextField.inactiveForeground #9a9a9a  HSL   0   0  60    javax.swing.plaf.ColorUIResource [UI]
+FormattedTextField.margin      2,6,2,6    javax.swing.plaf.InsetsUIResource [UI]
+FormattedTextField.placeholderForeground #9a9a9a  HSL   0   0  60    javax.swing.plaf.ColorUIResource [UI]
+FormattedTextField.selectionBackground #3f638b  HSL 212  38  40    javax.swing.plaf.ColorUIResource [UI]
+FormattedTextField.selectionForeground #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+FormattedTextFieldUI           com.formdev.flatlaf.ui.FlatFormattedTextFieldUI
+
+
+#---- Header ----
+
+HeaderUI                       com.formdev.flatlaf.swingx.ui.FlatHeaderUI
+
+
+#---- HelpButton ----
+
+HelpButton.background          #565656  HSL   0   0  34    javax.swing.plaf.ColorUIResource [UI]
+HelpButton.borderColor         #676767  HSL   0   0  40    javax.swing.plaf.ColorUIResource [UI]
+HelpButton.borderWidth         0
+HelpButton.disabledBackground  #3d3d3d  HSL   0   0  24    javax.swing.plaf.ColorUIResource [UI]
+HelpButton.disabledBorderColor #676767  HSL   0   0  40    javax.swing.plaf.ColorUIResource [UI]
+HelpButton.disabledQuestionMarkColor #626262  HSL   0   0  38    javax.swing.plaf.ColorUIResource [UI]
+HelpButton.focusedBorderColor  #34b3ff7f  50%  HSLA 202 100  60 50    javax.swing.plaf.ColorUIResource [UI]
+HelpButton.hoverBackground     #5e5e5e  HSL   0   0  37    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(3% autoInverse)
+HelpButton.hoverBorderColor    #34b3ff7f  50%  HSLA 202 100  60 50    javax.swing.plaf.ColorUIResource [UI]
+HelpButton.icon                [lazy] 26,26    com.formdev.flatlaf.icons.FlatHelpButtonIcon [UI]
+HelpButton.innerFocusWidth     1
+HelpButton.pressedBackground   #656565  HSL   0   0  40    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(6% autoInverse)
+HelpButton.questionMarkColor   #c7c7c7  HSL   0   0  78    javax.swing.plaf.ColorUIResource [UI]
+
+
+#---- Hyperlink ----
+
+Hyperlink.disabledText         #9a9a9a  HSL   0   0  60    javax.swing.plaf.ColorUIResource [UI]
+Hyperlink.linkColor            #007aff  HSL 211 100  50    javax.swing.plaf.ColorUIResource [UI]
+Hyperlink.visitedColor         #007aff  HSL 211 100  50    javax.swing.plaf.ColorUIResource [UI]
+HyperlinkUI                    com.formdev.flatlaf.swingx.ui.FlatHyperlinkUI
+
+
+#---- InternalFrame ----
+
+InternalFrame.activeBorderColor #0c0c0c  HSL   0   0   5    javax.swing.plaf.ColorUIResource [UI]
+InternalFrame.activeDropShadowInsets 5,5,6,6    javax.swing.plaf.InsetsUIResource [UI]
+InternalFrame.activeDropShadowOpacity 0.5
+InternalFrame.activeTitleBackground #040404  HSL   0   0   2    javax.swing.plaf.ColorUIResource [UI]
+InternalFrame.activeTitleForeground #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+InternalFrame.border           [lazy] 6,6,6,6  false    com.formdev.flatlaf.ui.FlatInternalFrameUI$FlatInternalFrameBorder [UI]
+InternalFrame.borderColor      #1e1e1e  HSL   0   0  12    javax.swing.plaf.ColorUIResource [UI]
+InternalFrame.borderDarkShadow #ffffff19  10%  HSLA   0   0 100 10    javax.swing.plaf.ColorUIResource [UI]
+InternalFrame.borderHighlight  #bfbfbf19  10%  HSLA   0   0  75 10    javax.swing.plaf.ColorUIResource [UI]
+InternalFrame.borderLight      #cccccc19  10%  HSLA   0   0  80 10    javax.swing.plaf.ColorUIResource [UI]
+InternalFrame.borderLineWidth  1
+InternalFrame.borderMargins    6,6,6,6    javax.swing.plaf.InsetsUIResource [UI]
+InternalFrame.borderShadow     #ffffff19  10%  HSLA   0   0 100 10    javax.swing.plaf.ColorUIResource [UI]
+InternalFrame.buttonHoverBackground #1e1e1e  HSL   0   0  12    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(10% autoInverse)
+InternalFrame.buttonPressedBackground #373737  HSL   0   0  22    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(20% autoInverse)
+InternalFrame.buttonSize       24,24    javax.swing.plaf.DimensionUIResource [UI]
+InternalFrame.closeHoverBackground [lazy] #c75450  HSL   2  52  55    javax.swing.plaf.ColorUIResource [UI]
+InternalFrame.closeHoverForeground #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+InternalFrame.closeIcon        [lazy] 24,24    com.formdev.flatlaf.icons.FlatInternalFrameCloseIcon [UI]
+InternalFrame.closePressedBackground [lazy] #ad3b37  HSL   2  52  45    javax.swing.plaf.ColorUIResource [UI]
+InternalFrame.closePressedForeground #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+InternalFrame.dropShadowPainted true
+InternalFrame.icon             [lazy] 16,16    sun.swing.ImageIconUIResource [UI]  (sun.awt.image.ToolkitImage)
+InternalFrame.iconifyIcon      [lazy] 24,24    com.formdev.flatlaf.icons.FlatInternalFrameIconifyIcon [UI]
+InternalFrame.inactiveBorderColor #161616  HSL   0   0   9    javax.swing.plaf.ColorUIResource [UI]
+InternalFrame.inactiveDropShadowInsets 3,3,4,4    javax.swing.plaf.InsetsUIResource [UI]
+InternalFrame.inactiveDropShadowOpacity 0.75
+InternalFrame.inactiveTitleBackground #111111  HSL   0   0   7    javax.swing.plaf.ColorUIResource [UI]
+InternalFrame.inactiveTitleForeground #9a9a9a  HSL   0   0  60    javax.swing.plaf.ColorUIResource [UI]
+InternalFrame.maximizeIcon     [lazy] 24,24    com.formdev.flatlaf.icons.FlatInternalFrameMaximizeIcon [UI]
+InternalFrame.minimizeIcon     [lazy] 24,24    com.formdev.flatlaf.icons.FlatInternalFrameRestoreIcon [UI]
+InternalFrame.titleFont        [active] $defaultFont [UI]
+
+
+#---- InternalFrameTitlePane ----
+
+InternalFrameTitlePane.border  [lazy] 0,8,0,0  false    com.formdev.flatlaf.ui.FlatEmptyBorder [UI]
+InternalFrameTitlePane.closeButtonOpacity true
+InternalFrameTitlePane.iconifyButtonOpacity true
+InternalFrameTitlePane.maximizeButtonOpacity true
+
+
+#---- InternalFrame ----
+
+InternalFrameUI                com.formdev.flatlaf.ui.FlatInternalFrameUI
+
+
+#---- JXBusyLabel ----
+
+JXBusyLabel.baseColor          #777777  HSL   0   0  47    javax.swing.plaf.ColorUIResource [UI]
+JXBusyLabel.highlightColor     #e0e0e0  HSL   0   0  88    javax.swing.plaf.ColorUIResource [UI]
+
+
+#---- JXDatePicker ----
+
+JXDatePicker.border            [lazy] 3,3,3,3  false    com.formdev.flatlaf.swingx.ui.FlatDatePickerBorder [UI]
+
+
+#---- JXHeader ----
+
+JXHeader.background            #1e1e1e  HSL   0   0  12    javax.swing.plaf.ColorUIResource [UI]
+JXHeader.startBackground       #4c5052  HSL 200   4  31    javax.swing.plaf.ColorUIResource [UI]
+
+
+#---- JXMonthView ----
+
+JXMonthView.arrowColor         #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+JXMonthView.background         #282828  HSL   0   0  16    javax.swing.plaf.ColorUIResource [UI]
+JXMonthView.daysOfTheWeekForeground #aaaaaa  HSL   0   0  67    javax.swing.plaf.ColorUIResource [UI]
+JXMonthView.disabledArrowColor #9a9a9a  HSL   0   0  60    javax.swing.plaf.ColorUIResource [UI]
+JXMonthView.flaggedDayForeground #e05555  HSL   0  69  61    javax.swing.plaf.ColorUIResource [UI]
+JXMonthView.leadingDayForeground #9a9a9a  HSL   0   0  60    javax.swing.plaf.ColorUIResource [UI]
+JXMonthView.monthDownFileName  [lazy] 20,20    com.formdev.flatlaf.swingx.ui.FlatMonthDownIcon [UI]
+JXMonthView.monthStringBackground #4c5052  HSL 200   4  31    javax.swing.plaf.ColorUIResource [UI]
+JXMonthView.monthStringForeground #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+JXMonthView.monthUpFileName    [lazy] 20,20    com.formdev.flatlaf.swingx.ui.FlatMonthUpIcon [UI]
+JXMonthView.selectedBackground #0058d0  HSL 215 100  41    javax.swing.plaf.ColorUIResource [UI]
+JXMonthView.trailingDayForeground #9a9a9a  HSL   0   0  60    javax.swing.plaf.ColorUIResource [UI]
+JXMonthView.unselectableDayForeground #e05555  HSL   0  69  61    javax.swing.plaf.ColorUIResource [UI]
+JXMonthView.weekOfTheYearForeground #888888  HSL   0   0  53    javax.swing.plaf.ColorUIResource [UI]
+
+
+#---- JXTitledPanel ----
+
+JXTitledPanel.borderColor      #676767  HSL   0   0  40    javax.swing.plaf.ColorUIResource [UI]
+JXTitledPanel.captionInsets    4,10,4,10    javax.swing.plaf.InsetsUIResource [UI]
+JXTitledPanel.titleBackground  #4c5052  HSL 200   4  31    javax.swing.plaf.ColorUIResource [UI]
+JXTitledPanel.titleForeground  #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+
+
+#---- JideButton ----
+
+JideButton.background          #565656  HSL   0   0  34    javax.swing.plaf.ColorUIResource [UI]
+JideButton.border              [lazy] 0,0,0,0  false    com.formdev.flatlaf.ui.FlatMarginBorder [UI]
+JideButton.borderColor         #676767  HSL   0   0  40    javax.swing.plaf.ColorUIResource [UI]
+JideButton.darkShadow          #676767  HSL   0   0  40    javax.swing.plaf.ColorUIResource [UI]
+JideButton.focusedBackground   #ffffff11  7%  HSLA   0   0 100  7    javax.swing.plaf.ColorUIResource [UI]
+JideButton.foreground          #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+JideButton.highlight           #707070  HSL   0   0  44    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(10% autoInverse)
+JideButton.light               #676767  HSL   0   0  40    javax.swing.plaf.ColorUIResource [UI]
+JideButton.margin              3,3,3,3    javax.swing.plaf.InsetsUIResource [UI]
+JideButton.selectedAndFocusedBackground #ffffff22  13%  HSLA   0   0 100 13    javax.swing.plaf.ColorUIResource [UI]
+JideButton.selectedBackground  #ffffff33  20%  HSLA   0   0 100 20    javax.swing.plaf.ColorUIResource [UI]
+JideButton.shadow              #676767  HSL   0   0  40    javax.swing.plaf.ColorUIResource [UI]
+JideButton.textIconGap         [active] 4
+JideButtonUI                   com.formdev.flatlaf.jideoss.ui.FlatJideButtonUI
+
+
+#---- JideLabel ----
+
+JideLabel.background           #1e1e1e  HSL   0   0  12    javax.swing.plaf.ColorUIResource [UI]
+JideLabel.disabledForeground   #9a9a9a  HSL   0   0  60    javax.swing.plaf.ColorUIResource [UI]
+JideLabel.foreground           #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+JideLabelUI                    com.formdev.flatlaf.jideoss.ui.FlatJideLabelUI
+
+
+#---- JidePopupMenu ----
+
+JidePopupMenuUI                com.formdev.flatlaf.jideoss.ui.FlatJidePopupMenuUI
+
+
+#---- JideSplitButton ----
+
+JideSplitButton.background     #565656  HSL   0   0  34    javax.swing.plaf.ColorUIResource [UI]
+JideSplitButton.border         [lazy] 0,0,0,0  false    com.formdev.flatlaf.ui.FlatMarginBorder [UI]
+JideSplitButton.buttonArrowColor #b7b7b7  HSL   0   0  72    javax.swing.plaf.ColorUIResource [UI]
+JideSplitButton.buttonDisabledArrowColor #777777  HSL   0   0  47    javax.swing.plaf.ColorUIResource [UI]
+JideSplitButton.foreground     #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+JideSplitButton.margin         3,3,3,3    javax.swing.plaf.InsetsUIResource [UI]
+JideSplitButton.selectionForeground #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+JideSplitButton.textIconGap    [active] 4
+JideSplitButtonUI              com.formdev.flatlaf.jideoss.ui.FlatJideSplitButtonUI
+
+
+#---- JideTabbedPane ----
+
+JideTabbedPane.background      #1e1e1e  HSL   0   0  12    javax.swing.plaf.ColorUIResource [UI]
+JideTabbedPane.closeButtonLeftMargin 0
+JideTabbedPane.closeButtonRightMargin 0
+JideTabbedPane.contentBorderInsets 0,0,0,0    javax.swing.plaf.InsetsUIResource [UI]
+JideTabbedPane.fitStyleBoundSize 0
+JideTabbedPane.fitStyleFirstTabMargin 0
+JideTabbedPane.foreground      #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+JideTabbedPane.shadow          #1e1e1e  HSL   0   0  12    javax.swing.plaf.ColorUIResource [UI]
+JideTabbedPane.tabAreaBackground #1e1e1e  HSL   0   0  12    javax.swing.plaf.ColorUIResource [UI]
+JideTabbedPane.tabAreaInsets   0,0,0,0    javax.swing.plaf.InsetsUIResource [UI]
+JideTabbedPane.tabInsets       4,12,4,12    javax.swing.plaf.InsetsUIResource [UI]
+JideTabbedPane.tabRunOverlay   0
+JideTabbedPaneUI               com.formdev.flatlaf.jideoss.ui.FlatJideTabbedPaneUI
+
+
+#---- Label ----
+
+Label.background               #1e1e1e  HSL   0   0  12    javax.swing.plaf.ColorUIResource [UI]
+Label.disabledForeground       #9a9a9a  HSL   0   0  60    javax.swing.plaf.ColorUIResource [UI]
+Label.disabledShadow           #ffffff19  10%  HSLA   0   0 100 10    javax.swing.plaf.ColorUIResource [UI]
+Label.font                     [active] $defaultFont [UI]
+Label.foreground               #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+LabelUI                        com.formdev.flatlaf.ui.FlatLabelUI
+
+
+#---- List ----
+
+List.background                #282828  HSL   0   0  16    javax.swing.plaf.ColorUIResource [UI]
+List.border                    [lazy] 0,0,0,0  false    com.formdev.flatlaf.ui.FlatEmptyBorder [UI]
+List.cellFocusColor            #000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]
+List.cellMargins               1,6,1,6    javax.swing.plaf.InsetsUIResource [UI]
+List.cellNoFocusBorder         [lazy] 1,6,1,6  false    com.formdev.flatlaf.ui.FlatListCellBorder$Default [UI]    lineColor=#000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]    lineThickness=1.000000
+List.cellRenderer              [active] javax.swing.DefaultListCellRenderer$UIResource [UI]
+List.dropCellBackground        [lazy] #00429d  HSL 215 100  31    javax.swing.plaf.ColorUIResource [UI]
+List.dropCellForeground        [lazy] #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+List.dropLineColor             [lazy] #046eff  HSL 215 100  51    javax.swing.plaf.ColorUIResource [UI]
+List.focusCellHighlightBorder  [lazy] 1,6,1,6  false    com.formdev.flatlaf.ui.FlatListCellBorder$Focused [UI]    lineColor=#000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]    lineThickness=1.000000
+List.focusSelectedCellHighlightBorder [lazy] 1,6,1,6  false    com.formdev.flatlaf.ui.FlatListCellBorder$Selected [UI]    lineColor=#000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]    lineThickness=1.000000
+List.font                      [active] $defaultFont [UI]
+List.foreground                #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+List.noFocusBorder             1,1,1,1  false    javax.swing.plaf.BorderUIResource$EmptyBorderUIResource [UI]
+List.selectionBackground       #0058d0  HSL 215 100  41    javax.swing.plaf.ColorUIResource [UI]
+List.selectionForeground       #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+List.selectionInactiveBackground #464646  HSL   0   0  27    javax.swing.plaf.ColorUIResource [UI]
+List.selectionInactiveForeground #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+List.showCellFocusIndicator    false
+List.timeFactor                1000
+ListUI                         com.formdev.flatlaf.ui.FlatListUI
+
+
+#---- Menu ----
+
+Menu.acceleratorFont           [active] $defaultFont [UI]
+Menu.acceleratorForeground     #b7b7b7  HSL   0   0  72    javax.swing.plaf.ColorUIResource [UI]
+Menu.acceleratorSelectionForeground #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+Menu.arrowIcon                 [lazy] 6,10    com.formdev.flatlaf.icons.FlatMenuArrowIcon [UI]
+Menu.background                #323232  HSL   0   0  20    javax.swing.plaf.ColorUIResource [UI]
+Menu.border                    [lazy] 0,0,0,0  false    com.formdev.flatlaf.ui.FlatMenuItemBorder [UI]
+Menu.borderPainted             true
+Menu.cancelMode                hideLastSubmenu
+Menu.crossMenuMnemonic         true
+Menu.disabledForeground        #9a9a9a  HSL   0   0  60    javax.swing.plaf.ColorUIResource [UI]
+Menu.font                      [active] $defaultFont [UI]
+Menu.foreground                #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+Menu.icon.arrowColor           #b7b7b7  HSL   0   0  72    javax.swing.plaf.ColorUIResource [UI]
+Menu.icon.disabledArrowColor   #777777  HSL   0   0  47    javax.swing.plaf.ColorUIResource [UI]
+Menu.margin                    3,6,3,6    javax.swing.plaf.InsetsUIResource [UI]
+Menu.menuPopupOffsetX          0
+Menu.menuPopupOffsetY          0
+Menu.opaque                    false
+Menu.preserveTopLevelSelection false
+Menu.selectionBackground       #0058d0  HSL 215 100  41    javax.swing.plaf.ColorUIResource [UI]
+Menu.selectionForeground       #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+Menu.shortcutKeys              length=1    [I
+    [0] 8
+Menu.submenuPopupOffsetX       [active] -4
+Menu.submenuPopupOffsetY       [active] -4
+
+
+#---- MenuBar ----
+
+MenuBar.background             #323232  HSL   0   0  20    javax.swing.plaf.ColorUIResource [UI]
+MenuBar.border                 [lazy] 0,0,1,0  false    com.formdev.flatlaf.ui.FlatMenuBarBorder [UI]
+MenuBar.borderColor            #ffffff19  10%  HSLA   0   0 100 10    javax.swing.plaf.ColorUIResource [UI]
+MenuBar.font                   [active] $defaultFont [UI]
+MenuBar.foreground             #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+MenuBar.highlight              #bfbfbf19  10%  HSLA   0   0  75 10    javax.swing.plaf.ColorUIResource [UI]
+MenuBar.hoverBackground        #4c4c4c  HSL   0   0  30    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(10% autoInverse)
+MenuBar.itemMargins            3,8,3,8    javax.swing.plaf.InsetsUIResource [UI]
+MenuBar.shadow                 #ffffff19  10%  HSLA   0   0 100 10    javax.swing.plaf.ColorUIResource [UI]
+MenuBar.windowBindings         length=2    [Ljava.lang.Object;
+    [0] F10
+    [1] takeFocus
+MenuBarUI                      com.formdev.flatlaf.ui.FlatMenuBarUI
+
+
+#---- MenuItem ----
+
+MenuItem.acceleratorArrowGap   2
+MenuItem.acceleratorDelimiter  +
+MenuItem.acceleratorFont       [active] $defaultFont [UI]
+MenuItem.acceleratorForeground #b7b7b7  HSL   0   0  72    javax.swing.plaf.ColorUIResource [UI]
+MenuItem.acceleratorSelectionForeground #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+MenuItem.arrowIcon             [lazy] 6,10    com.formdev.flatlaf.icons.FlatMenuItemArrowIcon [UI]
+MenuItem.background            #323232  HSL   0   0  20    javax.swing.plaf.ColorUIResource [UI]
+MenuItem.border                [lazy] 0,0,0,0  false    com.formdev.flatlaf.ui.FlatMenuItemBorder [UI]
+MenuItem.borderPainted         true
+MenuItem.checkBackground       #00429d  HSL 215 100  31    com.formdev.flatlaf.util.DerivedColor [UI]    darken(10%)
+MenuItem.checkMargins          2,2,2,2    javax.swing.plaf.InsetsUIResource [UI]
+MenuItem.disabledForeground    #9a9a9a  HSL   0   0  60    javax.swing.plaf.ColorUIResource [UI]
+MenuItem.font                  [active] $defaultFont [UI]
+MenuItem.foreground            #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+MenuItem.iconTextGap           6
+MenuItem.margin                3,6,3,6    javax.swing.plaf.InsetsUIResource [UI]
+MenuItem.minimumIconSize       16,16    javax.swing.plaf.DimensionUIResource [UI]
+MenuItem.minimumWidth          72
+MenuItem.opaque                false
+MenuItem.selectionBackground   #0058d0  HSL 215 100  41    javax.swing.plaf.ColorUIResource [UI]
+MenuItem.selectionForeground   #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+MenuItem.textAcceleratorGap    24
+MenuItem.textNoAcceleratorGap  6
+MenuItem.underlineSelectionBackground #4c4c4c  HSL   0   0  30    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(10% autoInverse)
+MenuItem.underlineSelectionCheckBackground #00429d  HSL 215 100  31    com.formdev.flatlaf.util.DerivedColor [UI]    darken(10%)
+MenuItem.underlineSelectionColor #007aff  HSL 211 100  50    javax.swing.plaf.ColorUIResource [UI]
+MenuItem.underlineSelectionHeight 3
+MenuItem.verticallyAlignText   true
+MenuItemUI                     com.formdev.flatlaf.ui.FlatMenuItemUI
+
+
+#---- Menu ----
+
+MenuUI                         com.formdev.flatlaf.ui.FlatMenuUI
+
+
+#---- MonthView ----
+
+MonthViewUI                    com.formdev.flatlaf.swingx.ui.FlatMonthViewUI
+
+
+#---- Objects ----
+
+Objects.BlackText              #231f20  HSL 345   6  13    javax.swing.plaf.ColorUIResource [UI]
+Objects.Blue                   #40b6e0  HSL 196  72  56    javax.swing.plaf.ColorUIResource [UI]
+Objects.Green                  #62b543  HSL 104  46  49    javax.swing.plaf.ColorUIResource [UI]
+Objects.GreenAndroid           #a4c639  HSL  74  55  50    javax.swing.plaf.ColorUIResource [UI]
+Objects.Grey                   #9aa7b0  HSL 205  12  65    javax.swing.plaf.ColorUIResource [UI]
+Objects.Pink                   #f98b9e  HSL 350  90  76    javax.swing.plaf.ColorUIResource [UI]
+Objects.Purple                 #b99bf8  HSL 259  87  79    javax.swing.plaf.ColorUIResource [UI]
+Objects.Red                    #f26522  HSL  19  89  54    javax.swing.plaf.ColorUIResource [UI]
+Objects.RedStatus              #e05555  HSL   0  69  61    javax.swing.plaf.ColorUIResource [UI]
+Objects.Yellow                 #f4af3d  HSL  37  89  60    javax.swing.plaf.ColorUIResource [UI]
+Objects.YellowDark             #d9a343  HSL  38  66  56    javax.swing.plaf.ColorUIResource [UI]
+
+
+#---- OptionPane ----
+
+OptionPane.background          #1e1e1e  HSL   0   0  12    javax.swing.plaf.ColorUIResource [UI]
+OptionPane.border              [lazy] 12,12,12,12  false    com.formdev.flatlaf.ui.FlatEmptyBorder [UI]
+OptionPane.buttonAreaBorder    [lazy] 12,0,0,0  false    com.formdev.flatlaf.ui.FlatEmptyBorder [UI]
+OptionPane.buttonClickThreshhold 500
+OptionPane.buttonMinimumWidth  [active] 72
+OptionPane.buttonOrientation   4
+OptionPane.buttonPadding       8
+OptionPane.errorIcon           [lazy] 32,32    com.formdev.flatlaf.icons.FlatOptionPaneErrorIcon [UI]
+OptionPane.font                [active] $defaultFont [UI]
+OptionPane.foreground          #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+OptionPane.iconMessageGap      16
+OptionPane.informationIcon     [lazy] 32,32    com.formdev.flatlaf.icons.FlatOptionPaneInformationIcon [UI]
+OptionPane.maxCharactersPerLine 80
+OptionPane.messageAreaBorder   [lazy] 0,0,0,0  false    com.formdev.flatlaf.ui.FlatEmptyBorder [UI]
+OptionPane.messagePadding      3
+OptionPane.minimumSize         262,90    javax.swing.plaf.DimensionUIResource [UI]
+OptionPane.questionIcon        [lazy] 32,32    com.formdev.flatlaf.icons.FlatOptionPaneQuestionIcon [UI]
+OptionPane.sameSizeButtons     true
+OptionPane.setButtonMargin     false
+OptionPane.showIcon            false
+OptionPane.warningIcon         [lazy] 32,32    com.formdev.flatlaf.icons.FlatOptionPaneWarningIcon [UI]
+OptionPane.windowBindings      length=2    [Ljava.lang.Object;
+    [0] ESCAPE
+    [1] close
+OptionPaneUI                   com.formdev.flatlaf.ui.FlatOptionPaneUI
+
+
+#---- Panel ----
+
+Panel.background               #1e1e1e  HSL   0   0  12    javax.swing.plaf.ColorUIResource [UI]
+Panel.font                     [active] $defaultFont [UI]
+Panel.foreground               #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+PanelUI                        com.formdev.flatlaf.ui.FlatPanelUI
+
+
+#---- PasswordField ----
+
+PasswordField.background       #282828  HSL   0   0  16    javax.swing.plaf.ColorUIResource [UI]
+PasswordField.border           [lazy] 3,3,3,3  false    com.formdev.flatlaf.ui.FlatTextBorder [UI]
+PasswordField.capsLockIcon     [lazy] 16,16    com.formdev.flatlaf.icons.FlatCapsLockIcon [UI]
+PasswordField.capsLockIconColor #ffffff64  39%  HSLA   0   0 100 39    javax.swing.plaf.ColorUIResource [UI]
+PasswordField.caretBlinkRate   500
+PasswordField.caretForeground  #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+PasswordField.disabledBackground #232323  HSL   0   0  14    javax.swing.plaf.ColorUIResource [UI]
+PasswordField.echoChar         '\u2022'
+PasswordField.font             [active] $defaultFont [UI]
+PasswordField.foreground       #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+PasswordField.iconTextGap      4
+PasswordField.inactiveBackground #1e1e1e  HSL   0   0  12    javax.swing.plaf.ColorUIResource [UI]
+PasswordField.inactiveForeground #9a9a9a  HSL   0   0  60    javax.swing.plaf.ColorUIResource [UI]
+PasswordField.margin           2,6,2,6    javax.swing.plaf.InsetsUIResource [UI]
+PasswordField.placeholderForeground #9a9a9a  HSL   0   0  60    javax.swing.plaf.ColorUIResource [UI]
+PasswordField.revealIcon       [lazy] 16,16    com.formdev.flatlaf.icons.FlatRevealIcon [UI]
+PasswordField.revealIconColor  #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+PasswordField.selectionBackground #3f638b  HSL 212  38  40    javax.swing.plaf.ColorUIResource [UI]
+PasswordField.selectionForeground #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+PasswordField.showCapsLock     true
+PasswordField.showRevealButton false
+PasswordFieldUI                com.formdev.flatlaf.ui.FlatPasswordFieldUI
+
+
+#---- Popup ----
+
+Popup.dropShadowColor          #000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]
+Popup.dropShadowInsets         -4,-4,4,4    javax.swing.plaf.InsetsUIResource [UI]
+Popup.dropShadowOpacity        0.25
+Popup.dropShadowPainted        true
+
+
+#---- PopupMenu ----
+
+PopupMenu.background           #323232  HSL   0   0  20    javax.swing.plaf.ColorUIResource [UI]
+PopupMenu.border               [lazy] 4,1,4,1  false    com.formdev.flatlaf.ui.FlatPopupMenuBorder [UI]    lineColor=#444444  HSL   0   0  27    javax.swing.plaf.ColorUIResource [UI]    lineThickness=1.000000
+PopupMenu.borderColor          #444444  HSL   0   0  27    javax.swing.plaf.ColorUIResource [UI]
+PopupMenu.borderInsets         4,1,4,1    javax.swing.plaf.InsetsUIResource [UI]
+PopupMenu.consumeEventOnClose  false
+PopupMenu.font                 [active] $defaultFont [UI]
+PopupMenu.foreground           #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+PopupMenu.hoverScrollArrowBackground #2b2b2b  HSL   0   0  17    javax.swing.plaf.ColorUIResource [UI]
+PopupMenu.scrollArrowColor     #b7b7b7  HSL   0   0  72    javax.swing.plaf.ColorUIResource [UI]
+
+
+#---- PopupMenuSeparator ----
+
+PopupMenuSeparator.height      9
+PopupMenuSeparator.stripeIndent 4
+PopupMenuSeparator.stripeWidth 1
+PopupMenuSeparatorUI           com.formdev.flatlaf.ui.FlatPopupMenuSeparatorUI
+
+
+#---- PopupMenu ----
+
+PopupMenuUI                    com.formdev.flatlaf.ui.FlatPopupMenuUI
+
+
+#---- ProgressBar ----
+
+ProgressBar.arc                4
+ProgressBar.background         #323232  HSL   0   0  20    javax.swing.plaf.ColorUIResource [UI]
+ProgressBar.border             [lazy] 0,0,0,0  false    com.formdev.flatlaf.ui.FlatEmptyBorder [UI]
+ProgressBar.cellLength         1
+ProgressBar.cellSpacing        0
+ProgressBar.cycleTime          4000
+ProgressBar.font               [active] Segoe UI plain 10    javax.swing.plaf.FontUIResource [UI]
+ProgressBar.foreground         #007aff  HSL 211 100  50    javax.swing.plaf.ColorUIResource [UI]
+ProgressBar.horizontalSize     146,4    javax.swing.plaf.DimensionUIResource [UI]
+ProgressBar.repaintInterval    15
+ProgressBar.selectionBackground #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+ProgressBar.selectionForeground #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+ProgressBar.verticalSize       4,146    javax.swing.plaf.DimensionUIResource [UI]
+ProgressBarUI                  com.formdev.flatlaf.ui.FlatProgressBarUI
+
+
+#---- RadioButton ----
+
+RadioButton.background         #1e1e1e  HSL   0   0  12    javax.swing.plaf.ColorUIResource [UI]
+RadioButton.border             [lazy] 0,0,0,0  false    com.formdev.flatlaf.ui.FlatMarginBorder [UI]
+RadioButton.darkShadow         #ffffff19  10%  HSLA   0   0 100 10    javax.swing.plaf.ColorUIResource [UI]
+RadioButton.disabledText       #9a9a9a  HSL   0   0  60    javax.swing.plaf.ColorUIResource [UI]
+RadioButton.font               [active] $defaultFont [UI]
+RadioButton.foreground         #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+RadioButton.highlight          #bfbfbf19  10%  HSLA   0   0  75 10    javax.swing.plaf.ColorUIResource [UI]
+RadioButton.icon.centerDiameter 8
+RadioButton.icon.style         filled
+RadioButton.icon               [lazy] 15,15    com.formdev.flatlaf.icons.FlatRadioButtonIcon [UI]
+RadioButton.iconTextGap        6
+RadioButton.icon[filled].centerDiameter 6
+RadioButton.light              #cccccc19  10%  HSLA   0   0  80 10    javax.swing.plaf.ColorUIResource [UI]
+RadioButton.margin             2,2,2,2    javax.swing.plaf.InsetsUIResource [UI]
+RadioButton.rollover           true
+RadioButton.shadow             #ffffff19  10%  HSLA   0   0 100 10    javax.swing.plaf.ColorUIResource [UI]
+RadioButton.textIconGap        4
+RadioButton.textShiftOffset    0
+
+
+#---- RadioButtonMenuItem ----
+
+RadioButtonMenuItem.acceleratorFont [active] $defaultFont [UI]
+RadioButtonMenuItem.acceleratorForeground #b7b7b7  HSL   0   0  72    javax.swing.plaf.ColorUIResource [UI]
+RadioButtonMenuItem.acceleratorSelectionForeground #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+RadioButtonMenuItem.arrowIcon  [lazy] 6,10    com.formdev.flatlaf.icons.FlatMenuItemArrowIcon [UI]
+RadioButtonMenuItem.background #323232  HSL   0   0  20    javax.swing.plaf.ColorUIResource [UI]
+RadioButtonMenuItem.border     [lazy] 0,0,0,0  false    com.formdev.flatlaf.ui.FlatMenuItemBorder [UI]
+RadioButtonMenuItem.borderPainted true
+RadioButtonMenuItem.checkIcon  [lazy] 15,15    com.formdev.flatlaf.icons.FlatRadioButtonMenuItemIcon [UI]
+RadioButtonMenuItem.disabledForeground #9a9a9a  HSL   0   0  60    javax.swing.plaf.ColorUIResource [UI]
+RadioButtonMenuItem.font       [active] $defaultFont [UI]
+RadioButtonMenuItem.foreground #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+RadioButtonMenuItem.margin     3,6,3,6    javax.swing.plaf.InsetsUIResource [UI]
+RadioButtonMenuItem.opaque     false
+RadioButtonMenuItem.selectionBackground #0058d0  HSL 215 100  41    javax.swing.plaf.ColorUIResource [UI]
+RadioButtonMenuItem.selectionForeground #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+RadioButtonMenuItemUI          com.formdev.flatlaf.ui.FlatRadioButtonMenuItemUI
+
+
+#---- RadioButton ----
+
+RadioButtonUI                  com.formdev.flatlaf.ui.FlatRadioButtonUI
+
+
+#---- RangeSlider ----
+
+RangeSliderUI                  com.formdev.flatlaf.jideoss.ui.FlatRangeSliderUI
+
+
+#---- Resizable ----
+
+Resizable.resizeBorder         [lazy] 4,4,4,4  false    com.formdev.flatlaf.ui.FlatLineBorder [UI]    lineColor=#444444  HSL   0   0  27    javax.swing.plaf.ColorUIResource [UI]    lineThickness=1.000000
+
+
+#---- RootPane ----
+
+RootPane.activeBorderColor     #303030  HSL   0   0  19    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(7% autoInverse)
+RootPane.background            #1e1e1e  HSL   0   0  12    javax.swing.plaf.ColorUIResource [UI]
+RootPane.border                [lazy] 1,1,1,1  false    com.formdev.flatlaf.ui.FlatRootPaneUI$FlatWindowBorder [UI]
+RootPane.borderDragThickness   5
+RootPane.cornerDragWidth       16
+RootPane.defaultButtonWindowKeyBindings length=8    [Ljava.lang.Object;
+    [0] ENTER
+    [1] press
+    [2] released ENTER
+    [3] release
+    [4] ctrl ENTER
+    [5] press
+    [6] ctrl released ENTER
+    [7] release
+RootPane.font                  [active] $defaultFont [UI]
+RootPane.foreground            #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+RootPane.honorDialogMinimumSizeOnResize true
+RootPane.honorFrameMinimumSizeOnResize false
+RootPane.inactiveBorderColor   #2b2b2b  HSL   0   0  17    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(5% autoInverse)
+RootPaneUI                     com.formdev.flatlaf.ui.FlatRootPaneUI
+
+
+#---- ScrollBar ----
+
+ScrollBar.allowsAbsolutePositioning true
+ScrollBar.background           #1e1e1e  HSL   0   0  12    javax.swing.plaf.ColorUIResource [UI]
+ScrollBar.buttonArrowColor     #b7b7b7  HSL   0   0  72    javax.swing.plaf.ColorUIResource [UI]
+ScrollBar.buttonDisabledArrowColor #777777  HSL   0   0  47    javax.swing.plaf.ColorUIResource [UI]
+ScrollBar.foreground           #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+ScrollBar.hoverButtonBackground #2b2b2b  HSL   0   0  17    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(5%)
+ScrollBar.hoverThumbColor      #707070  HSL   0   0  44    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(10%)
+ScrollBar.hoverThumbWithTrack  false
+ScrollBar.hoverTrackColor      #323232  HSL   0   0  20    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(4%)
+ScrollBar.maximumThumbSize     100000,100000    javax.swing.plaf.DimensionUIResource [UI]
+ScrollBar.minimumButtonSize    12,12    javax.swing.plaf.DimensionUIResource [UI]
+ScrollBar.minimumThumbSize     10,10    javax.swing.plaf.DimensionUIResource [UI]
+ScrollBar.pressedButtonBackground #383838  HSL   0   0  22    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(10%)
+ScrollBar.pressedThumbColor    #7c7c7c  HSL   0   0  49    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(15%)
+ScrollBar.pressedThumbWithTrack false
+ScrollBar.showButtons          false
+ScrollBar.squareButtons        false
+ScrollBar.thumb                #565656  HSL   0   0  34    javax.swing.plaf.ColorUIResource [UI]
+ScrollBar.thumbArc             0
+ScrollBar.thumbDarkShadow      #ffffff19  10%  HSLA   0   0 100 10    javax.swing.plaf.ColorUIResource [UI]
+ScrollBar.thumbHighlight       #bfbfbf19  10%  HSLA   0   0  75 10    javax.swing.plaf.ColorUIResource [UI]
+ScrollBar.thumbInsets          0,0,0,0    javax.swing.plaf.InsetsUIResource [UI]
+ScrollBar.thumbShadow          #ffffff19  10%  HSLA   0   0 100 10    javax.swing.plaf.ColorUIResource [UI]
+ScrollBar.track                #282828  HSL   0   0  16    javax.swing.plaf.ColorUIResource [UI]
+ScrollBar.trackArc             0
+ScrollBar.trackHighlight       #ffffff19  10%  HSLA   0   0 100 10    javax.swing.plaf.ColorUIResource [UI]
+ScrollBar.trackInsets          0,0,0,0    javax.swing.plaf.InsetsUIResource [UI]
+ScrollBar.width                12
+ScrollBarUI                    com.formdev.flatlaf.ui.FlatScrollBarUI
+
+
+#---- ScrollPane ----
+
+ScrollPane.background          #282828  HSL   0   0  16    javax.swing.plaf.ColorUIResource [UI]
+ScrollPane.border              [lazy] 3,3,3,3  false    com.formdev.flatlaf.ui.FlatBorder [UI]
+ScrollPane.fillUpperCorner     true
+ScrollPane.font                [active] $defaultFont [UI]
+ScrollPane.foreground          #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+ScrollPane.smoothScrolling     true
+ScrollPaneUI                   com.formdev.flatlaf.ui.FlatScrollPaneUI
+
+
+#---- SearchField ----
+
+SearchField.clearIcon          [lazy] 16,16    com.formdev.flatlaf.icons.FlatClearIcon [UI]
+SearchField.clearIconColor     [lazy] #7f8b9180  50%  HSLA 200   8  53 50    javax.swing.plaf.ColorUIResource [UI]
+SearchField.clearIconHoverColor [lazy] #7f8b9180  50%  HSLA 200   8  53 50    javax.swing.plaf.ColorUIResource [UI]
+SearchField.clearIconPressedColor [lazy] #7f8b91cc  80%  HSLA 200   8  53 80    javax.swing.plaf.ColorUIResource [UI]
+SearchField.clearPressedIcon   [lazy] 16,16    com.formdev.flatlaf.icons.FlatClearIcon [UI]
+SearchField.clearRolloverIcon  [lazy] 16,16    com.formdev.flatlaf.icons.FlatClearIcon [UI]
+SearchField.icon               [lazy] 16,16    com.formdev.flatlaf.icons.FlatSearchIcon [UI]
+SearchField.popupIcon          [lazy] 16,16    com.formdev.flatlaf.icons.FlatSearchWithHistoryIcon [UI]
+SearchField.popupPressedIcon   [lazy] 16,16    com.formdev.flatlaf.icons.FlatSearchWithHistoryIcon [UI]
+SearchField.popupRolloverIcon  [lazy] 16,16    com.formdev.flatlaf.icons.FlatSearchWithHistoryIcon [UI]
+SearchField.pressedIcon        [lazy] 16,16    com.formdev.flatlaf.icons.FlatSearchIcon [UI]
+SearchField.rolloverIcon       [lazy] 16,16    com.formdev.flatlaf.icons.FlatSearchIcon [UI]
+SearchField.searchIconColor    [lazy] #7f8b91e6  90%  HSLA 200   8  53 90    javax.swing.plaf.ColorUIResource [UI]
+SearchField.searchIconHoverColor [lazy] #7f8b91b3  70%  HSLA 200   8  53 70    javax.swing.plaf.ColorUIResource [UI]
+SearchField.searchIconPressedColor [lazy] #7f8b9180  50%  HSLA 200   8  53 50    javax.swing.plaf.ColorUIResource [UI]
+
+
+#---- Separator ----
+
+Separator.background           #1e1e1e  HSL   0   0  12    javax.swing.plaf.ColorUIResource [UI]
+Separator.foreground           #ffffff19  10%  HSLA   0   0 100 10    javax.swing.plaf.ColorUIResource [UI]
+Separator.height               3
+Separator.highlight            #bfbfbf19  10%  HSLA   0   0  75 10    javax.swing.plaf.ColorUIResource [UI]
+Separator.shadow               #ffffff19  10%  HSLA   0   0 100 10    javax.swing.plaf.ColorUIResource [UI]
+Separator.stripeIndent         1
+Separator.stripeWidth          1
+SeparatorUI                    com.formdev.flatlaf.ui.FlatSeparatorUI
+
+
+#---- Slider ----
+
+Slider.background              #1e1e1e  HSL   0   0  12    javax.swing.plaf.ColorUIResource [UI]
+Slider.disabledThumbColor      #393939  HSL   0   0  22    javax.swing.plaf.ColorUIResource [UI]
+Slider.disabledTrackColor      #282828  HSL   0   0  16    javax.swing.plaf.ColorUIResource [UI]
+Slider.focus                   #ffffff19  10%  HSLA   0   0 100 10    javax.swing.plaf.ColorUIResource [UI]
+Slider.focusInsets             0,0,0,0    javax.swing.plaf.InsetsUIResource [UI]
+Slider.focusWidth              4
+Slider.focusedColor            #1aa9ff7f  50%  HSLA 203 100  55 50    javax.swing.plaf.ColorUIResource [UI]
+Slider.font                    [active] $defaultFont [UI]
+Slider.foreground              #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+Slider.highlight               #bfbfbf19  10%  HSLA   0   0  75 10    javax.swing.plaf.ColorUIResource [UI]
+Slider.horizontalSize          200,21    java.awt.Dimension
+Slider.hoverThumbColor         #989898  HSL   0   0  60    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(5% autoInverse)
+Slider.minimumHorizontalSize   36,21    java.awt.Dimension
+Slider.minimumVerticalSize     21,36    java.awt.Dimension
+Slider.onlyLeftMouseButtonDrag true
+Slider.pressedThumbColor       #9f9f9f  HSL   0   0  62    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(8% autoInverse)
+Slider.shadow                  #ffffff19  10%  HSLA   0   0 100 10    javax.swing.plaf.ColorUIResource [UI]
+Slider.thumbColor              #8b8b8b  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
+Slider.thumbSize               14,14    javax.swing.plaf.DimensionUIResource [UI]
+Slider.tickColor               #9a9a9a  HSL   0   0  60    javax.swing.plaf.ColorUIResource [UI]
+Slider.trackColor              #323232  HSL   0   0  20    javax.swing.plaf.ColorUIResource [UI]
+Slider.trackValueColor         #007aff  HSL 211 100  50    javax.swing.plaf.ColorUIResource [UI]
+Slider.trackWidth              3
+Slider.verticalSize            21,200    java.awt.Dimension
+SliderUI                       com.formdev.flatlaf.ui.FlatSliderUI
+
+
+#---- Spinner ----
+
+Spinner.arrowButtonSize        16,5    java.awt.Dimension
+Spinner.background             #282828  HSL   0   0  16    javax.swing.plaf.ColorUIResource [UI]
+Spinner.border                 [lazy] 3,3,3,3  false    com.formdev.flatlaf.ui.FlatRoundBorder [UI]
+Spinner.buttonArrowColor       #b7b7b7  HSL   0   0  72    javax.swing.plaf.ColorUIResource [UI]
+Spinner.buttonBackground       #565656  HSL   0   0  34    javax.swing.plaf.ColorUIResource [UI]
+Spinner.buttonDisabledArrowColor #777777  HSL   0   0  47    javax.swing.plaf.ColorUIResource [UI]
+Spinner.buttonDisabledSeparatorColor #ffffff0c  5%  HSLA   0   0 100  5    javax.swing.plaf.ColorUIResource [UI]
+Spinner.buttonHoverArrowColor  #d1d1d1  HSL   0   0  82    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(10%)
+Spinner.buttonPressedArrowColor #eaeaea  HSL   0   0  92    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(20%)
+Spinner.buttonSeparatorColor   #ffffff19  10%  HSLA   0   0 100 10    javax.swing.plaf.ColorUIResource [UI]
+Spinner.buttonSeparatorWidth   0
+Spinner.buttonStyle            mac
+Spinner.disabledBackground     #232323  HSL   0   0  14    javax.swing.plaf.ColorUIResource [UI]
+Spinner.disabledForeground     #9a9a9a  HSL   0   0  60    javax.swing.plaf.ColorUIResource [UI]
+Spinner.editorAlignment        11
+Spinner.editorBorderPainted    false
+Spinner.font                   [active] $defaultFont [UI]
+Spinner.foreground             #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+Spinner.padding                2,6,2,6    javax.swing.plaf.InsetsUIResource [UI]
+SpinnerUI                      com.formdev.flatlaf.ui.FlatSpinnerUI
+
+
+#---- SplitPane ----
+
+SplitPane.background           #1e1e1e  HSL   0   0  12    javax.swing.plaf.ColorUIResource [UI]
+SplitPane.centerOneTouchButtons true
+SplitPane.continuousLayout     true
+SplitPane.darkShadow           #ffffff19  10%  HSLA   0   0 100 10    javax.swing.plaf.ColorUIResource [UI]
+SplitPane.dividerSize          5
+SplitPane.highlight            #bfbfbf19  10%  HSLA   0   0  75 10    javax.swing.plaf.ColorUIResource [UI]
+SplitPane.oneTouchButtonOffset [active] 2
+SplitPane.oneTouchButtonSize   [active] 6
+SplitPane.shadow               #ffffff19  10%  HSLA   0   0 100 10    javax.swing.plaf.ColorUIResource [UI]
+
+
+#---- SplitPaneDivider ----
+
+SplitPaneDivider.draggingColor #ffffff19  10%  HSLA   0   0 100 10    javax.swing.plaf.ColorUIResource [UI]
+SplitPaneDivider.gripColor     #cecece  HSL   0   0  81    javax.swing.plaf.ColorUIResource [UI]
+SplitPaneDivider.gripDotCount  3
+SplitPaneDivider.gripDotSize   3
+SplitPaneDivider.gripGap       2
+SplitPaneDivider.oneTouchArrowColor #b7b7b7  HSL   0   0  72    javax.swing.plaf.ColorUIResource [UI]
+SplitPaneDivider.oneTouchHoverArrowColor #d1d1d1  HSL   0   0  82    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(10%)
+SplitPaneDivider.oneTouchPressedArrowColor #eaeaea  HSL   0   0  92    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(20%)
+SplitPaneDivider.style         grip
+
+
+#---- SplitPane ----
+
+SplitPaneUI                    com.formdev.flatlaf.ui.FlatSplitPaneUI
+
+
+#---- TabbedPane ----
+
+TabbedPane.arrowType           chevron
+TabbedPane.background          #1e1e1e  HSL   0   0  12    javax.swing.plaf.ColorUIResource [UI]
+TabbedPane.buttonArc           12
+TabbedPane.buttonHoverBackground #111111  HSL   0   0   7    com.formdev.flatlaf.util.DerivedColor [UI]    darken(5%)
+TabbedPane.buttonInsets        2,1,2,1    javax.swing.plaf.InsetsUIResource [UI]
+TabbedPane.buttonPressedBackground #0a0a0a  HSL   0   0   4    com.formdev.flatlaf.util.DerivedColor [UI]    darken(8%)
+TabbedPane.cardTabSelectionHeight 2
+TabbedPane.closeArc            4
+TabbedPane.closeCrossFilledSize 7.5
+TabbedPane.closeCrossLineWidth 1
+TabbedPane.closeCrossPlainSize 7.5
+TabbedPane.closeForeground     #9a9a9a  HSL   0   0  60    javax.swing.plaf.ColorUIResource [UI]
+TabbedPane.closeHoverBackground #2b2b2b  HSL   0   0  17    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(5% autoInverse)
+TabbedPane.closeHoverForeground #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+TabbedPane.closeIcon           [lazy] 16,16    com.formdev.flatlaf.icons.FlatTabbedPaneCloseIcon [UI]
+TabbedPane.closePressedBackground #383838  HSL   0   0  22    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(10% autoInverse)
+TabbedPane.closePressedForeground #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+TabbedPane.closeSize           16,16    javax.swing.plaf.DimensionUIResource [UI]
+TabbedPane.contentAreaColor    #ffffff19  10%  HSLA   0   0 100 10    javax.swing.plaf.ColorUIResource [UI]
+TabbedPane.contentOpaque       true
+TabbedPane.contentSeparatorHeight 1
+TabbedPane.darkShadow          #ffffff19  10%  HSLA   0   0 100 10    javax.swing.plaf.ColorUIResource [UI]
+TabbedPane.disabledForeground  #9a9a9a  HSL   0   0  60    javax.swing.plaf.ColorUIResource [UI]
+TabbedPane.disabledUnderlineColor #595959  HSL   0   0  35    javax.swing.plaf.ColorUIResource [UI]
+TabbedPane.focus               #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+TabbedPane.focusColor          #172d4b  HSL 215  53  19    javax.swing.plaf.ColorUIResource [UI]
+TabbedPane.font                [active] $defaultFont [UI]
+TabbedPane.foreground          #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+TabbedPane.hasFullBorder       false
+TabbedPane.hiddenTabsNavigation moreTabsButton
+TabbedPane.highlight           #bfbfbf19  10%  HSLA   0   0  75 10    javax.swing.plaf.ColorUIResource [UI]
+TabbedPane.hoverColor          #111111  HSL   0   0   7    com.formdev.flatlaf.util.DerivedColor [UI]    darken(5%)
+TabbedPane.inactiveUnderlineColor #0c55a5  HSL 211  86  35    javax.swing.plaf.ColorUIResource [UI]
+TabbedPane.labelShift          1
+TabbedPane.light               #cccccc19  10%  HSLA   0   0  80 10    javax.swing.plaf.ColorUIResource [UI]
+TabbedPane.scrollButtonsPlacement both
+TabbedPane.scrollButtonsPolicy asNeededSingle
+TabbedPane.selectedLabelShift  -1
+TabbedPane.selectedTabPadInsets 0,0,0,0    javax.swing.plaf.InsetsUIResource [UI]
+TabbedPane.selectionFollowsFocus true
+TabbedPane.shadow              #1e1e1e  HSL   0   0  12    javax.swing.plaf.ColorUIResource [UI]
+TabbedPane.showTabSeparators   false
+TabbedPane.tabAlignment        center
+TabbedPane.tabAreaAlignment    leading
+TabbedPane.tabAreaInsets       0,0,0,0    javax.swing.plaf.InsetsUIResource [UI]
+TabbedPane.tabHeight           32
+TabbedPane.tabInsets           4,12,4,12    javax.swing.plaf.InsetsUIResource [UI]
+TabbedPane.tabRunOverlay       0
+TabbedPane.tabSelectionHeight  3
+TabbedPane.tabSeparatorsFullHeight false
+TabbedPane.tabType             underlined
+TabbedPane.tabWidthMode        preferred
+TabbedPane.tabsOpaque          true
+TabbedPane.tabsOverlapBorder   false
+TabbedPane.tabsPopupPolicy     asNeeded
+TabbedPane.textIconGap         4
+TabbedPane.underlineColor      #007aff  HSL 211 100  50    javax.swing.plaf.ColorUIResource [UI]
+TabbedPaneUI                   com.formdev.flatlaf.ui.FlatTabbedPaneUI
+
+
+#---- Table ----
+
+Table.ascendingSortIcon        [lazy] 10,5    com.formdev.flatlaf.icons.FlatAscendingSortIcon [UI]
+Table.background               #282828  HSL   0   0  16    javax.swing.plaf.ColorUIResource [UI]
+Table.cellFocusColor           #000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]
+Table.cellMargins              2,3,2,3    javax.swing.plaf.InsetsUIResource [UI]
+Table.cellNoFocusBorder        [lazy] 2,3,2,3  false    com.formdev.flatlaf.ui.FlatTableCellBorder$Default [UI]    lineColor=#000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]    lineThickness=1.000000
+Table.consistentHomeEndKeyBehavior true
+Table.descendingSortIcon       [lazy] 10,5    com.formdev.flatlaf.icons.FlatDescendingSortIcon [UI]
+Table.dropCellBackground       [lazy] #00429d  HSL 215 100  31    javax.swing.plaf.ColorUIResource [UI]
+Table.dropCellForeground       [lazy] #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+Table.dropLineColor            [lazy] #046eff  HSL 215 100  51    javax.swing.plaf.ColorUIResource [UI]
+Table.dropLineShortColor       [lazy] #6aa9ff  HSL 215 100  71    javax.swing.plaf.ColorUIResource [UI]
+Table.focusCellBackground      #282828  HSL   0   0  16    javax.swing.plaf.ColorUIResource [UI]
+Table.focusCellForeground      #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+Table.focusCellHighlightBorder [lazy] 2,3,2,3  false    com.formdev.flatlaf.ui.FlatTableCellBorder$Focused [UI]    lineColor=#000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]    lineThickness=1.000000
+Table.focusSelectedCellHighlightBorder [lazy] 2,3,2,3  false    com.formdev.flatlaf.ui.FlatTableCellBorder$Selected [UI]    lineColor=#000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]    lineThickness=1.000000
+Table.font                     [active] $defaultFont [UI]
+Table.foreground               #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+Table.gridColor                #3c3c3c  HSL   0   0  24    javax.swing.plaf.ColorUIResource [UI]
+Table.intercellSpacing         0,0    javax.swing.plaf.DimensionUIResource [UI]
+Table.rowHeight                20
+Table.scrollPaneBorder         [lazy] 3,3,3,3  false    com.formdev.flatlaf.ui.FlatBorder [UI]
+Table.selectionBackground      #0058d0  HSL 215 100  41    javax.swing.plaf.ColorUIResource [UI]
+Table.selectionForeground      #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+Table.selectionInactiveBackground #464646  HSL   0   0  27    javax.swing.plaf.ColorUIResource [UI]
+Table.selectionInactiveForeground #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+Table.showHorizontalLines      false
+Table.showTrailingVerticalLine false
+Table.showVerticalLines        false
+Table.sortIconColor            #cecece  HSL   0   0  81    javax.swing.plaf.ColorUIResource [UI]
+
+
+#---- TableHeader ----
+
+TableHeader.background         #282828  HSL   0   0  16    javax.swing.plaf.ColorUIResource [UI]
+TableHeader.bottomSeparatorColor #424242  HSL   0   0  26    javax.swing.plaf.ColorUIResource [UI]
+TableHeader.cellBorder         [lazy] 2,3,2,3  false    com.formdev.flatlaf.ui.FlatTableHeaderBorder [UI]
+TableHeader.cellMargins        2,3,2,3    javax.swing.plaf.InsetsUIResource [UI]
+TableHeader.focusCellBackground #282828  HSL   0   0  16    javax.swing.plaf.ColorUIResource [UI]
+TableHeader.font               [active] $defaultFont [UI]
+TableHeader.foreground         #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+TableHeader.height             25
+TableHeader.separatorColor     #424242  HSL   0   0  26    javax.swing.plaf.ColorUIResource [UI]
+TableHeader.showTrailingVerticalLine false
+TableHeaderUI                  com.formdev.flatlaf.ui.FlatTableHeaderUI
+
+
+#---- Table ----
+
+TableUI                        com.formdev.flatlaf.ui.FlatTableUI
+
+
+#---- TaskPane ----
+
+TaskPane.background            #1e1e1e  HSL   0   0  12    javax.swing.plaf.ColorUIResource [UI]
+TaskPane.borderColor           #676767  HSL   0   0  40    javax.swing.plaf.ColorUIResource [UI]
+TaskPane.contentInsets         10,10,10,10    javax.swing.plaf.InsetsUIResource [UI]
+TaskPane.specialTitleBackground #afafaf  HSL   0   0  69    javax.swing.plaf.ColorUIResource [UI]
+TaskPane.specialTitleForeground #222222  HSL   0   0  13    javax.swing.plaf.ColorUIResource [UI]
+TaskPane.specialTitleOver      #666666  HSL   0   0  40    javax.swing.plaf.ColorUIResource [UI]
+TaskPane.titleBackgroundGradientStart #4c5052  HSL 200   4  31    javax.swing.plaf.ColorUIResource [UI]
+TaskPane.titleForeground       #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+TaskPane.titleOver             #888888  HSL   0   0  53    javax.swing.plaf.ColorUIResource [UI]
+
+
+#---- TaskPaneContainer ----
+
+TaskPaneContainer.background   #3e434c  HSL 219  10  27    javax.swing.plaf.ColorUIResource [UI]
+TaskPaneContainer.border       [lazy] 10,10,10,10  false    com.formdev.flatlaf.ui.FlatEmptyBorder [UI]
+
+
+#---- TextArea ----
+
+TextArea.background            #282828  HSL   0   0  16    javax.swing.plaf.ColorUIResource [UI]
+TextArea.border                [lazy] 0,0,0,0  false    com.formdev.flatlaf.ui.FlatMarginBorder [UI]
+TextArea.caretBlinkRate        500
+TextArea.caretForeground       #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+TextArea.disabledBackground    #232323  HSL   0   0  14    javax.swing.plaf.ColorUIResource [UI]
+TextArea.font                  [active] $defaultFont [UI]
+TextArea.foreground            #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+TextArea.inactiveBackground    #1e1e1e  HSL   0   0  12    javax.swing.plaf.ColorUIResource [UI]
+TextArea.inactiveForeground    #9a9a9a  HSL   0   0  60    javax.swing.plaf.ColorUIResource [UI]
+TextArea.margin                2,6,2,6    javax.swing.plaf.InsetsUIResource [UI]
+TextArea.selectionBackground   #3f638b  HSL 212  38  40    javax.swing.plaf.ColorUIResource [UI]
+TextArea.selectionForeground   #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+TextAreaUI                     com.formdev.flatlaf.ui.FlatTextAreaUI
+
+
+#---- TextComponent ----
+
+TextComponent.arc              0
+TextComponent.selectAllOnFocusPolicy once
+TextComponent.selectAllOnMouseClick false
+
+
+#---- TextField ----
+
+TextField.background           #282828  HSL   0   0  16    javax.swing.plaf.ColorUIResource [UI]
+TextField.border               [lazy] 3,3,3,3  false    com.formdev.flatlaf.ui.FlatTextBorder [UI]
+TextField.caretBlinkRate       500
+TextField.caretForeground      #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+TextField.darkShadow           #ffffff19  10%  HSLA   0   0 100 10    javax.swing.plaf.ColorUIResource [UI]
+TextField.disabledBackground   #232323  HSL   0   0  14    javax.swing.plaf.ColorUIResource [UI]
+TextField.font                 [active] $defaultFont [UI]
+TextField.foreground           #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+TextField.highlight            #bfbfbf19  10%  HSLA   0   0  75 10    javax.swing.plaf.ColorUIResource [UI]
+TextField.iconTextGap          4
+TextField.inactiveBackground   #1e1e1e  HSL   0   0  12    javax.swing.plaf.ColorUIResource [UI]
+TextField.inactiveForeground   #9a9a9a  HSL   0   0  60    javax.swing.plaf.ColorUIResource [UI]
+TextField.light                #cccccc19  10%  HSLA   0   0  80 10    javax.swing.plaf.ColorUIResource [UI]
+TextField.margin               2,6,2,6    javax.swing.plaf.InsetsUIResource [UI]
+TextField.placeholderForeground #9a9a9a  HSL   0   0  60    javax.swing.plaf.ColorUIResource [UI]
+TextField.selectionBackground  #3f638b  HSL 212  38  40    javax.swing.plaf.ColorUIResource [UI]
+TextField.selectionForeground  #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+TextField.shadow               #ffffff19  10%  HSLA   0   0 100 10    javax.swing.plaf.ColorUIResource [UI]
+TextFieldUI                    com.formdev.flatlaf.ui.FlatTextFieldUI
+
+
+#---- TextPane ----
+
+TextPane.background            #282828  HSL   0   0  16    javax.swing.plaf.ColorUIResource [UI]
+TextPane.border                [lazy] 0,0,0,0  false    com.formdev.flatlaf.ui.FlatMarginBorder [UI]
+TextPane.caretBlinkRate        500
+TextPane.caretForeground       #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+TextPane.disabledBackground    #232323  HSL   0   0  14    javax.swing.plaf.ColorUIResource [UI]
+TextPane.font                  [active] $defaultFont [UI]
+TextPane.foreground            #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+TextPane.inactiveBackground    #1e1e1e  HSL   0   0  12    javax.swing.plaf.ColorUIResource [UI]
+TextPane.inactiveForeground    #9a9a9a  HSL   0   0  60    javax.swing.plaf.ColorUIResource [UI]
+TextPane.margin                2,6,2,6    javax.swing.plaf.InsetsUIResource [UI]
+TextPane.selectionBackground   #3f638b  HSL 212  38  40    javax.swing.plaf.ColorUIResource [UI]
+TextPane.selectionForeground   #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+TextPaneUI                     com.formdev.flatlaf.ui.FlatTextPaneUI
+
+
+#---- TitlePane ----
+
+TitlePane.background           #323232  HSL   0   0  20    javax.swing.plaf.ColorUIResource [UI]
+TitlePane.buttonHoverBackground #585858  HSL   0   0  35    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(15% autoInverse)
+TitlePane.buttonMaximizedHeight 22
+TitlePane.buttonPressedBackground #4c4c4c  HSL   0   0  30    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(10% autoInverse)
+TitlePane.buttonSize           44,30    javax.swing.plaf.DimensionUIResource [UI]
+TitlePane.centerTitle          false
+TitlePane.centerTitleIfMenuBarEmbedded true
+TitlePane.closeHoverBackground #c42b1c  HSL   5  75  44    javax.swing.plaf.ColorUIResource [UI]
+TitlePane.closeHoverForeground #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+TitlePane.closeIcon            [lazy] 44,30    com.formdev.flatlaf.icons.FlatWindowCloseIcon [UI]
+TitlePane.closePressedBackground #c42b1ce6  90%  HSLA   5  75  44 90    javax.swing.plaf.ColorUIResource [UI]
+TitlePane.closePressedForeground #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+TitlePane.embeddedForeground   #b7b7b7  HSL   0   0  72    javax.swing.plaf.ColorUIResource [UI]
+TitlePane.foreground           #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+TitlePane.icon                 [lazy] 16,16    sun.swing.ImageIconUIResource [UI]  (sun.awt.image.ToolkitImage)
+TitlePane.iconMargins          3,8,3,8    javax.swing.plaf.InsetsUIResource [UI]
+TitlePane.iconSize             16,16    javax.swing.plaf.DimensionUIResource [UI]
+TitlePane.iconifyIcon          [lazy] 44,30    com.formdev.flatlaf.icons.FlatWindowIconifyIcon [UI]
+TitlePane.inactiveBackground   #323232  HSL   0   0  20    javax.swing.plaf.ColorUIResource [UI]
+TitlePane.inactiveForeground   #9a9a9a  HSL   0   0  60    javax.swing.plaf.ColorUIResource [UI]
+TitlePane.maximizeIcon         [lazy] 44,30    com.formdev.flatlaf.icons.FlatWindowMaximizeIcon [UI]
+TitlePane.menuBarEmbedded      true
+TitlePane.menuBarTitleGap      20
+TitlePane.noIconLeftGap        8
+TitlePane.restoreIcon          [lazy] 44,30    com.formdev.flatlaf.icons.FlatWindowRestoreIcon [UI]
+TitlePane.showIcon             true
+TitlePane.titleMargins         3,0,3,0    javax.swing.plaf.InsetsUIResource [UI]
+TitlePane.unifiedBackground    true
+TitlePane.useWindowDecorations true
+
+
+#---- TitledBorder ----
+
+TitledBorder.border            [lazy] 1,1,1,1  false    com.formdev.flatlaf.ui.FlatLineBorder [UI]    lineColor=#ffffff19  10%  HSLA   0   0 100 10    javax.swing.plaf.ColorUIResource [UI]    lineThickness=1.000000
+TitledBorder.font              [active] $defaultFont [UI]
+TitledBorder.titleColor        #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+
+
+#---- TitledPanel ----
+
+TitledPanelUI                  com.formdev.flatlaf.swingx.ui.FlatTitledPanelUI
+
+
+#---- ToggleButton ----
+
+ToggleButton.background        #565656  HSL   0   0  34    javax.swing.plaf.ColorUIResource [UI]
+ToggleButton.border            [lazy] 3,3,3,3  false    com.formdev.flatlaf.ui.FlatButtonBorder [UI]
+ToggleButton.darkShadow        #ffffff19  10%  HSLA   0   0 100 10    javax.swing.plaf.ColorUIResource [UI]
+ToggleButton.disabledBackground #3d3d3d  HSL   0   0  24    javax.swing.plaf.ColorUIResource [UI]
+ToggleButton.disabledSelectedBackground #5e5e5e  HSL   0   0  37    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(3% autoInverse)
+ToggleButton.disabledText      #9a9a9a  HSL   0   0  60    javax.swing.plaf.ColorUIResource [UI]
+ToggleButton.font              [active] $defaultFont [UI]
+ToggleButton.foreground        #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+ToggleButton.highlight         #bfbfbf19  10%  HSLA   0   0  75 10    javax.swing.plaf.ColorUIResource [UI]
+ToggleButton.iconTextGap       4
+ToggleButton.light             #cccccc19  10%  HSLA   0   0  80 10    javax.swing.plaf.ColorUIResource [UI]
+ToggleButton.margin            2,14,2,14    javax.swing.plaf.InsetsUIResource [UI]
+ToggleButton.pressedBackground #656565  HSL   0   0  40    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(6% autoInverse)
+ToggleButton.rollover          true
+ToggleButton.selectedBackground #898989  HSL   0   0  54    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(20% autoInverse)
+ToggleButton.selectedForeground #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+ToggleButton.shadow            #ffffff19  10%  HSLA   0   0 100 10    javax.swing.plaf.ColorUIResource [UI]
+ToggleButton.tab.disabledUnderlineColor #595959  HSL   0   0  35    javax.swing.plaf.ColorUIResource [UI]
+ToggleButton.tab.focusBackground #172d4b  HSL 215  53  19    javax.swing.plaf.ColorUIResource [UI]
+ToggleButton.tab.hoverBackground #111111  HSL   0   0   7    com.formdev.flatlaf.util.DerivedColor [UI]    darken(5%)
+ToggleButton.tab.underlineColor #007aff  HSL 211 100  50    javax.swing.plaf.ColorUIResource [UI]
+ToggleButton.tab.underlineHeight 2
+ToggleButton.textIconGap       4
+ToggleButton.textShiftOffset   0
+ToggleButton.toolbar.hoverBackground #ffffff11  7%  HSLA   0   0 100  7    javax.swing.plaf.ColorUIResource [UI]
+ToggleButton.toolbar.pressedBackground #ffffff22  13%  HSLA   0   0 100 13    javax.swing.plaf.ColorUIResource [UI]
+ToggleButton.toolbar.selectedBackground #ffffff33  20%  HSLA   0   0 100 20    javax.swing.plaf.ColorUIResource [UI]
+ToggleButtonUI                 com.formdev.flatlaf.ui.FlatToggleButtonUI
+
+
+#---- ToolBar ----
+
+ToolBar.arrowKeysOnlyNavigation true
+ToolBar.background             #1e1e1e  HSL   0   0  12    javax.swing.plaf.ColorUIResource [UI]
+ToolBar.border                 [lazy] 2,2,2,2  false    com.formdev.flatlaf.ui.FlatToolBarBorder [UI]
+ToolBar.borderMargins          2,2,2,2    javax.swing.plaf.InsetsUIResource [UI]
+ToolBar.darkShadow             #ffffff19  10%  HSLA   0   0 100 10    javax.swing.plaf.ColorUIResource [UI]
+ToolBar.dockingBackground      #111111  HSL   0   0   7    javax.swing.plaf.ColorUIResource [UI]
+ToolBar.dockingForeground      #ffffff19  10%  HSLA   0   0 100 10    javax.swing.plaf.ColorUIResource [UI]
+ToolBar.floatable              false
+ToolBar.floatingBackground     #1e1e1e  HSL   0   0  12    javax.swing.plaf.ColorUIResource [UI]
+ToolBar.floatingForeground     #ffffff19  10%  HSLA   0   0 100 10    javax.swing.plaf.ColorUIResource [UI]
+ToolBar.focusableButtons       false
+ToolBar.font                   [active] $defaultFont [UI]
+ToolBar.foreground             #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+ToolBar.gripColor              #cecece  HSL   0   0  81    javax.swing.plaf.ColorUIResource [UI]
+ToolBar.highlight              #bfbfbf19  10%  HSLA   0   0  75 10    javax.swing.plaf.ColorUIResource [UI]
+ToolBar.isRollover             true
+ToolBar.light                  #cccccc19  10%  HSLA   0   0  80 10    javax.swing.plaf.ColorUIResource [UI]
+ToolBar.separatorColor         #ffffff19  10%  HSLA   0   0 100 10    javax.swing.plaf.ColorUIResource [UI]
+ToolBar.separatorWidth         7
+ToolBar.shadow                 #ffffff19  10%  HSLA   0   0 100 10    javax.swing.plaf.ColorUIResource [UI]
+ToolBar.spacingBorder          [lazy] 1,2,1,2  false    com.formdev.flatlaf.ui.FlatEmptyBorder [UI]
+
+
+#---- ToolBarSeparator ----
+
+ToolBarSeparatorUI             com.formdev.flatlaf.ui.FlatToolBarSeparatorUI
+
+
+#---- ToolBar ----
+
+ToolBarUI                      com.formdev.flatlaf.ui.FlatToolBarUI
+
+
+#---- ToolTip ----
+
+ToolTip.background             #0f0f0f  HSL   0   0   6    javax.swing.plaf.ColorUIResource [UI]
+ToolTip.border                 [lazy] 4,6,4,6  false    com.formdev.flatlaf.ui.FlatEmptyBorder [UI]
+ToolTip.font                   [active] $defaultFont [UI]
+ToolTip.foreground             #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+
+
+#---- ToolTipManager ----
+
+ToolTipManager.enableToolTipMode activeApplication
+
+
+#---- ToolTip ----
+
+ToolTipUI                      com.formdev.flatlaf.ui.FlatToolTipUI
+
+
+#---- Tree ----
+
+Tree.background                #282828  HSL   0   0  16    javax.swing.plaf.ColorUIResource [UI]
+Tree.border                    [lazy] 1,1,1,1  false    com.formdev.flatlaf.ui.FlatEmptyBorder [UI]
+Tree.changeSelectionWithFocus  true
+Tree.closedIcon                [lazy] 16,16    com.formdev.flatlaf.icons.FlatTreeClosedIcon [UI]
+Tree.collapsedIcon             [lazy] 11,11    com.formdev.flatlaf.icons.FlatTreeCollapsedIcon [UI]
+Tree.drawsFocusBorderAroundIcon false
+Tree.dropCellBackground        [lazy] #00429d  HSL 215 100  31    javax.swing.plaf.ColorUIResource [UI]
+Tree.dropCellForeground        [lazy] #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+Tree.dropLineColor             [lazy] #046eff  HSL 215 100  51    javax.swing.plaf.ColorUIResource [UI]
+Tree.editorBorder              [lazy] 1,1,1,1  false    com.formdev.flatlaf.ui.FlatLineBorder [UI]    lineColor=#000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]    lineThickness=1.000000
+Tree.expandedIcon              [lazy] 11,11    com.formdev.flatlaf.icons.FlatTreeExpandedIcon [UI]
+Tree.font                      [active] $defaultFont [UI]
+Tree.foreground                #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+Tree.hash                      #353535  HSL   0   0  21    javax.swing.plaf.ColorUIResource [UI]
+Tree.icon.closedColor          #cecece  HSL   0   0  81    javax.swing.plaf.ColorUIResource [UI]
+Tree.icon.collapsedColor       #cecece  HSL   0   0  81    javax.swing.plaf.ColorUIResource [UI]
+Tree.icon.expandedColor        #cecece  HSL   0   0  81    javax.swing.plaf.ColorUIResource [UI]
+Tree.icon.leafColor            #cecece  HSL   0   0  81    javax.swing.plaf.ColorUIResource [UI]
+Tree.icon.openColor            #cecece  HSL   0   0  81    javax.swing.plaf.ColorUIResource [UI]
+Tree.leafIcon                  [lazy] 16,16    com.formdev.flatlaf.icons.FlatTreeLeafIcon [UI]
+Tree.leftChildIndent           7
+Tree.lineTypeDashed            false
+Tree.openIcon                  [lazy] 16,16    com.formdev.flatlaf.icons.FlatTreeOpenIcon [UI]
+Tree.paintLines                false
+Tree.rendererFillBackground    false
+Tree.rendererMargins           1,2,1,2    javax.swing.plaf.InsetsUIResource [UI]
+Tree.repaintWholeRow           true
+Tree.rightChildIndent          11
+Tree.rowHeight                 0
+Tree.scrollsOnExpand           true
+Tree.selectionBackground       #0058d0  HSL 215 100  41    javax.swing.plaf.ColorUIResource [UI]
+Tree.selectionBorderColor      #000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]
+Tree.selectionForeground       #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+Tree.selectionInactiveBackground #464646  HSL   0   0  27    javax.swing.plaf.ColorUIResource [UI]
+Tree.selectionInactiveForeground #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+Tree.showCellFocusIndicator    false
+Tree.textBackground            #282828  HSL   0   0  16    javax.swing.plaf.ColorUIResource [UI]
+Tree.textForeground            #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+Tree.timeFactor                1000
+Tree.wideSelection             true
+TreeUI                         com.formdev.flatlaf.ui.FlatTreeUI
+
+
+#---- TristateCheckBox ----
+
+TristateCheckBox.clearMixed.clientProperty length=2    [Ljava.lang.Object;
+    [0] JButton.selectedState
+    [1] null
+TristateCheckBox.setMixed.clientProperty length=2    [Ljava.lang.Object;
+    [0] JButton.selectedState
+    [1] indeterminate
+
+
+#---- UIColorHighlighter ----
+
+UIColorHighlighter.stripingBackground #353535  HSL   0   0  21    javax.swing.plaf.ColorUIResource [UI]
+
+
+#---- Viewport ----
+
+Viewport.background            #1e1e1e  HSL   0   0  12    javax.swing.plaf.ColorUIResource [UI]
+Viewport.font                  [active] $defaultFont [UI]
+Viewport.foreground            #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+ViewportUI                     com.formdev.flatlaf.ui.FlatViewportUI
+
+
+#---- [style] ----
+
+[style].h00                    font: $h00.font
+[style].h0                     font: $h0.font
+[style].h1.regular             font: $h1.regular.font
+[style].h1                     font: $h1.font
+[style].h2.regular             font: $h2.regular.font
+[style].h2                     font: $h2.font
+[style].h3.regular             font: $h3.regular.font
+[style].h3                     font: $h3.font
+[style].h4                     font: $h4.font
+[style].large                  font: $large.font
+[style].light                  font: $light.font
+[style].medium                 font: $medium.font
+[style].mini                   font: $mini.font
+[style].monospaced             font: $monospaced.font
+[style].semibold               font: $semibold.font
+[style].small                  font: $small.font
+
+
+#---- [style]Button ----
+
+[style]Button.clearButton      icon: com.formdev.flatlaf.icons.FlatClearIcon; focusable: false; toolbar.margin: 1,1,1,1; toolbar.spacingInsets: 1,1,1,1; toolbar.hoverBackground: null; toolbar.pressedBackground: null
+[style]Button.inTextField      focusable: false; toolbar.margin: 1,1,1,1; toolbar.spacingInsets: 1,1,1,1; toolbar.hoverBackground: lighten($TextField.background,5%); toolbar.pressedBackground: lighten($TextField.background,10%); toolbar.selectedBackground: lighten($TextField.background,15%)
+
+
+#---- [style]ToggleButton ----
+
+[style]ToggleButton.inTextField focusable: false; toolbar.margin: 1,1,1,1; toolbar.spacingInsets: 1,1,1,1; toolbar.hoverBackground: lighten($TextField.background,5%); toolbar.pressedBackground: lighten($TextField.background,10%); toolbar.selectedBackground: lighten($TextField.background,15%)
+
+
+#---- [style]ToolBar ----
+
+[style]ToolBar.inTextField     floatable: false; opaque: false; borderMargins: 0,0,0,0
+
+
+#---- [style]ToolBarSeparator ----
+
+[style]ToolBarSeparator.inTextField separatorWidth: 3
+
+
+#----  ----
+
+activeCaption                  #434e60  HSL 217  18  32    javax.swing.plaf.ColorUIResource [UI]
+activeCaptionBorder            #434e60  HSL 217  18  32    javax.swing.plaf.ColorUIResource [UI]
+activeCaptionText              #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+control                        #1e1e1e  HSL   0   0  12    javax.swing.plaf.ColorUIResource [UI]
+controlDkShadow                #ffffff19  10%  HSLA   0   0 100 10    javax.swing.plaf.ColorUIResource [UI]
+controlHighlight               #cccccc19  10%  HSLA   0   0  80 10    javax.swing.plaf.ColorUIResource [UI]
+controlLtHighlight             #bfbfbf19  10%  HSLA   0   0  75 10    javax.swing.plaf.ColorUIResource [UI]
+controlShadow                  #ffffff19  10%  HSLA   0   0 100 10    javax.swing.plaf.ColorUIResource [UI]
+controlText                    #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+defaultFont                    Segoe UI plain 12    javax.swing.plaf.FontUIResource [UI]
+desktop                        #282828  HSL   0   0  16    javax.swing.plaf.ColorUIResource [UI]
+
+
+#---- h0 ----
+
+h0.font                        [active] Segoe UI plain 30    javax.swing.plaf.FontUIResource [UI]
+
+
+#---- h00 ----
+
+h00.font                       [active] Segoe UI plain 36    javax.swing.plaf.FontUIResource [UI]
+
+
+#---- h1 ----
+
+h1.font                        [active] Segoe UI Semibold plain 24    javax.swing.plaf.FontUIResource [UI]
+h1.regular.font                [active] Segoe UI plain 24    javax.swing.plaf.FontUIResource [UI]
+
+
+#---- h2 ----
+
+h2.font                        [active] Segoe UI Semibold plain 18    javax.swing.plaf.FontUIResource [UI]
+h2.regular.font                [active] Segoe UI plain 18    javax.swing.plaf.FontUIResource [UI]
+
+
+#---- h3 ----
+
+h3.font                        [active] Segoe UI Semibold plain 15    javax.swing.plaf.FontUIResource [UI]
+h3.regular.font                [active] Segoe UI plain 15    javax.swing.plaf.FontUIResource [UI]
+
+
+#---- h4 ----
+
+h4.font                        [active] Segoe UI bold 12    javax.swing.plaf.FontUIResource [UI]
+
+
+#---- html ----
+
+html.missingImage              [lazy] 38,38    sun.swing.ImageIconUIResource [UI]  (sun.awt.image.ToolkitImage)
+html.pendingImage              [lazy] 38,38    sun.swing.ImageIconUIResource [UI]  (sun.awt.image.ToolkitImage)
+
+
+#----  ----
+
+inactiveCaption                #393c3d  HSL 195   3  23    javax.swing.plaf.ColorUIResource [UI]
+inactiveCaptionBorder          #393c3d  HSL 195   3  23    javax.swing.plaf.ColorUIResource [UI]
+inactiveCaptionText            #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+info                           #0f0f0f  HSL   0   0   6    javax.swing.plaf.ColorUIResource [UI]
+infoText                       #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+
+
+#---- laf ----
+
+laf.dark                       true
+laf.scaleFactor                [active] 1.0
+
+
+#---- large ----
+
+large.font                     [active] Segoe UI plain 14    javax.swing.plaf.FontUIResource [UI]
+
+
+#---- light ----
+
+light.font                     [active] Segoe UI Light plain 12    javax.swing.plaf.FontUIResource [UI]
+
+
+#---- medium ----
+
+medium.font                    [active] Segoe UI plain 11    javax.swing.plaf.FontUIResource [UI]
+
+
+#----  ----
+
+menu                           #1e1e1e  HSL   0   0  12    javax.swing.plaf.ColorUIResource [UI]
+menuText                       #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+
+
+#---- mini ----
+
+mini.font                      [active] Segoe UI plain 9    javax.swing.plaf.FontUIResource [UI]
+
+
+#---- monospaced ----
+
+monospaced.font                [active] Consolas plain 12    javax.swing.plaf.FontUIResource [UI]
+
+
+#----  ----
+
+scrollbar                      #282828  HSL   0   0  16    javax.swing.plaf.ColorUIResource [UI]
+
+
+#---- semibold ----
+
+semibold.font                  [active] Segoe UI Semibold plain 12    javax.swing.plaf.FontUIResource [UI]
+
+
+#---- small ----
+
+small.font                     [active] Segoe UI plain 10    javax.swing.plaf.FontUIResource [UI]
+
+
+#---- swingx/TaskPane ----
+
+swingx/TaskPaneUI              com.formdev.flatlaf.swingx.ui.FlatTaskPaneUI
+
+
+#----  ----
+
+text                           #282828  HSL   0   0  16    javax.swing.plaf.ColorUIResource [UI]
+textHighlight                  #0058d0  HSL 215 100  41    javax.swing.plaf.ColorUIResource [UI]
+textHighlightText              #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+textInactiveText               #9a9a9a  HSL   0   0  60    javax.swing.plaf.ColorUIResource [UI]
+textText                       #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+window                         #1e1e1e  HSL   0   0  12    javax.swing.plaf.ColorUIResource [UI]
+windowBorder                   #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+windowText                     #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]

--- a/flatlaf-testing/dumps/uidefaults/FlatMacLightLaf_1.8.0.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatMacLightLaf_1.8.0.txt
@@ -174,9 +174,9 @@ CheckBoxMenuItem.font          [active] $defaultFont [UI]
 CheckBoxMenuItem.foreground    #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
 CheckBoxMenuItem.icon.checkmarkColor #007aff  HSL 211 100  50    javax.swing.plaf.ColorUIResource [UI]
 CheckBoxMenuItem.icon.disabledCheckmarkColor #bdbdbd  HSL   0   0  74    javax.swing.plaf.ColorUIResource [UI]
-CheckBoxMenuItem.margin        3,6,3,6    javax.swing.plaf.InsetsUIResource [UI]
+CheckBoxMenuItem.margin        3,11,3,11    javax.swing.plaf.InsetsUIResource [UI]
 CheckBoxMenuItem.opaque        false
-CheckBoxMenuItem.selectionBackground #0063e1  HSL 214 100  44    javax.swing.plaf.ColorUIResource [UI]
+CheckBoxMenuItem.selectionBackground #3d9aff  HSL 211 100  62    javax.swing.plaf.ColorUIResource [UI]
 CheckBoxMenuItem.selectionForeground #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
 CheckBoxMenuItemUI             com.formdev.flatlaf.ui.FlatCheckBoxMenuItemUI
 
@@ -230,8 +230,11 @@ ComboBox.minimumWidth          72
 ComboBox.noActionOnKeyNavigation false
 ComboBox.padding               2,6,2,6    javax.swing.plaf.InsetsUIResource [UI]
 ComboBox.popupBackground       #ececec  HSL   0   0  93    javax.swing.plaf.ColorUIResource [UI]
-ComboBox.selectionBackground   #0063e1  HSL 214 100  44    javax.swing.plaf.ColorUIResource [UI]
+ComboBox.popupInsets           5,0,5,0    javax.swing.plaf.InsetsUIResource [UI]
+ComboBox.selectionArc          8
+ComboBox.selectionBackground   #3d9aff  HSL 211 100  62    javax.swing.plaf.ColorUIResource [UI]
 ComboBox.selectionForeground   #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+ComboBox.selectionInsets       0,5,0,5    javax.swing.plaf.InsetsUIResource [UI]
 ComboBox.timeFactor            1000
 ComboBoxUI                     com.formdev.flatlaf.ui.FlatComboBoxUI
 
@@ -555,10 +558,12 @@ List.focusSelectedCellHighlightBorder [lazy] 1,6,1,6  false    com.formdev.flatl
 List.font                      [active] $defaultFont [UI]
 List.foreground                #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
 List.noFocusBorder             1,1,1,1  false    javax.swing.plaf.BorderUIResource$EmptyBorderUIResource [UI]
+List.selectionArc              0
 List.selectionBackground       #0063e1  HSL 214 100  44    javax.swing.plaf.ColorUIResource [UI]
 List.selectionForeground       #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
 List.selectionInactiveBackground #dcdcdc  HSL   0   0  86    javax.swing.plaf.ColorUIResource [UI]
 List.selectionInactiveForeground #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
+List.selectionInsets           0,0,0,0    javax.swing.plaf.InsetsUIResource [UI]
 List.showCellFocusIndicator    false
 List.timeFactor                1000
 ListUI                         com.formdev.flatlaf.ui.FlatListUI
@@ -580,12 +585,12 @@ Menu.font                      [active] $defaultFont [UI]
 Menu.foreground                #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
 Menu.icon.arrowColor           #7d7d7d  HSL   0   0  49    javax.swing.plaf.ColorUIResource [UI]
 Menu.icon.disabledArrowColor   #bdbdbd  HSL   0   0  74    javax.swing.plaf.ColorUIResource [UI]
-Menu.margin                    3,6,3,6    javax.swing.plaf.InsetsUIResource [UI]
+Menu.margin                    3,11,3,11    javax.swing.plaf.InsetsUIResource [UI]
 Menu.menuPopupOffsetX          0
 Menu.menuPopupOffsetY          0
 Menu.opaque                    false
 Menu.preserveTopLevelSelection false
-Menu.selectionBackground       #0063e1  HSL 214 100  44    javax.swing.plaf.ColorUIResource [UI]
+Menu.selectionBackground       #3d9aff  HSL 211 100  62    javax.swing.plaf.ColorUIResource [UI]
 Menu.selectionForeground       #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
 Menu.shortcutKeys              length=1    [I
     [0] 8
@@ -603,6 +608,11 @@ MenuBar.foreground             #262626  HSL   0   0  15    javax.swing.plaf.Colo
 MenuBar.highlight              #40404026  15%  HSLA   0   0  25 15    javax.swing.plaf.ColorUIResource [UI]
 MenuBar.hoverBackground        #d3d3d3  HSL   0   0  83    com.formdev.flatlaf.util.DerivedColor [UI]    darken(10% autoInverse)
 MenuBar.itemMargins            3,8,3,8    javax.swing.plaf.InsetsUIResource [UI]
+MenuBar.selectionArc           8
+MenuBar.selectionBackground    #c6c6c6  HSL   0   0  78    com.formdev.flatlaf.util.DerivedColor [UI]    darken(15% autoInverse)
+MenuBar.selectionEmbeddedInsets 3,0,3,0    javax.swing.plaf.InsetsUIResource [UI]
+MenuBar.selectionForeground    #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
+MenuBar.selectionInsets        0,0,0,0    javax.swing.plaf.InsetsUIResource [UI]
 MenuBar.shadow                 #00000026  15%  HSLA   0   0   0 15    javax.swing.plaf.ColorUIResource [UI]
 MenuBar.windowBindings         length=2    [Ljava.lang.Object;
     [0] F10
@@ -621,22 +631,24 @@ MenuItem.arrowIcon             [lazy] 6,10    com.formdev.flatlaf.icons.FlatMenu
 MenuItem.background            #ececec  HSL   0   0  93    javax.swing.plaf.ColorUIResource [UI]
 MenuItem.border                [lazy] 0,0,0,0  false    com.formdev.flatlaf.ui.FlatMenuItemBorder [UI]
 MenuItem.borderPainted         true
-MenuItem.checkBackground       #aed2ff  HSL 213 100  84    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(40%)
+MenuItem.checkBackground       #bddcff  HSL 212 100  87    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(25%)
 MenuItem.checkMargins          2,2,2,2    javax.swing.plaf.InsetsUIResource [UI]
 MenuItem.disabledForeground    #b6b6b6  HSL   0   0  71    javax.swing.plaf.ColorUIResource [UI]
 MenuItem.font                  [active] $defaultFont [UI]
 MenuItem.foreground            #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
 MenuItem.iconTextGap           6
-MenuItem.margin                3,6,3,6    javax.swing.plaf.InsetsUIResource [UI]
+MenuItem.margin                3,11,3,11    javax.swing.plaf.InsetsUIResource [UI]
 MenuItem.minimumIconSize       16,16    javax.swing.plaf.DimensionUIResource [UI]
 MenuItem.minimumWidth          72
 MenuItem.opaque                false
-MenuItem.selectionBackground   #0063e1  HSL 214 100  44    javax.swing.plaf.ColorUIResource [UI]
+MenuItem.selectionArc          8
+MenuItem.selectionBackground   #3d9aff  HSL 211 100  62    javax.swing.plaf.ColorUIResource [UI]
 MenuItem.selectionForeground   #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+MenuItem.selectionInsets       0,5,0,5    javax.swing.plaf.InsetsUIResource [UI]
 MenuItem.textAcceleratorGap    24
 MenuItem.textNoAcceleratorGap  6
 MenuItem.underlineSelectionBackground #d3d3d3  HSL   0   0  83    com.formdev.flatlaf.util.DerivedColor [UI]    darken(10% autoInverse)
-MenuItem.underlineSelectionCheckBackground #aed2ff  HSL 213 100  84    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(40%)
+MenuItem.underlineSelectionCheckBackground #bddcff  HSL 212 100  87    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(25%)
 MenuItem.underlineSelectionColor #007aff  HSL 211 100  50    javax.swing.plaf.ColorUIResource [UI]
 MenuItem.underlineSelectionHeight 3
 MenuItem.verticallyAlignText   true
@@ -742,9 +754,9 @@ Popup.dropShadowPainted        true
 #---- PopupMenu ----
 
 PopupMenu.background           #ececec  HSL   0   0  93    javax.swing.plaf.ColorUIResource [UI]
-PopupMenu.border               [lazy] 4,1,4,1  false    com.formdev.flatlaf.ui.FlatPopupMenuBorder [UI]    lineColor=#b1b1b1  HSL   0   0  69    javax.swing.plaf.ColorUIResource [UI]    lineThickness=1.000000
+PopupMenu.border               [lazy] 6,1,6,1  false    com.formdev.flatlaf.ui.FlatPopupMenuBorder [UI]    lineColor=#b1b1b1  HSL   0   0  69    javax.swing.plaf.ColorUIResource [UI]    lineThickness=1.000000
 PopupMenu.borderColor          #b1b1b1  HSL   0   0  69    javax.swing.plaf.ColorUIResource [UI]
-PopupMenu.borderInsets         4,1,4,1    javax.swing.plaf.InsetsUIResource [UI]
+PopupMenu.borderInsets         6,1,6,1    javax.swing.plaf.InsetsUIResource [UI]
 PopupMenu.consumeEventOnClose  false
 PopupMenu.font                 [active] $defaultFont [UI]
 PopupMenu.foreground           #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
@@ -818,9 +830,9 @@ RadioButtonMenuItem.checkIcon  [lazy] 15,15    com.formdev.flatlaf.icons.FlatRad
 RadioButtonMenuItem.disabledForeground #b6b6b6  HSL   0   0  71    javax.swing.plaf.ColorUIResource [UI]
 RadioButtonMenuItem.font       [active] $defaultFont [UI]
 RadioButtonMenuItem.foreground #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
-RadioButtonMenuItem.margin     3,6,3,6    javax.swing.plaf.InsetsUIResource [UI]
+RadioButtonMenuItem.margin     3,11,3,11    javax.swing.plaf.InsetsUIResource [UI]
 RadioButtonMenuItem.opaque     false
-RadioButtonMenuItem.selectionBackground #0063e1  HSL 214 100  44    javax.swing.plaf.ColorUIResource [UI]
+RadioButtonMenuItem.selectionBackground #3d9aff  HSL 211 100  62    javax.swing.plaf.ColorUIResource [UI]
 RadioButtonMenuItem.selectionForeground #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
 RadioButtonMenuItemUI          com.formdev.flatlaf.ui.FlatRadioButtonMenuItemUI
 
@@ -1315,6 +1327,8 @@ ToolBar.font                   [active] $defaultFont [UI]
 ToolBar.foreground             #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
 ToolBar.gripColor              #b4b4b4  HSL   0   0  71    javax.swing.plaf.ColorUIResource [UI]
 ToolBar.highlight              #40404026  15%  HSLA   0   0  25 15    javax.swing.plaf.ColorUIResource [UI]
+ToolBar.hoverButtonGroupArc    8
+ToolBar.hoverButtonGroupBackground #eeeeee  HSL   0   0  93    com.formdev.flatlaf.util.DerivedColor [UI]    darken(3% autoInverse)
 ToolBar.isRollover             true
 ToolBar.light                  #1f1f1f26  15%  HSLA   0   0  12 15    javax.swing.plaf.ColorUIResource [UI]
 ToolBar.separatorColor         #00000019  10%  HSLA   0   0   0 10    javax.swing.plaf.ColorUIResource [UI]
@@ -1383,11 +1397,13 @@ Tree.repaintWholeRow           true
 Tree.rightChildIndent          11
 Tree.rowHeight                 0
 Tree.scrollsOnExpand           true
+Tree.selectionArc              0
 Tree.selectionBackground       #0063e1  HSL 214 100  44    javax.swing.plaf.ColorUIResource [UI]
 Tree.selectionBorderColor      #000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]
 Tree.selectionForeground       #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
 Tree.selectionInactiveBackground #dcdcdc  HSL   0   0  86    javax.swing.plaf.ColorUIResource [UI]
 Tree.selectionInactiveForeground #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
+Tree.selectionInsets           0,0,0,0    javax.swing.plaf.InsetsUIResource [UI]
 Tree.showCellFocusIndicator    false
 Tree.textBackground            #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
 Tree.textForeground            #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]

--- a/flatlaf-testing/dumps/uidefaults/FlatMacLightLaf_1.8.0.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatMacLightLaf_1.8.0.txt
@@ -873,21 +873,21 @@ ScrollBar.buttonDisabledArrowColor #bdbdbd  HSL   0   0  74    javax.swing.plaf.
 ScrollBar.foreground           #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
 ScrollBar.hoverButtonBackground #e9e9e9  HSL   0   0  91    com.formdev.flatlaf.util.DerivedColor [UI]    darken(5%)
 ScrollBar.hoverThumbColor      #a9a9a9  HSL   0   0  66    com.formdev.flatlaf.util.DerivedColor [UI]    darken(10%)
-ScrollBar.hoverThumbWithTrack  false
+ScrollBar.hoverThumbWithTrack  true
 ScrollBar.hoverTrackColor      #f2f2f2  HSL   0   0  95    com.formdev.flatlaf.util.DerivedColor [UI]    darken(3%)
 ScrollBar.maximumThumbSize     100000,100000    javax.swing.plaf.DimensionUIResource [UI]
 ScrollBar.minimumButtonSize    12,12    javax.swing.plaf.DimensionUIResource [UI]
-ScrollBar.minimumThumbSize     10,10    javax.swing.plaf.DimensionUIResource [UI]
+ScrollBar.minimumThumbSize     18,18    javax.swing.plaf.DimensionUIResource [UI]
 ScrollBar.pressedButtonBackground #dddddd  HSL   0   0  87    com.formdev.flatlaf.util.DerivedColor [UI]    darken(10%)
 ScrollBar.pressedThumbColor    #8f8f8f  HSL   0   0  56    com.formdev.flatlaf.util.DerivedColor [UI]    darken(20%)
 ScrollBar.pressedThumbWithTrack false
 ScrollBar.showButtons          false
 ScrollBar.squareButtons        false
 ScrollBar.thumb                #c2c2c2  HSL   0   0  76    javax.swing.plaf.ColorUIResource [UI]
-ScrollBar.thumbArc             0
+ScrollBar.thumbArc             999
 ScrollBar.thumbDarkShadow      #00000026  15%  HSLA   0   0   0 15    javax.swing.plaf.ColorUIResource [UI]
 ScrollBar.thumbHighlight       #40404026  15%  HSLA   0   0  25 15    javax.swing.plaf.ColorUIResource [UI]
-ScrollBar.thumbInsets          0,0,0,0    javax.swing.plaf.InsetsUIResource [UI]
+ScrollBar.thumbInsets          2,2,2,2    javax.swing.plaf.InsetsUIResource [UI]
 ScrollBar.thumbShadow          #00000026  15%  HSLA   0   0   0 15    javax.swing.plaf.ColorUIResource [UI]
 ScrollBar.track                #fafafa  HSL   0   0  98    javax.swing.plaf.ColorUIResource [UI]
 ScrollBar.trackArc             0

--- a/flatlaf-testing/dumps/uidefaults/FlatMacLightLaf_1.8.0.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatMacLightLaf_1.8.0.txt
@@ -1,0 +1,1592 @@
+Class  com.formdev.flatlaf.themes.FlatMacLightLaf
+ID     FlatLaf - FlatLaf macOS Light
+Name   FlatLaf macOS Light
+Java   1.8.0_202
+OS     Windows 10
+
+
+#----  ----
+
+AATextInfoPropertyKey          [unknown type] sun.swing.SwingUtilities2$AATextInfo
+
+
+#---- Actions ----
+
+Actions.Blue                   #389fd6  HSL 201  66  53    javax.swing.plaf.ColorUIResource [UI]
+Actions.Green                  #59a869  HSL 132  31  50    javax.swing.plaf.ColorUIResource [UI]
+Actions.Grey                   #6e6e6e  HSL   0   0  43    javax.swing.plaf.ColorUIResource [UI]
+Actions.GreyInline             #7f8b91  HSL 200   8  53    javax.swing.plaf.ColorUIResource [UI]
+Actions.Red                    #db5860  HSL 356  65  60    javax.swing.plaf.ColorUIResource [UI]
+Actions.Yellow                 #eda200  HSL  41 100  46    javax.swing.plaf.ColorUIResource [UI]
+
+
+#---- AuditoryCues ----
+
+AuditoryCues.allAuditoryCues   length=13    [Ljava.lang.Object;
+    [0] CheckBoxMenuItem.commandSound
+    [1] InternalFrame.closeSound
+    [2] InternalFrame.maximizeSound
+    [3] InternalFrame.minimizeSound
+    [4] InternalFrame.restoreDownSound
+    [5] InternalFrame.restoreUpSound
+    [6] MenuItem.commandSound
+    [7] OptionPane.errorSound
+    [8] OptionPane.informationSound
+    [9] OptionPane.questionSound
+    [10] OptionPane.warningSound
+    [11] PopupMenu.popupSound
+    [12] RadioButtonMenuItem.commandSound
+AuditoryCues.cueList           length=13    [Ljava.lang.Object;
+    [0] CheckBoxMenuItem.commandSound
+    [1] InternalFrame.closeSound
+    [2] InternalFrame.maximizeSound
+    [3] InternalFrame.minimizeSound
+    [4] InternalFrame.restoreDownSound
+    [5] InternalFrame.restoreUpSound
+    [6] MenuItem.commandSound
+    [7] OptionPane.errorSound
+    [8] OptionPane.informationSound
+    [9] OptionPane.questionSound
+    [10] OptionPane.warningSound
+    [11] PopupMenu.popupSound
+    [12] RadioButtonMenuItem.commandSound
+AuditoryCues.noAuditoryCues    length=1    [Ljava.lang.Object;
+    [0] mute
+
+
+#---- BusyLabel ----
+
+BusyLabelUI                    com.formdev.flatlaf.swingx.ui.FlatBusyLabelUI
+
+
+#---- Button ----
+
+Button.arc                     12
+Button.background              #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+Button.border                  [lazy] 3,3,3,3  false    com.formdev.flatlaf.ui.FlatButtonBorder [UI]
+Button.borderColor             #00000026  15%  HSLA   0   0   0 15    javax.swing.plaf.ColorUIResource [UI]
+Button.borderWidth             1
+Button.darkShadow              #00000026  15%  HSLA   0   0   0 15    javax.swing.plaf.ColorUIResource [UI]
+Button.default.background      #007aff  HSL 211 100  50    javax.swing.plaf.ColorUIResource [UI]
+Button.default.boldText        true
+Button.default.borderColor     #007aff  HSL 211 100  50    javax.swing.plaf.ColorUIResource [UI]
+Button.default.borderWidth     1
+Button.default.focusColor      #0067f47f  50%  HSLA 215 100  48 50    javax.swing.plaf.ColorUIResource [UI]
+Button.default.focusedBorderColor #005ddc8c  55%  HSLA 215 100  43 55    javax.swing.plaf.ColorUIResource [UI]
+Button.default.foreground      #f6f6f6  HSL   0   0  96    javax.swing.plaf.ColorUIResource [UI]
+Button.default.hoverBackground #0073f0  HSL 211 100  47    com.formdev.flatlaf.util.DerivedColor [UI]    darken(3% autoInverse)
+Button.default.hoverBorderColor #005ddc8c  55%  HSLA 215 100  43 55    javax.swing.plaf.ColorUIResource [UI]
+Button.default.pressedBackground #0062cc  HSL 211 100  40    com.formdev.flatlaf.util.DerivedColor [UI]    darken(10% autoInverse)
+Button.defaultButtonFollowsFocus false
+Button.disabledBackground      #fafafa  HSL   0   0  98    javax.swing.plaf.ColorUIResource [UI]
+Button.disabledBorderColor     #00000019  10%  HSLA   0   0   0 10    javax.swing.plaf.ColorUIResource [UI]
+Button.disabledForeground      #b6b6b6  HSL   0   0  71    javax.swing.plaf.ColorUIResource [UI]
+Button.disabledSelectedBackground #dedede  HSL   0   0  87    com.formdev.flatlaf.util.DerivedColor [UI]    darken(13% autoInverse)
+Button.disabledText            #b6b6b6  HSL   0   0  71    javax.swing.plaf.ColorUIResource [UI]
+Button.focusedBorderColor      #005ddc8c  55%  HSLA 215 100  43 55    javax.swing.plaf.ColorUIResource [UI]
+Button.font                    [active] $defaultFont [UI]
+Button.foreground              #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
+Button.highlight               #40404026  15%  HSLA   0   0  25 15    javax.swing.plaf.ColorUIResource [UI]
+Button.hoverBackground         #f7f7f7  HSL   0   0  97    com.formdev.flatlaf.util.DerivedColor [UI]    darken(3% autoInverse)
+Button.hoverBorderColor        #005ddc8c  55%  HSLA 215 100  43 55    javax.swing.plaf.ColorUIResource [UI]
+Button.iconTextGap             4
+Button.innerFocusWidth         0
+Button.light                   #1f1f1f26  15%  HSLA   0   0  12 15    javax.swing.plaf.ColorUIResource [UI]
+Button.margin                  2,14,2,14    javax.swing.plaf.InsetsUIResource [UI]
+Button.minimumWidth            72
+Button.pressedBackground       #e6e6e6  HSL   0   0  90    com.formdev.flatlaf.util.DerivedColor [UI]    darken(10% autoInverse)
+Button.rollover                true
+Button.selectedBackground      #cccccc  HSL   0   0  80    com.formdev.flatlaf.util.DerivedColor [UI]    darken(20% autoInverse)
+Button.selectedForeground      #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
+Button.shadow                  #00000026  15%  HSLA   0   0   0 15    javax.swing.plaf.ColorUIResource [UI]
+Button.textIconGap             4
+Button.textShiftOffset         0
+Button.toolbar.hoverBackground #e0e0e0  HSL   0   0  88    com.formdev.flatlaf.util.DerivedColor [UI]    darken(12% autoInverse)
+Button.toolbar.margin          3,3,3,3    javax.swing.plaf.InsetsUIResource [UI]
+Button.toolbar.pressedBackground #d9d9d9  HSL   0   0  85    com.formdev.flatlaf.util.DerivedColor [UI]    darken(15% autoInverse)
+Button.toolbar.selectedBackground #cccccc  HSL   0   0  80    com.formdev.flatlaf.util.DerivedColor [UI]    darken(20% autoInverse)
+Button.toolbar.spacingInsets   1,2,1,2    javax.swing.plaf.InsetsUIResource [UI]
+ButtonUI                       com.formdev.flatlaf.ui.FlatButtonUI
+
+
+#---- Caret ----
+
+Caret.width                    [active] 1
+
+
+#---- CheckBox ----
+
+CheckBox.arc                   7
+CheckBox.background            #f6f6f6  HSL   0   0  96    javax.swing.plaf.ColorUIResource [UI]
+CheckBox.border                [lazy] 0,0,0,0  false    com.formdev.flatlaf.ui.FlatMarginBorder [UI]
+CheckBox.disabledText          #b6b6b6  HSL   0   0  71    javax.swing.plaf.ColorUIResource [UI]
+CheckBox.font                  [active] $defaultFont [UI]
+CheckBox.foreground            #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
+CheckBox.icon.background       #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+CheckBox.icon.borderColor      #0000003c  24%  HSLA   0   0   0 24    javax.swing.plaf.ColorUIResource [UI]
+CheckBox.icon.checkmarkColor   #007aff  HSL 211 100  50    javax.swing.plaf.ColorUIResource [UI]
+CheckBox.icon.disabledBackground #f6f6f6  HSL   0   0  96    javax.swing.plaf.ColorUIResource [UI]
+CheckBox.icon.disabledBorderColor #33333363  39%  HSLA   0   0  20 39    javax.swing.plaf.ColorUIResource [UI]
+CheckBox.icon.disabledCheckmarkColor #8d8d8d  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
+CheckBox.icon.focusedBorderColor #0054c698  60%  HSLA 215 100  39 60    javax.swing.plaf.ColorUIResource [UI]
+CheckBox.icon.hoverBackground  #f7f7f7  HSL   0   0  97    com.formdev.flatlaf.util.DerivedColor [UI]    darken(3% autoInverse)
+CheckBox.icon.hoverBorderColor #0054c698  60%  HSLA 215 100  39 60    javax.swing.plaf.ColorUIResource [UI]
+CheckBox.icon.pressedBackground #e6e6e6  HSL   0   0  90    com.formdev.flatlaf.util.DerivedColor [UI]    darken(10% autoInverse)
+CheckBox.icon.pressedBorderColor #0054c698  60%  HSLA 215 100  39 60    javax.swing.plaf.ColorUIResource [UI]
+CheckBox.icon.selectedBackground #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+CheckBox.icon.selectedBorderColor #007aff  HSL 211 100  50    javax.swing.plaf.ColorUIResource [UI]
+CheckBox.icon.style            filled
+CheckBox.icon                  [lazy] 15,15    com.formdev.flatlaf.icons.FlatCheckBoxIcon [UI]
+CheckBox.iconTextGap           6
+CheckBox.icon[filled].background #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+CheckBox.icon[filled].borderColor #00000026  15%  HSLA   0   0   0 15    javax.swing.plaf.ColorUIResource [UI]
+CheckBox.icon[filled].borderWidth 1
+CheckBox.icon[filled].checkmarkColor #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+CheckBox.icon[filled].disabledBackground #fafafa  HSL   0   0  98    javax.swing.plaf.ColorUIResource [UI]
+CheckBox.icon[filled].disabledBorderColor #00000019  10%  HSLA   0   0   0 10    javax.swing.plaf.ColorUIResource [UI]
+CheckBox.icon[filled].disabledCheckmarkColor #bfbfbf  HSL   0   0  75    javax.swing.plaf.ColorUIResource [UI]
+CheckBox.icon[filled].disabledSelectedBorderWidth 1
+CheckBox.icon[filled].focusedSelectedBackground #007aff  HSL 211 100  50    javax.swing.plaf.ColorUIResource [UI]
+CheckBox.icon[filled].focusedSelectedBorderColor #80bdff  HSL 211 100  75    javax.swing.plaf.ColorUIResource [UI]
+CheckBox.icon[filled].hoverSelectedBackground #006ee6  HSL 211 100  45    com.formdev.flatlaf.util.DerivedColor [UI]    darken(5% autoInverse)
+CheckBox.icon[filled].pressedSelectedBackground #0062cc  HSL 211 100  40    com.formdev.flatlaf.util.DerivedColor [UI]    darken(10% autoInverse)
+CheckBox.icon[filled].selectedBackground #007aff  HSL 211 100  50    javax.swing.plaf.ColorUIResource [UI]
+CheckBox.icon[filled].selectedBorderColor #0074f2  HSL 211 100  47    javax.swing.plaf.ColorUIResource [UI]
+CheckBox.icon[filled].selectedBorderWidth 0
+CheckBox.margin                2,2,2,2    javax.swing.plaf.InsetsUIResource [UI]
+CheckBox.rollover              true
+CheckBox.textIconGap           4
+CheckBox.textShiftOffset       0
+
+
+#---- CheckBoxMenuItem ----
+
+CheckBoxMenuItem.acceleratorFont [active] $defaultFont [UI]
+CheckBoxMenuItem.acceleratorForeground #737373  HSL   0   0  45    javax.swing.plaf.ColorUIResource [UI]
+CheckBoxMenuItem.acceleratorSelectionForeground #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+CheckBoxMenuItem.arrowIcon     [lazy] 6,10    com.formdev.flatlaf.icons.FlatMenuItemArrowIcon [UI]
+CheckBoxMenuItem.background    #ececec  HSL   0   0  93    javax.swing.plaf.ColorUIResource [UI]
+CheckBoxMenuItem.border        [lazy] 0,0,0,0  false    com.formdev.flatlaf.ui.FlatMenuItemBorder [UI]
+CheckBoxMenuItem.borderPainted true
+CheckBoxMenuItem.checkIcon     [lazy] 15,15    com.formdev.flatlaf.icons.FlatCheckBoxMenuItemIcon [UI]
+CheckBoxMenuItem.disabledForeground #b6b6b6  HSL   0   0  71    javax.swing.plaf.ColorUIResource [UI]
+CheckBoxMenuItem.font          [active] $defaultFont [UI]
+CheckBoxMenuItem.foreground    #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
+CheckBoxMenuItem.icon.checkmarkColor #007aff  HSL 211 100  50    javax.swing.plaf.ColorUIResource [UI]
+CheckBoxMenuItem.icon.disabledCheckmarkColor #bdbdbd  HSL   0   0  74    javax.swing.plaf.ColorUIResource [UI]
+CheckBoxMenuItem.margin        3,6,3,6    javax.swing.plaf.InsetsUIResource [UI]
+CheckBoxMenuItem.opaque        false
+CheckBoxMenuItem.selectionBackground #0063e1  HSL 214 100  44    javax.swing.plaf.ColorUIResource [UI]
+CheckBoxMenuItem.selectionForeground #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+CheckBoxMenuItemUI             com.formdev.flatlaf.ui.FlatCheckBoxMenuItemUI
+
+
+#---- CheckBox ----
+
+CheckBoxUI                     com.formdev.flatlaf.ui.FlatCheckBoxUI
+
+
+#---- ColorChooser ----
+
+ColorChooser.background        #f6f6f6  HSL   0   0  96    javax.swing.plaf.ColorUIResource [UI]
+ColorChooser.font              [active] $defaultFont [UI]
+ColorChooser.foreground        #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
+ColorChooser.swatchesDefaultRecentColor #f6f6f6  HSL   0   0  96    javax.swing.plaf.ColorUIResource [UI]
+ColorChooser.swatchesRecentSwatchSize [active] 16,16    javax.swing.plaf.DimensionUIResource [UI]
+ColorChooser.swatchesSwatchSize [active] 16,16    javax.swing.plaf.DimensionUIResource [UI]
+ColorChooserUI                 com.formdev.flatlaf.ui.FlatColorChooserUI
+
+
+#---- ColumnControlButton ----
+
+ColumnControlButton.actionIcon [lazy] 10,10    com.formdev.flatlaf.swingx.icons.FlatColumnControlIcon [UI]
+ColumnControlButton.iconColor  #888888  HSL   0   0  53    javax.swing.plaf.ColorUIResource [UI]
+
+
+#---- ComboBox ----
+
+ComboBox.background            #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+ComboBox.border                [lazy] 3,3,3,3  false    com.formdev.flatlaf.ui.FlatRoundBorder [UI]
+ComboBox.buttonArrowColor      #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+ComboBox.buttonBackground      #007aff  HSL 211 100  50    javax.swing.plaf.ColorUIResource [UI]
+ComboBox.buttonDarkShadow      #00000026  15%  HSLA   0   0   0 15    javax.swing.plaf.ColorUIResource [UI]
+ComboBox.buttonDisabledArrowColor #bdbdbd  HSL   0   0  74    javax.swing.plaf.ColorUIResource [UI]
+ComboBox.buttonDisabledSeparatorColor #00000019  10%  HSLA   0   0   0 10    javax.swing.plaf.ColorUIResource [UI]
+ComboBox.buttonEditableBackground #fafafa  HSL   0   0  98    javax.swing.plaf.ColorUIResource [UI]
+ComboBox.buttonHighlight       #40404026  15%  HSLA   0   0  25 15    javax.swing.plaf.ColorUIResource [UI]
+ComboBox.buttonHoverArrowColor #d9d9d9  HSL   0   0  85    com.formdev.flatlaf.util.DerivedColor [UI]    darken(15%)
+ComboBox.buttonPressedArrowColor #bfbfbf  HSL   0   0  75    com.formdev.flatlaf.util.DerivedColor [UI]    darken(25%)
+ComboBox.buttonSeparatorColor  #00000026  15%  HSLA   0   0   0 15    javax.swing.plaf.ColorUIResource [UI]
+ComboBox.buttonShadow          #00000026  15%  HSLA   0   0   0 15    javax.swing.plaf.ColorUIResource [UI]
+ComboBox.buttonStyle           mac
+ComboBox.disabledBackground    #fafafa  HSL   0   0  98    javax.swing.plaf.ColorUIResource [UI]
+ComboBox.disabledForeground    #b6b6b6  HSL   0   0  71    javax.swing.plaf.ColorUIResource [UI]
+ComboBox.editorColumns         0
+ComboBox.font                  [active] $defaultFont [UI]
+ComboBox.foreground            #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
+ComboBox.isEnterSelectablePopup false
+ComboBox.maximumRowCount       15
+ComboBox.minimumWidth          72
+ComboBox.noActionOnKeyNavigation false
+ComboBox.padding               2,6,2,6    javax.swing.plaf.InsetsUIResource [UI]
+ComboBox.popupBackground       #ececec  HSL   0   0  93    javax.swing.plaf.ColorUIResource [UI]
+ComboBox.selectionBackground   #0063e1  HSL 214 100  44    javax.swing.plaf.ColorUIResource [UI]
+ComboBox.selectionForeground   #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+ComboBox.timeFactor            1000
+ComboBoxUI                     com.formdev.flatlaf.ui.FlatComboBoxUI
+
+
+#---- Component ----
+
+Component.accentColor          #007aff  HSL 211 100  50    javax.swing.plaf.ColorUIResource [UI]
+Component.arc                  12
+Component.arrowType            chevron
+Component.borderColor          #00000026  15%  HSLA   0   0   0 15    javax.swing.plaf.ColorUIResource [UI]
+Component.borderWidth          1
+Component.custom.borderColor   #f38d8d  HSL   0  81  75    com.formdev.flatlaf.util.DerivedColor [UI]    desaturate(20%) lighten(25%)
+Component.disabledBorderColor  #00000019  10%  HSLA   0   0   0 10    javax.swing.plaf.ColorUIResource [UI]
+Component.error.borderColor    #ebb8bc  HSL 355  56  82    javax.swing.plaf.ColorUIResource [UI]
+Component.error.focusedBorderColor #e53e4d  HSL 355  76  57    javax.swing.plaf.ColorUIResource [UI]
+Component.focusColor           #0067f47f  50%  HSLA 215 100  48 50    javax.swing.plaf.ColorUIResource [UI]
+Component.focusWidth           2
+Component.focusedBorderColor   #005ddc8c  55%  HSLA 215 100  43 55    javax.swing.plaf.ColorUIResource [UI]
+Component.grayFilter           [lazy] [unknown type] com.formdev.flatlaf.util.GrayFilter
+Component.hideMnemonics        true
+Component.innerFocusWidth      0
+Component.innerOutlineWidth    0
+Component.linkColor            #007aff  HSL 211 100  50    javax.swing.plaf.ColorUIResource [UI]
+Component.minimumWidth         64
+Component.warning.borderColor  #fed284  HSL  38  98  76    javax.swing.plaf.ColorUIResource [UI]
+Component.warning.focusedBorderColor #e2a53a  HSL  38  74  56    javax.swing.plaf.ColorUIResource [UI]
+
+
+#---- DatePicker ----
+
+DatePickerUI                   com.formdev.flatlaf.swingx.ui.FlatDatePickerUI
+
+
+#---- Desktop ----
+
+Desktop.background             #e6ebf0  HSL 210  25  92    javax.swing.plaf.ColorUIResource [UI]
+Desktop.minOnScreenInsets      3,3,3,3    javax.swing.plaf.InsetsUIResource [UI]
+
+
+#---- DesktopIcon ----
+
+DesktopIcon.background         #c6d2dd  HSL 209  25  82    com.formdev.flatlaf.util.DerivedColor [UI]    darken(10% autoInverse)
+DesktopIcon.border             [lazy] 4,4,4,4  false    com.formdev.flatlaf.ui.FlatEmptyBorder [UI]
+DesktopIcon.closeIcon          [lazy] 24,24    com.formdev.flatlaf.icons.FlatInternalFrameCloseIcon [UI]
+DesktopIcon.closeSize          20,20    javax.swing.plaf.DimensionUIResource [UI]
+DesktopIcon.foreground         #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
+DesktopIcon.iconSize           64,64    javax.swing.plaf.DimensionUIResource [UI]
+DesktopIconUI                  com.formdev.flatlaf.ui.FlatDesktopIconUI
+
+
+#---- DesktopPane ----
+
+DesktopPaneUI                  com.formdev.flatlaf.ui.FlatDesktopPaneUI
+
+
+#---- EditorPane ----
+
+EditorPane.background          #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+EditorPane.border              [lazy] 0,0,0,0  false    com.formdev.flatlaf.ui.FlatMarginBorder [UI]
+EditorPane.caretBlinkRate      500
+EditorPane.caretForeground     #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
+EditorPane.disabledBackground  #fafafa  HSL   0   0  98    javax.swing.plaf.ColorUIResource [UI]
+EditorPane.font                [active] $defaultFont [UI]
+EditorPane.foreground          #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
+EditorPane.inactiveBackground  #f6f6f6  HSL   0   0  96    javax.swing.plaf.ColorUIResource [UI]
+EditorPane.inactiveForeground  #b6b6b6  HSL   0   0  71    javax.swing.plaf.ColorUIResource [UI]
+EditorPane.margin              2,6,2,6    javax.swing.plaf.InsetsUIResource [UI]
+EditorPane.selectionBackground #b3d7ff  HSL 212 100  85    javax.swing.plaf.ColorUIResource [UI]
+EditorPane.selectionForeground #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
+EditorPaneUI                   com.formdev.flatlaf.ui.FlatEditorPaneUI
+
+
+#---- FileChooser ----
+
+FileChooser.detailsViewIcon    [lazy] 16,16    com.formdev.flatlaf.icons.FlatFileChooserDetailsViewIcon [UI]
+FileChooser.homeFolderIcon     [lazy] 16,16    com.formdev.flatlaf.icons.FlatFileChooserHomeFolderIcon [UI]
+FileChooser.listViewIcon       [lazy] 16,16    com.formdev.flatlaf.icons.FlatFileChooserListViewIcon [UI]
+FileChooser.newFolderIcon      [lazy] 16,16    com.formdev.flatlaf.icons.FlatFileChooserNewFolderIcon [UI]
+FileChooser.readOnly           false
+FileChooser.upFolderIcon       [lazy] 16,16    com.formdev.flatlaf.icons.FlatFileChooserUpFolderIcon [UI]
+FileChooser.useSystemExtensionHiding true
+FileChooser.usesSingleFilePane true
+FileChooserUI                  com.formdev.flatlaf.ui.FlatFileChooserUI
+
+
+#---- FileView ----
+
+FileView.computerIcon          [lazy] 16,16    com.formdev.flatlaf.icons.FlatFileViewComputerIcon [UI]
+FileView.directoryIcon         [lazy] 16,16    com.formdev.flatlaf.icons.FlatFileViewDirectoryIcon [UI]
+FileView.fileIcon              [lazy] 16,16    com.formdev.flatlaf.icons.FlatFileViewFileIcon [UI]
+FileView.floppyDriveIcon       [lazy] 16,16    com.formdev.flatlaf.icons.FlatFileViewFloppyDriveIcon [UI]
+FileView.fullRowSelection      true
+FileView.hardDriveIcon         [lazy] 16,16    com.formdev.flatlaf.icons.FlatFileViewHardDriveIcon [UI]
+
+
+#---- FormattedTextField ----
+
+FormattedTextField.background  #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+FormattedTextField.border      [lazy] 3,3,3,3  false    com.formdev.flatlaf.ui.FlatTextBorder [UI]
+FormattedTextField.caretBlinkRate 500
+FormattedTextField.caretForeground #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
+FormattedTextField.disabledBackground #fafafa  HSL   0   0  98    javax.swing.plaf.ColorUIResource [UI]
+FormattedTextField.font        [active] $defaultFont [UI]
+FormattedTextField.foreground  #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
+FormattedTextField.iconTextGap 4
+FormattedTextField.inactiveBackground #f6f6f6  HSL   0   0  96    javax.swing.plaf.ColorUIResource [UI]
+FormattedTextField.inactiveForeground #b6b6b6  HSL   0   0  71    javax.swing.plaf.ColorUIResource [UI]
+FormattedTextField.margin      2,6,2,6    javax.swing.plaf.InsetsUIResource [UI]
+FormattedTextField.placeholderForeground #b6b6b6  HSL   0   0  71    javax.swing.plaf.ColorUIResource [UI]
+FormattedTextField.selectionBackground #b3d7ff  HSL 212 100  85    javax.swing.plaf.ColorUIResource [UI]
+FormattedTextField.selectionForeground #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
+FormattedTextFieldUI           com.formdev.flatlaf.ui.FlatFormattedTextFieldUI
+
+
+#---- Header ----
+
+HeaderUI                       com.formdev.flatlaf.swingx.ui.FlatHeaderUI
+
+
+#---- HelpButton ----
+
+HelpButton.background          #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+HelpButton.borderColor         #00000026  15%  HSLA   0   0   0 15    javax.swing.plaf.ColorUIResource [UI]
+HelpButton.borderWidth         1
+HelpButton.disabledBackground  #fafafa  HSL   0   0  98    javax.swing.plaf.ColorUIResource [UI]
+HelpButton.disabledBorderColor #00000019  10%  HSLA   0   0   0 10    javax.swing.plaf.ColorUIResource [UI]
+HelpButton.disabledQuestionMarkColor #acacac  HSL   0   0  67    javax.swing.plaf.ColorUIResource [UI]
+HelpButton.focusedBorderColor  #005ddc8c  55%  HSLA 215 100  43 55    javax.swing.plaf.ColorUIResource [UI]
+HelpButton.hoverBackground     #f7f7f7  HSL   0   0  97    com.formdev.flatlaf.util.DerivedColor [UI]    darken(3% autoInverse)
+HelpButton.hoverBorderColor    #005ddc8c  55%  HSLA 215 100  43 55    javax.swing.plaf.ColorUIResource [UI]
+HelpButton.icon                [lazy] 26,26    com.formdev.flatlaf.icons.FlatHelpButtonIcon [UI]
+HelpButton.innerFocusWidth     0
+HelpButton.pressedBackground   #e6e6e6  HSL   0   0  90    com.formdev.flatlaf.util.DerivedColor [UI]    darken(10% autoInverse)
+HelpButton.questionMarkColor   #007aff  HSL 211 100  50    javax.swing.plaf.ColorUIResource [UI]
+
+
+#---- Hyperlink ----
+
+Hyperlink.disabledText         #b6b6b6  HSL   0   0  71    javax.swing.plaf.ColorUIResource [UI]
+Hyperlink.linkColor            #007aff  HSL 211 100  50    javax.swing.plaf.ColorUIResource [UI]
+Hyperlink.visitedColor         #007aff  HSL 211 100  50    javax.swing.plaf.ColorUIResource [UI]
+HyperlinkUI                    com.formdev.flatlaf.swingx.ui.FlatHyperlinkUI
+
+
+#---- InternalFrame ----
+
+InternalFrame.activeBorderColor #949494  HSL   0   0  58    javax.swing.plaf.ColorUIResource [UI]
+InternalFrame.activeDropShadowInsets 5,5,6,6    javax.swing.plaf.InsetsUIResource [UI]
+InternalFrame.activeDropShadowOpacity 0.25
+InternalFrame.activeTitleBackground #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+InternalFrame.activeTitleForeground #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
+InternalFrame.border           [lazy] 6,6,6,6  false    com.formdev.flatlaf.ui.FlatInternalFrameUI$FlatInternalFrameBorder [UI]
+InternalFrame.borderColor      #f6f6f6  HSL   0   0  96    javax.swing.plaf.ColorUIResource [UI]
+InternalFrame.borderDarkShadow #00000026  15%  HSLA   0   0   0 15    javax.swing.plaf.ColorUIResource [UI]
+InternalFrame.borderHighlight  #40404026  15%  HSLA   0   0  25 15    javax.swing.plaf.ColorUIResource [UI]
+InternalFrame.borderLight      #1f1f1f26  15%  HSLA   0   0  12 15    javax.swing.plaf.ColorUIResource [UI]
+InternalFrame.borderLineWidth  1
+InternalFrame.borderMargins    6,6,6,6    javax.swing.plaf.InsetsUIResource [UI]
+InternalFrame.borderShadow     #00000026  15%  HSLA   0   0   0 15    javax.swing.plaf.ColorUIResource [UI]
+InternalFrame.buttonHoverBackground #e6e6e6  HSL   0   0  90    com.formdev.flatlaf.util.DerivedColor [UI]    darken(10% autoInverse)
+InternalFrame.buttonPressedBackground #cccccc  HSL   0   0  80    com.formdev.flatlaf.util.DerivedColor [UI]    darken(20% autoInverse)
+InternalFrame.buttonSize       24,24    javax.swing.plaf.DimensionUIResource [UI]
+InternalFrame.closeHoverBackground [lazy] #db5860  HSL 356  65  60    javax.swing.plaf.ColorUIResource [UI]
+InternalFrame.closeHoverForeground #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+InternalFrame.closeIcon        [lazy] 24,24    com.formdev.flatlaf.icons.FlatInternalFrameCloseIcon [UI]
+InternalFrame.closePressedBackground [lazy] #d22e38  HSL 356  65  50    javax.swing.plaf.ColorUIResource [UI]
+InternalFrame.closePressedForeground #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+InternalFrame.dropShadowPainted true
+InternalFrame.icon             [lazy] 16,16    sun.swing.ImageIconUIResource [UI]  (sun.awt.image.ToolkitImage)
+InternalFrame.iconifyIcon      [lazy] 24,24    com.formdev.flatlaf.icons.FlatInternalFrameIconifyIcon [UI]
+InternalFrame.inactiveBorderColor #c5c5c5  HSL   0   0  77    javax.swing.plaf.ColorUIResource [UI]
+InternalFrame.inactiveDropShadowInsets 3,3,4,4    javax.swing.plaf.InsetsUIResource [UI]
+InternalFrame.inactiveDropShadowOpacity 0.5
+InternalFrame.inactiveTitleBackground #fafafa  HSL   0   0  98    javax.swing.plaf.ColorUIResource [UI]
+InternalFrame.inactiveTitleForeground #b6b6b6  HSL   0   0  71    javax.swing.plaf.ColorUIResource [UI]
+InternalFrame.maximizeIcon     [lazy] 24,24    com.formdev.flatlaf.icons.FlatInternalFrameMaximizeIcon [UI]
+InternalFrame.minimizeIcon     [lazy] 24,24    com.formdev.flatlaf.icons.FlatInternalFrameRestoreIcon [UI]
+InternalFrame.titleFont        [active] $defaultFont [UI]
+
+
+#---- InternalFrameTitlePane ----
+
+InternalFrameTitlePane.border  [lazy] 0,8,0,0  false    com.formdev.flatlaf.ui.FlatEmptyBorder [UI]
+InternalFrameTitlePane.closeButtonOpacity true
+InternalFrameTitlePane.iconifyButtonOpacity true
+InternalFrameTitlePane.maximizeButtonOpacity true
+
+
+#---- InternalFrame ----
+
+InternalFrameUI                com.formdev.flatlaf.ui.FlatInternalFrameUI
+
+
+#---- JXBusyLabel ----
+
+JXBusyLabel.baseColor          #c4c4c4  HSL   0   0  77    javax.swing.plaf.ColorUIResource [UI]
+JXBusyLabel.highlightColor     #808080  HSL   0   0  50    javax.swing.plaf.ColorUIResource [UI]
+
+
+#---- JXDatePicker ----
+
+JXDatePicker.border            [lazy] 3,3,3,3  false    com.formdev.flatlaf.swingx.ui.FlatDatePickerBorder [UI]
+
+
+#---- JXHeader ----
+
+JXHeader.background            #f6f6f6  HSL   0   0  96    javax.swing.plaf.ColorUIResource [UI]
+JXHeader.startBackground       #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+
+
+#---- JXMonthView ----
+
+JXMonthView.arrowColor         #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
+JXMonthView.background         #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+JXMonthView.daysOfTheWeekForeground #444444  HSL   0   0  27    javax.swing.plaf.ColorUIResource [UI]
+JXMonthView.disabledArrowColor #b6b6b6  HSL   0   0  71    javax.swing.plaf.ColorUIResource [UI]
+JXMonthView.flaggedDayForeground #e02222  HSL   0  75  51    javax.swing.plaf.ColorUIResource [UI]
+JXMonthView.leadingDayForeground #b6b6b6  HSL   0   0  71    javax.swing.plaf.ColorUIResource [UI]
+JXMonthView.monthDownFileName  [lazy] 20,20    com.formdev.flatlaf.swingx.ui.FlatMonthDownIcon [UI]
+JXMonthView.monthStringBackground #dfdfdf  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+JXMonthView.monthStringForeground #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
+JXMonthView.monthUpFileName    [lazy] 20,20    com.formdev.flatlaf.swingx.ui.FlatMonthUpIcon [UI]
+JXMonthView.selectedBackground #b3d4ff  HSL 214 100  85    javax.swing.plaf.ColorUIResource [UI]
+JXMonthView.trailingDayForeground #b6b6b6  HSL   0   0  71    javax.swing.plaf.ColorUIResource [UI]
+JXMonthView.unselectableDayForeground #e02222  HSL   0  75  51    javax.swing.plaf.ColorUIResource [UI]
+JXMonthView.weekOfTheYearForeground #666666  HSL   0   0  40    javax.swing.plaf.ColorUIResource [UI]
+
+
+#---- JXTitledPanel ----
+
+JXTitledPanel.borderColor      #00000026  15%  HSLA   0   0   0 15    javax.swing.plaf.ColorUIResource [UI]
+JXTitledPanel.captionInsets    4,10,4,10    javax.swing.plaf.InsetsUIResource [UI]
+JXTitledPanel.titleBackground  #dfdfdf  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+JXTitledPanel.titleForeground  #222222  HSL   0   0  13    javax.swing.plaf.ColorUIResource [UI]
+
+
+#---- JideButton ----
+
+JideButton.background          #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+JideButton.border              [lazy] 0,0,0,0  false    com.formdev.flatlaf.ui.FlatMarginBorder [UI]
+JideButton.borderColor         #00000026  15%  HSLA   0   0   0 15    javax.swing.plaf.ColorUIResource [UI]
+JideButton.darkShadow          #00000026  15%  HSLA   0   0   0 15    javax.swing.plaf.ColorUIResource [UI]
+JideButton.focusedBackground   #e0e0e0  HSL   0   0  88    com.formdev.flatlaf.util.DerivedColor [UI]    darken(12% autoInverse)
+JideButton.foreground          #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
+JideButton.highlight           #cccccc  HSL   0   0  80    com.formdev.flatlaf.util.DerivedColor [UI]    darken(20% autoInverse)
+JideButton.light               #00000026  15%  HSLA   0   0   0 15    javax.swing.plaf.ColorUIResource [UI]
+JideButton.margin              3,3,3,3    javax.swing.plaf.InsetsUIResource [UI]
+JideButton.selectedAndFocusedBackground #d9d9d9  HSL   0   0  85    com.formdev.flatlaf.util.DerivedColor [UI]    darken(15% autoInverse)
+JideButton.selectedBackground  #cccccc  HSL   0   0  80    com.formdev.flatlaf.util.DerivedColor [UI]    darken(20% autoInverse)
+JideButton.shadow              #00000026  15%  HSLA   0   0   0 15    javax.swing.plaf.ColorUIResource [UI]
+JideButton.textIconGap         [active] 4
+JideButtonUI                   com.formdev.flatlaf.jideoss.ui.FlatJideButtonUI
+
+
+#---- JideLabel ----
+
+JideLabel.background           #f6f6f6  HSL   0   0  96    javax.swing.plaf.ColorUIResource [UI]
+JideLabel.disabledForeground   #b6b6b6  HSL   0   0  71    javax.swing.plaf.ColorUIResource [UI]
+JideLabel.foreground           #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
+JideLabelUI                    com.formdev.flatlaf.jideoss.ui.FlatJideLabelUI
+
+
+#---- JidePopupMenu ----
+
+JidePopupMenuUI                com.formdev.flatlaf.jideoss.ui.FlatJidePopupMenuUI
+
+
+#---- JideSplitButton ----
+
+JideSplitButton.background     #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+JideSplitButton.border         [lazy] 0,0,0,0  false    com.formdev.flatlaf.ui.FlatMarginBorder [UI]
+JideSplitButton.buttonArrowColor #7d7d7d  HSL   0   0  49    javax.swing.plaf.ColorUIResource [UI]
+JideSplitButton.buttonDisabledArrowColor #bdbdbd  HSL   0   0  74    javax.swing.plaf.ColorUIResource [UI]
+JideSplitButton.foreground     #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
+JideSplitButton.margin         3,3,3,3    javax.swing.plaf.InsetsUIResource [UI]
+JideSplitButton.selectionForeground #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
+JideSplitButton.textIconGap    [active] 4
+JideSplitButtonUI              com.formdev.flatlaf.jideoss.ui.FlatJideSplitButtonUI
+
+
+#---- JideTabbedPane ----
+
+JideTabbedPane.background      #f6f6f6  HSL   0   0  96    javax.swing.plaf.ColorUIResource [UI]
+JideTabbedPane.closeButtonLeftMargin 0
+JideTabbedPane.closeButtonRightMargin 0
+JideTabbedPane.contentBorderInsets 0,0,0,0    javax.swing.plaf.InsetsUIResource [UI]
+JideTabbedPane.fitStyleBoundSize 0
+JideTabbedPane.fitStyleFirstTabMargin 0
+JideTabbedPane.foreground      #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
+JideTabbedPane.shadow          #f6f6f6  HSL   0   0  96    javax.swing.plaf.ColorUIResource [UI]
+JideTabbedPane.tabAreaBackground #f6f6f6  HSL   0   0  96    javax.swing.plaf.ColorUIResource [UI]
+JideTabbedPane.tabAreaInsets   0,0,0,0    javax.swing.plaf.InsetsUIResource [UI]
+JideTabbedPane.tabInsets       4,12,4,12    javax.swing.plaf.InsetsUIResource [UI]
+JideTabbedPane.tabRunOverlay   0
+JideTabbedPaneUI               com.formdev.flatlaf.jideoss.ui.FlatJideTabbedPaneUI
+
+
+#---- Label ----
+
+Label.background               #f6f6f6  HSL   0   0  96    javax.swing.plaf.ColorUIResource [UI]
+Label.disabledForeground       #b6b6b6  HSL   0   0  71    javax.swing.plaf.ColorUIResource [UI]
+Label.disabledShadow           #00000026  15%  HSLA   0   0   0 15    javax.swing.plaf.ColorUIResource [UI]
+Label.font                     [active] $defaultFont [UI]
+Label.foreground               #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
+LabelUI                        com.formdev.flatlaf.ui.FlatLabelUI
+
+
+#---- List ----
+
+List.background                #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+List.border                    [lazy] 0,0,0,0  false    com.formdev.flatlaf.ui.FlatEmptyBorder [UI]
+List.cellFocusColor            #000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]
+List.cellMargins               1,6,1,6    javax.swing.plaf.InsetsUIResource [UI]
+List.cellNoFocusBorder         [lazy] 1,6,1,6  false    com.formdev.flatlaf.ui.FlatListCellBorder$Default [UI]    lineColor=#000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]    lineThickness=1.000000
+List.cellRenderer              [active] javax.swing.DefaultListCellRenderer$UIResource [UI]
+List.dropCellBackground        [lazy] #157cff  HSL 214 100  54    javax.swing.plaf.ColorUIResource [UI]
+List.dropCellForeground        [lazy] #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+List.dropLineColor             [lazy] #4899ff  HSL 213 100  64    javax.swing.plaf.ColorUIResource [UI]
+List.focusCellHighlightBorder  [lazy] 1,6,1,6  false    com.formdev.flatlaf.ui.FlatListCellBorder$Focused [UI]    lineColor=#000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]    lineThickness=1.000000
+List.focusSelectedCellHighlightBorder [lazy] 1,6,1,6  false    com.formdev.flatlaf.ui.FlatListCellBorder$Selected [UI]    lineColor=#000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]    lineThickness=1.000000
+List.font                      [active] $defaultFont [UI]
+List.foreground                #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
+List.noFocusBorder             1,1,1,1  false    javax.swing.plaf.BorderUIResource$EmptyBorderUIResource [UI]
+List.selectionBackground       #0063e1  HSL 214 100  44    javax.swing.plaf.ColorUIResource [UI]
+List.selectionForeground       #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+List.selectionInactiveBackground #dcdcdc  HSL   0   0  86    javax.swing.plaf.ColorUIResource [UI]
+List.selectionInactiveForeground #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
+List.showCellFocusIndicator    false
+List.timeFactor                1000
+ListUI                         com.formdev.flatlaf.ui.FlatListUI
+
+
+#---- Menu ----
+
+Menu.acceleratorFont           [active] $defaultFont [UI]
+Menu.acceleratorForeground     #737373  HSL   0   0  45    javax.swing.plaf.ColorUIResource [UI]
+Menu.acceleratorSelectionForeground #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+Menu.arrowIcon                 [lazy] 6,10    com.formdev.flatlaf.icons.FlatMenuArrowIcon [UI]
+Menu.background                #ececec  HSL   0   0  93    javax.swing.plaf.ColorUIResource [UI]
+Menu.border                    [lazy] 0,0,0,0  false    com.formdev.flatlaf.ui.FlatMenuItemBorder [UI]
+Menu.borderPainted             true
+Menu.cancelMode                hideLastSubmenu
+Menu.crossMenuMnemonic         true
+Menu.disabledForeground        #b6b6b6  HSL   0   0  71    javax.swing.plaf.ColorUIResource [UI]
+Menu.font                      [active] $defaultFont [UI]
+Menu.foreground                #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
+Menu.icon.arrowColor           #7d7d7d  HSL   0   0  49    javax.swing.plaf.ColorUIResource [UI]
+Menu.icon.disabledArrowColor   #bdbdbd  HSL   0   0  74    javax.swing.plaf.ColorUIResource [UI]
+Menu.margin                    3,6,3,6    javax.swing.plaf.InsetsUIResource [UI]
+Menu.menuPopupOffsetX          0
+Menu.menuPopupOffsetY          0
+Menu.opaque                    false
+Menu.preserveTopLevelSelection false
+Menu.selectionBackground       #0063e1  HSL 214 100  44    javax.swing.plaf.ColorUIResource [UI]
+Menu.selectionForeground       #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+Menu.shortcutKeys              length=1    [I
+    [0] 8
+Menu.submenuPopupOffsetX       [active] -4
+Menu.submenuPopupOffsetY       [active] -4
+
+
+#---- MenuBar ----
+
+MenuBar.background             #ececec  HSL   0   0  93    javax.swing.plaf.ColorUIResource [UI]
+MenuBar.border                 [lazy] 0,0,1,0  false    com.formdev.flatlaf.ui.FlatMenuBarBorder [UI]
+MenuBar.borderColor            #00000019  10%  HSLA   0   0   0 10    javax.swing.plaf.ColorUIResource [UI]
+MenuBar.font                   [active] $defaultFont [UI]
+MenuBar.foreground             #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
+MenuBar.highlight              #40404026  15%  HSLA   0   0  25 15    javax.swing.plaf.ColorUIResource [UI]
+MenuBar.hoverBackground        #d3d3d3  HSL   0   0  83    com.formdev.flatlaf.util.DerivedColor [UI]    darken(10% autoInverse)
+MenuBar.itemMargins            3,8,3,8    javax.swing.plaf.InsetsUIResource [UI]
+MenuBar.shadow                 #00000026  15%  HSLA   0   0   0 15    javax.swing.plaf.ColorUIResource [UI]
+MenuBar.windowBindings         length=2    [Ljava.lang.Object;
+    [0] F10
+    [1] takeFocus
+MenuBarUI                      com.formdev.flatlaf.ui.FlatMenuBarUI
+
+
+#---- MenuItem ----
+
+MenuItem.acceleratorArrowGap   2
+MenuItem.acceleratorDelimiter  +
+MenuItem.acceleratorFont       [active] $defaultFont [UI]
+MenuItem.acceleratorForeground #737373  HSL   0   0  45    javax.swing.plaf.ColorUIResource [UI]
+MenuItem.acceleratorSelectionForeground #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+MenuItem.arrowIcon             [lazy] 6,10    com.formdev.flatlaf.icons.FlatMenuItemArrowIcon [UI]
+MenuItem.background            #ececec  HSL   0   0  93    javax.swing.plaf.ColorUIResource [UI]
+MenuItem.border                [lazy] 0,0,0,0  false    com.formdev.flatlaf.ui.FlatMenuItemBorder [UI]
+MenuItem.borderPainted         true
+MenuItem.checkBackground       #aed2ff  HSL 213 100  84    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(40%)
+MenuItem.checkMargins          2,2,2,2    javax.swing.plaf.InsetsUIResource [UI]
+MenuItem.disabledForeground    #b6b6b6  HSL   0   0  71    javax.swing.plaf.ColorUIResource [UI]
+MenuItem.font                  [active] $defaultFont [UI]
+MenuItem.foreground            #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
+MenuItem.iconTextGap           6
+MenuItem.margin                3,6,3,6    javax.swing.plaf.InsetsUIResource [UI]
+MenuItem.minimumIconSize       16,16    javax.swing.plaf.DimensionUIResource [UI]
+MenuItem.minimumWidth          72
+MenuItem.opaque                false
+MenuItem.selectionBackground   #0063e1  HSL 214 100  44    javax.swing.plaf.ColorUIResource [UI]
+MenuItem.selectionForeground   #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+MenuItem.textAcceleratorGap    24
+MenuItem.textNoAcceleratorGap  6
+MenuItem.underlineSelectionBackground #d3d3d3  HSL   0   0  83    com.formdev.flatlaf.util.DerivedColor [UI]    darken(10% autoInverse)
+MenuItem.underlineSelectionCheckBackground #aed2ff  HSL 213 100  84    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(40%)
+MenuItem.underlineSelectionColor #007aff  HSL 211 100  50    javax.swing.plaf.ColorUIResource [UI]
+MenuItem.underlineSelectionHeight 3
+MenuItem.verticallyAlignText   true
+MenuItemUI                     com.formdev.flatlaf.ui.FlatMenuItemUI
+
+
+#---- Menu ----
+
+MenuUI                         com.formdev.flatlaf.ui.FlatMenuUI
+
+
+#---- MonthView ----
+
+MonthViewUI                    com.formdev.flatlaf.swingx.ui.FlatMonthViewUI
+
+
+#---- Objects ----
+
+Objects.BlackText              #231f20  HSL 345   6  13    javax.swing.plaf.ColorUIResource [UI]
+Objects.Blue                   #40b6e0  HSL 196  72  56    javax.swing.plaf.ColorUIResource [UI]
+Objects.Green                  #62b543  HSL 104  46  49    javax.swing.plaf.ColorUIResource [UI]
+Objects.GreenAndroid           #a4c639  HSL  74  55  50    javax.swing.plaf.ColorUIResource [UI]
+Objects.Grey                   #9aa7b0  HSL 205  12  65    javax.swing.plaf.ColorUIResource [UI]
+Objects.Pink                   #f98b9e  HSL 350  90  76    javax.swing.plaf.ColorUIResource [UI]
+Objects.Purple                 #b99bf8  HSL 259  87  79    javax.swing.plaf.ColorUIResource [UI]
+Objects.Red                    #f26522  HSL  19  89  54    javax.swing.plaf.ColorUIResource [UI]
+Objects.RedStatus              #e05555  HSL   0  69  61    javax.swing.plaf.ColorUIResource [UI]
+Objects.Yellow                 #f4af3d  HSL  37  89  60    javax.swing.plaf.ColorUIResource [UI]
+Objects.YellowDark             #d9a343  HSL  38  66  56    javax.swing.plaf.ColorUIResource [UI]
+
+
+#---- OptionPane ----
+
+OptionPane.background          #f6f6f6  HSL   0   0  96    javax.swing.plaf.ColorUIResource [UI]
+OptionPane.border              [lazy] 12,12,12,12  false    com.formdev.flatlaf.ui.FlatEmptyBorder [UI]
+OptionPane.buttonAreaBorder    [lazy] 12,0,0,0  false    com.formdev.flatlaf.ui.FlatEmptyBorder [UI]
+OptionPane.buttonClickThreshhold 500
+OptionPane.buttonMinimumWidth  [active] 72
+OptionPane.buttonOrientation   4
+OptionPane.buttonPadding       8
+OptionPane.errorIcon           [lazy] 32,32    com.formdev.flatlaf.icons.FlatOptionPaneErrorIcon [UI]
+OptionPane.font                [active] $defaultFont [UI]
+OptionPane.foreground          #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
+OptionPane.iconMessageGap      16
+OptionPane.informationIcon     [lazy] 32,32    com.formdev.flatlaf.icons.FlatOptionPaneInformationIcon [UI]
+OptionPane.maxCharactersPerLine 80
+OptionPane.messageAreaBorder   [lazy] 0,0,0,0  false    com.formdev.flatlaf.ui.FlatEmptyBorder [UI]
+OptionPane.messagePadding      3
+OptionPane.minimumSize         262,90    javax.swing.plaf.DimensionUIResource [UI]
+OptionPane.questionIcon        [lazy] 32,32    com.formdev.flatlaf.icons.FlatOptionPaneQuestionIcon [UI]
+OptionPane.sameSizeButtons     true
+OptionPane.setButtonMargin     false
+OptionPane.showIcon            false
+OptionPane.warningIcon         [lazy] 32,32    com.formdev.flatlaf.icons.FlatOptionPaneWarningIcon [UI]
+OptionPane.windowBindings      length=2    [Ljava.lang.Object;
+    [0] ESCAPE
+    [1] close
+OptionPaneUI                   com.formdev.flatlaf.ui.FlatOptionPaneUI
+
+
+#---- Panel ----
+
+Panel.background               #f6f6f6  HSL   0   0  96    javax.swing.plaf.ColorUIResource [UI]
+Panel.font                     [active] $defaultFont [UI]
+Panel.foreground               #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
+PanelUI                        com.formdev.flatlaf.ui.FlatPanelUI
+
+
+#---- PasswordField ----
+
+PasswordField.background       #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+PasswordField.border           [lazy] 3,3,3,3  false    com.formdev.flatlaf.ui.FlatTextBorder [UI]
+PasswordField.capsLockIcon     [lazy] 16,16    com.formdev.flatlaf.icons.FlatCapsLockIcon [UI]
+PasswordField.capsLockIconColor #00000064  39%  HSLA   0   0   0 39    javax.swing.plaf.ColorUIResource [UI]
+PasswordField.caretBlinkRate   500
+PasswordField.caretForeground  #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
+PasswordField.disabledBackground #fafafa  HSL   0   0  98    javax.swing.plaf.ColorUIResource [UI]
+PasswordField.echoChar         '\u2022'
+PasswordField.font             [active] $defaultFont [UI]
+PasswordField.foreground       #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
+PasswordField.iconTextGap      4
+PasswordField.inactiveBackground #f6f6f6  HSL   0   0  96    javax.swing.plaf.ColorUIResource [UI]
+PasswordField.inactiveForeground #b6b6b6  HSL   0   0  71    javax.swing.plaf.ColorUIResource [UI]
+PasswordField.margin           2,6,2,6    javax.swing.plaf.InsetsUIResource [UI]
+PasswordField.placeholderForeground #b6b6b6  HSL   0   0  71    javax.swing.plaf.ColorUIResource [UI]
+PasswordField.revealIcon       [lazy] 16,16    com.formdev.flatlaf.icons.FlatRevealIcon [UI]
+PasswordField.revealIconColor  #7d7d7d  HSL   0   0  49    javax.swing.plaf.ColorUIResource [UI]
+PasswordField.selectionBackground #b3d7ff  HSL 212 100  85    javax.swing.plaf.ColorUIResource [UI]
+PasswordField.selectionForeground #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
+PasswordField.showCapsLock     true
+PasswordField.showRevealButton false
+PasswordFieldUI                com.formdev.flatlaf.ui.FlatPasswordFieldUI
+
+
+#---- Popup ----
+
+Popup.dropShadowColor          #000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]
+Popup.dropShadowInsets         -4,-4,4,4    javax.swing.plaf.InsetsUIResource [UI]
+Popup.dropShadowOpacity        0.15
+Popup.dropShadowPainted        true
+
+
+#---- PopupMenu ----
+
+PopupMenu.background           #ececec  HSL   0   0  93    javax.swing.plaf.ColorUIResource [UI]
+PopupMenu.border               [lazy] 4,1,4,1  false    com.formdev.flatlaf.ui.FlatPopupMenuBorder [UI]    lineColor=#b1b1b1  HSL   0   0  69    javax.swing.plaf.ColorUIResource [UI]    lineThickness=1.000000
+PopupMenu.borderColor          #b1b1b1  HSL   0   0  69    javax.swing.plaf.ColorUIResource [UI]
+PopupMenu.borderInsets         4,1,4,1    javax.swing.plaf.InsetsUIResource [UI]
+PopupMenu.consumeEventOnClose  false
+PopupMenu.font                 [active] $defaultFont [UI]
+PopupMenu.foreground           #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
+PopupMenu.hoverScrollArrowBackground #e9e9e9  HSL   0   0  91    javax.swing.plaf.ColorUIResource [UI]
+PopupMenu.scrollArrowColor     #7d7d7d  HSL   0   0  49    javax.swing.plaf.ColorUIResource [UI]
+
+
+#---- PopupMenuSeparator ----
+
+PopupMenuSeparator.height      9
+PopupMenuSeparator.stripeIndent 4
+PopupMenuSeparator.stripeWidth 1
+PopupMenuSeparatorUI           com.formdev.flatlaf.ui.FlatPopupMenuSeparatorUI
+
+
+#---- PopupMenu ----
+
+PopupMenuUI                    com.formdev.flatlaf.ui.FlatPopupMenuUI
+
+
+#---- ProgressBar ----
+
+ProgressBar.arc                4
+ProgressBar.background         #e9e9e9  HSL   0   0  91    javax.swing.plaf.ColorUIResource [UI]
+ProgressBar.border             [lazy] 0,0,0,0  false    com.formdev.flatlaf.ui.FlatEmptyBorder [UI]
+ProgressBar.cellLength         1
+ProgressBar.cellSpacing        0
+ProgressBar.cycleTime          4000
+ProgressBar.font               [active] Segoe UI plain 10    javax.swing.plaf.FontUIResource [UI]
+ProgressBar.foreground         #007aff  HSL 211 100  50    javax.swing.plaf.ColorUIResource [UI]
+ProgressBar.horizontalSize     146,4    javax.swing.plaf.DimensionUIResource [UI]
+ProgressBar.repaintInterval    15
+ProgressBar.selectionBackground #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
+ProgressBar.selectionForeground #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+ProgressBar.verticalSize       4,146    javax.swing.plaf.DimensionUIResource [UI]
+ProgressBarUI                  com.formdev.flatlaf.ui.FlatProgressBarUI
+
+
+#---- RadioButton ----
+
+RadioButton.background         #f6f6f6  HSL   0   0  96    javax.swing.plaf.ColorUIResource [UI]
+RadioButton.border             [lazy] 0,0,0,0  false    com.formdev.flatlaf.ui.FlatMarginBorder [UI]
+RadioButton.darkShadow         #00000026  15%  HSLA   0   0   0 15    javax.swing.plaf.ColorUIResource [UI]
+RadioButton.disabledText       #b6b6b6  HSL   0   0  71    javax.swing.plaf.ColorUIResource [UI]
+RadioButton.font               [active] $defaultFont [UI]
+RadioButton.foreground         #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
+RadioButton.highlight          #40404026  15%  HSLA   0   0  25 15    javax.swing.plaf.ColorUIResource [UI]
+RadioButton.icon.centerDiameter 8
+RadioButton.icon.style         filled
+RadioButton.icon               [lazy] 15,15    com.formdev.flatlaf.icons.FlatRadioButtonIcon [UI]
+RadioButton.iconTextGap        6
+RadioButton.icon[filled].centerDiameter 6
+RadioButton.light              #1f1f1f26  15%  HSLA   0   0  12 15    javax.swing.plaf.ColorUIResource [UI]
+RadioButton.margin             2,2,2,2    javax.swing.plaf.InsetsUIResource [UI]
+RadioButton.rollover           true
+RadioButton.shadow             #00000026  15%  HSLA   0   0   0 15    javax.swing.plaf.ColorUIResource [UI]
+RadioButton.textIconGap        4
+RadioButton.textShiftOffset    0
+
+
+#---- RadioButtonMenuItem ----
+
+RadioButtonMenuItem.acceleratorFont [active] $defaultFont [UI]
+RadioButtonMenuItem.acceleratorForeground #737373  HSL   0   0  45    javax.swing.plaf.ColorUIResource [UI]
+RadioButtonMenuItem.acceleratorSelectionForeground #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+RadioButtonMenuItem.arrowIcon  [lazy] 6,10    com.formdev.flatlaf.icons.FlatMenuItemArrowIcon [UI]
+RadioButtonMenuItem.background #ececec  HSL   0   0  93    javax.swing.plaf.ColorUIResource [UI]
+RadioButtonMenuItem.border     [lazy] 0,0,0,0  false    com.formdev.flatlaf.ui.FlatMenuItemBorder [UI]
+RadioButtonMenuItem.borderPainted true
+RadioButtonMenuItem.checkIcon  [lazy] 15,15    com.formdev.flatlaf.icons.FlatRadioButtonMenuItemIcon [UI]
+RadioButtonMenuItem.disabledForeground #b6b6b6  HSL   0   0  71    javax.swing.plaf.ColorUIResource [UI]
+RadioButtonMenuItem.font       [active] $defaultFont [UI]
+RadioButtonMenuItem.foreground #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
+RadioButtonMenuItem.margin     3,6,3,6    javax.swing.plaf.InsetsUIResource [UI]
+RadioButtonMenuItem.opaque     false
+RadioButtonMenuItem.selectionBackground #0063e1  HSL 214 100  44    javax.swing.plaf.ColorUIResource [UI]
+RadioButtonMenuItem.selectionForeground #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+RadioButtonMenuItemUI          com.formdev.flatlaf.ui.FlatRadioButtonMenuItemUI
+
+
+#---- RadioButton ----
+
+RadioButtonUI                  com.formdev.flatlaf.ui.FlatRadioButtonUI
+
+
+#---- RangeSlider ----
+
+RangeSliderUI                  com.formdev.flatlaf.jideoss.ui.FlatRangeSliderUI
+
+
+#---- Resizable ----
+
+Resizable.resizeBorder         [lazy] 4,4,4,4  false    com.formdev.flatlaf.ui.FlatLineBorder [UI]    lineColor=#b1b1b1  HSL   0   0  69    javax.swing.plaf.ColorUIResource [UI]    lineThickness=1.000000
+
+
+#---- RootPane ----
+
+RootPane.activeBorderColor     #777777  HSL   0   0  47    com.formdev.flatlaf.util.DerivedColor [UI]    darken(50% autoInverse)
+RootPane.background            #f6f6f6  HSL   0   0  96    javax.swing.plaf.ColorUIResource [UI]
+RootPane.border                [lazy] 1,1,1,1  false    com.formdev.flatlaf.ui.FlatRootPaneUI$FlatWindowBorder [UI]
+RootPane.borderDragThickness   5
+RootPane.cornerDragWidth       16
+RootPane.defaultButtonWindowKeyBindings length=8    [Ljava.lang.Object;
+    [0] ENTER
+    [1] press
+    [2] released ENTER
+    [3] release
+    [4] ctrl ENTER
+    [5] press
+    [6] ctrl released ENTER
+    [7] release
+RootPane.font                  [active] $defaultFont [UI]
+RootPane.foreground            #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
+RootPane.honorDialogMinimumSizeOnResize true
+RootPane.honorFrameMinimumSizeOnResize false
+RootPane.inactiveBorderColor   #aaaaaa  HSL   0   0  67    com.formdev.flatlaf.util.DerivedColor [UI]    darken(30% autoInverse)
+RootPaneUI                     com.formdev.flatlaf.ui.FlatRootPaneUI
+
+
+#---- ScrollBar ----
+
+ScrollBar.allowsAbsolutePositioning true
+ScrollBar.background           #f6f6f6  HSL   0   0  96    javax.swing.plaf.ColorUIResource [UI]
+ScrollBar.buttonArrowColor     #7d7d7d  HSL   0   0  49    javax.swing.plaf.ColorUIResource [UI]
+ScrollBar.buttonDisabledArrowColor #bdbdbd  HSL   0   0  74    javax.swing.plaf.ColorUIResource [UI]
+ScrollBar.foreground           #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
+ScrollBar.hoverButtonBackground #e9e9e9  HSL   0   0  91    com.formdev.flatlaf.util.DerivedColor [UI]    darken(5%)
+ScrollBar.hoverThumbColor      #a9a9a9  HSL   0   0  66    com.formdev.flatlaf.util.DerivedColor [UI]    darken(10%)
+ScrollBar.hoverThumbWithTrack  false
+ScrollBar.hoverTrackColor      #f2f2f2  HSL   0   0  95    com.formdev.flatlaf.util.DerivedColor [UI]    darken(3%)
+ScrollBar.maximumThumbSize     100000,100000    javax.swing.plaf.DimensionUIResource [UI]
+ScrollBar.minimumButtonSize    12,12    javax.swing.plaf.DimensionUIResource [UI]
+ScrollBar.minimumThumbSize     10,10    javax.swing.plaf.DimensionUIResource [UI]
+ScrollBar.pressedButtonBackground #dddddd  HSL   0   0  87    com.formdev.flatlaf.util.DerivedColor [UI]    darken(10%)
+ScrollBar.pressedThumbColor    #8f8f8f  HSL   0   0  56    com.formdev.flatlaf.util.DerivedColor [UI]    darken(20%)
+ScrollBar.pressedThumbWithTrack false
+ScrollBar.showButtons          false
+ScrollBar.squareButtons        false
+ScrollBar.thumb                #c2c2c2  HSL   0   0  76    javax.swing.plaf.ColorUIResource [UI]
+ScrollBar.thumbArc             0
+ScrollBar.thumbDarkShadow      #00000026  15%  HSLA   0   0   0 15    javax.swing.plaf.ColorUIResource [UI]
+ScrollBar.thumbHighlight       #40404026  15%  HSLA   0   0  25 15    javax.swing.plaf.ColorUIResource [UI]
+ScrollBar.thumbInsets          0,0,0,0    javax.swing.plaf.InsetsUIResource [UI]
+ScrollBar.thumbShadow          #00000026  15%  HSLA   0   0   0 15    javax.swing.plaf.ColorUIResource [UI]
+ScrollBar.track                #fafafa  HSL   0   0  98    javax.swing.plaf.ColorUIResource [UI]
+ScrollBar.trackArc             0
+ScrollBar.trackHighlight       #00000026  15%  HSLA   0   0   0 15    javax.swing.plaf.ColorUIResource [UI]
+ScrollBar.trackInsets          0,0,0,0    javax.swing.plaf.InsetsUIResource [UI]
+ScrollBar.width                12
+ScrollBarUI                    com.formdev.flatlaf.ui.FlatScrollBarUI
+
+
+#---- ScrollPane ----
+
+ScrollPane.background          #fafafa  HSL   0   0  98    javax.swing.plaf.ColorUIResource [UI]
+ScrollPane.border              [lazy] 3,3,3,3  false    com.formdev.flatlaf.ui.FlatBorder [UI]
+ScrollPane.fillUpperCorner     true
+ScrollPane.font                [active] $defaultFont [UI]
+ScrollPane.foreground          #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
+ScrollPane.smoothScrolling     true
+ScrollPaneUI                   com.formdev.flatlaf.ui.FlatScrollPaneUI
+
+
+#---- SearchField ----
+
+SearchField.clearIcon          [lazy] 16,16    com.formdev.flatlaf.icons.FlatClearIcon [UI]
+SearchField.clearIconColor     [lazy] #7f8b9180  50%  HSLA 200   8  53 50    javax.swing.plaf.ColorUIResource [UI]
+SearchField.clearIconHoverColor [lazy] #7f8b9180  50%  HSLA 200   8  53 50    javax.swing.plaf.ColorUIResource [UI]
+SearchField.clearIconPressedColor [lazy] #7f8b91cc  80%  HSLA 200   8  53 80    javax.swing.plaf.ColorUIResource [UI]
+SearchField.clearPressedIcon   [lazy] 16,16    com.formdev.flatlaf.icons.FlatClearIcon [UI]
+SearchField.clearRolloverIcon  [lazy] 16,16    com.formdev.flatlaf.icons.FlatClearIcon [UI]
+SearchField.icon               [lazy] 16,16    com.formdev.flatlaf.icons.FlatSearchIcon [UI]
+SearchField.popupIcon          [lazy] 16,16    com.formdev.flatlaf.icons.FlatSearchWithHistoryIcon [UI]
+SearchField.popupPressedIcon   [lazy] 16,16    com.formdev.flatlaf.icons.FlatSearchWithHistoryIcon [UI]
+SearchField.popupRolloverIcon  [lazy] 16,16    com.formdev.flatlaf.icons.FlatSearchWithHistoryIcon [UI]
+SearchField.pressedIcon        [lazy] 16,16    com.formdev.flatlaf.icons.FlatSearchIcon [UI]
+SearchField.rolloverIcon       [lazy] 16,16    com.formdev.flatlaf.icons.FlatSearchIcon [UI]
+SearchField.searchIconColor    [lazy] #7f8b91e6  90%  HSLA 200   8  53 90    javax.swing.plaf.ColorUIResource [UI]
+SearchField.searchIconHoverColor [lazy] #7f8b91b3  70%  HSLA 200   8  53 70    javax.swing.plaf.ColorUIResource [UI]
+SearchField.searchIconPressedColor [lazy] #7f8b9180  50%  HSLA 200   8  53 50    javax.swing.plaf.ColorUIResource [UI]
+
+
+#---- Separator ----
+
+Separator.background           #f6f6f6  HSL   0   0  96    javax.swing.plaf.ColorUIResource [UI]
+Separator.foreground           #00000019  10%  HSLA   0   0   0 10    javax.swing.plaf.ColorUIResource [UI]
+Separator.height               3
+Separator.highlight            #40404026  15%  HSLA   0   0  25 15    javax.swing.plaf.ColorUIResource [UI]
+Separator.shadow               #00000026  15%  HSLA   0   0   0 15    javax.swing.plaf.ColorUIResource [UI]
+Separator.stripeIndent         1
+Separator.stripeWidth          1
+SeparatorUI                    com.formdev.flatlaf.ui.FlatSeparatorUI
+
+
+#---- Slider ----
+
+Slider.background              #f6f6f6  HSL   0   0  96    javax.swing.plaf.ColorUIResource [UI]
+Slider.disabledThumbColor      #f7f7f7  HSL   0   0  97    javax.swing.plaf.ColorUIResource [UI]
+Slider.disabledTrackColor      #ececec  HSL   0   0  93    javax.swing.plaf.ColorUIResource [UI]
+Slider.focus                   #00000026  15%  HSLA   0   0   0 15    javax.swing.plaf.ColorUIResource [UI]
+Slider.focusInsets             0,0,0,0    javax.swing.plaf.InsetsUIResource [UI]
+Slider.focusWidth              4
+Slider.focusedColor            #80b5ff80  50%  HSLA 215 100  75 50    com.formdev.flatlaf.util.DerivedColor [UI]    changeLightness(75%) fade(50%)
+Slider.font                    [active] $defaultFont [UI]
+Slider.foreground              #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
+Slider.highlight               #40404026  15%  HSLA   0   0  25 15    javax.swing.plaf.ColorUIResource [UI]
+Slider.horizontalSize          200,21    java.awt.Dimension
+Slider.hoverThumbColor         #f2f2f2  HSL   0   0  95    com.formdev.flatlaf.util.DerivedColor [UI]    darken(5% autoInverse)
+Slider.minimumHorizontalSize   36,21    java.awt.Dimension
+Slider.minimumVerticalSize     21,36    java.awt.Dimension
+Slider.onlyLeftMouseButtonDrag true
+Slider.pressedThumbColor       #ebebeb  HSL   0   0  92    com.formdev.flatlaf.util.DerivedColor [UI]    darken(8% autoInverse)
+Slider.shadow                  #00000026  15%  HSLA   0   0   0 15    javax.swing.plaf.ColorUIResource [UI]
+Slider.thumbBorderColor        #00000026  15%  HSLA   0   0   0 15    javax.swing.plaf.ColorUIResource [UI]
+Slider.thumbColor              #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+Slider.thumbSize               14,14    javax.swing.plaf.DimensionUIResource [UI]
+Slider.tickColor               #b6b6b6  HSL   0   0  71    javax.swing.plaf.ColorUIResource [UI]
+Slider.trackColor              #e4e4e4  HSL   0   0  89    javax.swing.plaf.ColorUIResource [UI]
+Slider.trackValueColor         #007aff  HSL 211 100  50    javax.swing.plaf.ColorUIResource [UI]
+Slider.trackWidth              3
+Slider.verticalSize            21,200    java.awt.Dimension
+SliderUI                       com.formdev.flatlaf.ui.FlatSliderUI
+
+
+#---- Spinner ----
+
+Spinner.arrowButtonSize        16,5    java.awt.Dimension
+Spinner.background             #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+Spinner.border                 [lazy] 3,3,3,3  false    com.formdev.flatlaf.ui.FlatRoundBorder [UI]
+Spinner.buttonArrowColor       #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
+Spinner.buttonBackground       #fafafa  HSL   0   0  98    javax.swing.plaf.ColorUIResource [UI]
+Spinner.buttonDisabledArrowColor #bdbdbd  HSL   0   0  74    javax.swing.plaf.ColorUIResource [UI]
+Spinner.buttonDisabledSeparatorColor #00000019  10%  HSLA   0   0   0 10    javax.swing.plaf.ColorUIResource [UI]
+Spinner.buttonHoverArrowColor  #595959  HSL   0   0  35    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(20%)
+Spinner.buttonPressedArrowColor #737373  HSL   0   0  45    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(30%)
+Spinner.buttonSeparatorColor   #00000026  15%  HSLA   0   0   0 15    javax.swing.plaf.ColorUIResource [UI]
+Spinner.buttonStyle            mac
+Spinner.disabledBackground     #fafafa  HSL   0   0  98    javax.swing.plaf.ColorUIResource [UI]
+Spinner.disabledForeground     #b6b6b6  HSL   0   0  71    javax.swing.plaf.ColorUIResource [UI]
+Spinner.editorAlignment        11
+Spinner.editorBorderPainted    false
+Spinner.font                   [active] $defaultFont [UI]
+Spinner.foreground             #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
+Spinner.padding                2,6,2,6    javax.swing.plaf.InsetsUIResource [UI]
+SpinnerUI                      com.formdev.flatlaf.ui.FlatSpinnerUI
+
+
+#---- SplitPane ----
+
+SplitPane.background           #f6f6f6  HSL   0   0  96    javax.swing.plaf.ColorUIResource [UI]
+SplitPane.centerOneTouchButtons true
+SplitPane.continuousLayout     true
+SplitPane.darkShadow           #00000026  15%  HSLA   0   0   0 15    javax.swing.plaf.ColorUIResource [UI]
+SplitPane.dividerSize          5
+SplitPane.highlight            #40404026  15%  HSLA   0   0  25 15    javax.swing.plaf.ColorUIResource [UI]
+SplitPane.oneTouchButtonOffset [active] 2
+SplitPane.oneTouchButtonSize   [active] 6
+SplitPane.shadow               #00000026  15%  HSLA   0   0   0 15    javax.swing.plaf.ColorUIResource [UI]
+
+
+#---- SplitPaneDivider ----
+
+SplitPaneDivider.draggingColor #00000026  15%  HSLA   0   0   0 15    javax.swing.plaf.ColorUIResource [UI]
+SplitPaneDivider.gripColor     #b4b4b4  HSL   0   0  71    javax.swing.plaf.ColorUIResource [UI]
+SplitPaneDivider.gripDotCount  3
+SplitPaneDivider.gripDotSize   3
+SplitPaneDivider.gripGap       2
+SplitPaneDivider.oneTouchArrowColor #7d7d7d  HSL   0   0  49    javax.swing.plaf.ColorUIResource [UI]
+SplitPaneDivider.oneTouchHoverArrowColor #b0b0b0  HSL   0   0  69    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(20%)
+SplitPaneDivider.oneTouchPressedArrowColor #cacaca  HSL   0   0  79    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(30%)
+SplitPaneDivider.style         grip
+
+
+#---- SplitPane ----
+
+SplitPaneUI                    com.formdev.flatlaf.ui.FlatSplitPaneUI
+
+
+#---- TabbedPane ----
+
+TabbedPane.arrowType           chevron
+TabbedPane.background          #f6f6f6  HSL   0   0  96    javax.swing.plaf.ColorUIResource [UI]
+TabbedPane.buttonArc           12
+TabbedPane.buttonHoverBackground #e4e4e4  HSL   0   0  89    com.formdev.flatlaf.util.DerivedColor [UI]    darken(7% autoInverse)
+TabbedPane.buttonInsets        2,1,2,1    javax.swing.plaf.InsetsUIResource [UI]
+TabbedPane.buttonPressedBackground #dddddd  HSL   0   0  87    com.formdev.flatlaf.util.DerivedColor [UI]    darken(10% autoInverse)
+TabbedPane.cardTabSelectionHeight 2
+TabbedPane.closeArc            4
+TabbedPane.closeCrossFilledSize 7.5
+TabbedPane.closeCrossLineWidth 1
+TabbedPane.closeCrossPlainSize 7.5
+TabbedPane.closeForeground     #b6b6b6  HSL   0   0  71    javax.swing.plaf.ColorUIResource [UI]
+TabbedPane.closeHoverBackground #c3c3c3  HSL   0   0  76    com.formdev.flatlaf.util.DerivedColor [UI]    darken(20% autoInverse)
+TabbedPane.closeHoverForeground #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
+TabbedPane.closeIcon           [lazy] 16,16    com.formdev.flatlaf.icons.FlatTabbedPaneCloseIcon [UI]
+TabbedPane.closePressedBackground #b6b6b6  HSL   0   0  71    com.formdev.flatlaf.util.DerivedColor [UI]    darken(25% autoInverse)
+TabbedPane.closePressedForeground #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
+TabbedPane.closeSize           16,16    javax.swing.plaf.DimensionUIResource [UI]
+TabbedPane.contentAreaColor    #00000026  15%  HSLA   0   0   0 15    javax.swing.plaf.ColorUIResource [UI]
+TabbedPane.contentOpaque       true
+TabbedPane.contentSeparatorHeight 1
+TabbedPane.darkShadow          #00000026  15%  HSLA   0   0   0 15    javax.swing.plaf.ColorUIResource [UI]
+TabbedPane.disabledForeground  #b6b6b6  HSL   0   0  71    javax.swing.plaf.ColorUIResource [UI]
+TabbedPane.disabledUnderlineColor #afafaf  HSL   0   0  69    javax.swing.plaf.ColorUIResource [UI]
+TabbedPane.focus               #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
+TabbedPane.focusColor          #dde7f4  HSL 214  51  91    javax.swing.plaf.ColorUIResource [UI]
+TabbedPane.font                [active] $defaultFont [UI]
+TabbedPane.foreground          #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
+TabbedPane.hasFullBorder       false
+TabbedPane.hiddenTabsNavigation moreTabsButton
+TabbedPane.highlight           #40404026  15%  HSLA   0   0  25 15    javax.swing.plaf.ColorUIResource [UI]
+TabbedPane.hoverColor          #e4e4e4  HSL   0   0  89    com.formdev.flatlaf.util.DerivedColor [UI]    darken(7% autoInverse)
+TabbedPane.inactiveUnderlineColor #7bb8fb  HSL 211  94  73    javax.swing.plaf.ColorUIResource [UI]
+TabbedPane.labelShift          1
+TabbedPane.light               #1f1f1f26  15%  HSLA   0   0  12 15    javax.swing.plaf.ColorUIResource [UI]
+TabbedPane.scrollButtonsPlacement both
+TabbedPane.scrollButtonsPolicy asNeededSingle
+TabbedPane.selectedLabelShift  -1
+TabbedPane.selectedTabPadInsets 0,0,0,0    javax.swing.plaf.InsetsUIResource [UI]
+TabbedPane.selectionFollowsFocus true
+TabbedPane.shadow              #f6f6f6  HSL   0   0  96    javax.swing.plaf.ColorUIResource [UI]
+TabbedPane.showTabSeparators   false
+TabbedPane.tabAlignment        center
+TabbedPane.tabAreaAlignment    leading
+TabbedPane.tabAreaInsets       0,0,0,0    javax.swing.plaf.InsetsUIResource [UI]
+TabbedPane.tabHeight           32
+TabbedPane.tabInsets           4,12,4,12    javax.swing.plaf.InsetsUIResource [UI]
+TabbedPane.tabRunOverlay       0
+TabbedPane.tabSelectionHeight  3
+TabbedPane.tabSeparatorsFullHeight false
+TabbedPane.tabType             underlined
+TabbedPane.tabWidthMode        preferred
+TabbedPane.tabsOpaque          true
+TabbedPane.tabsOverlapBorder   false
+TabbedPane.tabsPopupPolicy     asNeeded
+TabbedPane.textIconGap         4
+TabbedPane.underlineColor      #007aff  HSL 211 100  50    javax.swing.plaf.ColorUIResource [UI]
+TabbedPaneUI                   com.formdev.flatlaf.ui.FlatTabbedPaneUI
+
+
+#---- Table ----
+
+Table.ascendingSortIcon        [lazy] 10,5    com.formdev.flatlaf.icons.FlatAscendingSortIcon [UI]
+Table.background               #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+Table.cellFocusColor           #000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]
+Table.cellMargins              2,3,2,3    javax.swing.plaf.InsetsUIResource [UI]
+Table.cellNoFocusBorder        [lazy] 2,3,2,3  false    com.formdev.flatlaf.ui.FlatTableCellBorder$Default [UI]    lineColor=#000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]    lineThickness=1.000000
+Table.consistentHomeEndKeyBehavior true
+Table.descendingSortIcon       [lazy] 10,5    com.formdev.flatlaf.icons.FlatDescendingSortIcon [UI]
+Table.dropCellBackground       [lazy] #157cff  HSL 214 100  54    javax.swing.plaf.ColorUIResource [UI]
+Table.dropCellForeground       [lazy] #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+Table.dropLineColor            [lazy] #4899ff  HSL 213 100  64    javax.swing.plaf.ColorUIResource [UI]
+Table.dropLineShortColor       [lazy] #00367b  HSL 214 100  24    javax.swing.plaf.ColorUIResource [UI]
+Table.focusCellBackground      #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+Table.focusCellForeground      #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
+Table.focusCellHighlightBorder [lazy] 2,3,2,3  false    com.formdev.flatlaf.ui.FlatTableCellBorder$Focused [UI]    lineColor=#000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]    lineThickness=1.000000
+Table.focusSelectedCellHighlightBorder [lazy] 2,3,2,3  false    com.formdev.flatlaf.ui.FlatTableCellBorder$Selected [UI]    lineColor=#000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]    lineThickness=1.000000
+Table.font                     [active] $defaultFont [UI]
+Table.foreground               #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
+Table.gridColor                #ebebeb  HSL   0   0  92    javax.swing.plaf.ColorUIResource [UI]
+Table.intercellSpacing         0,0    javax.swing.plaf.DimensionUIResource [UI]
+Table.rowHeight                20
+Table.scrollPaneBorder         [lazy] 3,3,3,3  false    com.formdev.flatlaf.ui.FlatBorder [UI]
+Table.selectionBackground      #0063e1  HSL 214 100  44    javax.swing.plaf.ColorUIResource [UI]
+Table.selectionForeground      #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+Table.selectionInactiveBackground #dcdcdc  HSL   0   0  86    javax.swing.plaf.ColorUIResource [UI]
+Table.selectionInactiveForeground #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
+Table.showHorizontalLines      false
+Table.showTrailingVerticalLine false
+Table.showVerticalLines        false
+Table.sortIconColor            #b4b4b4  HSL   0   0  71    javax.swing.plaf.ColorUIResource [UI]
+
+
+#---- TableHeader ----
+
+TableHeader.background         #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+TableHeader.bottomSeparatorColor #e6e6e6  HSL   0   0  90    javax.swing.plaf.ColorUIResource [UI]
+TableHeader.cellBorder         [lazy] 2,3,2,3  false    com.formdev.flatlaf.ui.FlatTableHeaderBorder [UI]
+TableHeader.cellMargins        2,3,2,3    javax.swing.plaf.InsetsUIResource [UI]
+TableHeader.focusCellBackground #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+TableHeader.font               [active] $defaultFont [UI]
+TableHeader.foreground         #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
+TableHeader.height             25
+TableHeader.separatorColor     #e6e6e6  HSL   0   0  90    javax.swing.plaf.ColorUIResource [UI]
+TableHeader.showTrailingVerticalLine false
+TableHeaderUI                  com.formdev.flatlaf.ui.FlatTableHeaderUI
+
+
+#---- Table ----
+
+TableUI                        com.formdev.flatlaf.ui.FlatTableUI
+
+
+#---- TaskPane ----
+
+TaskPane.background            #f6f6f6  HSL   0   0  96    javax.swing.plaf.ColorUIResource [UI]
+TaskPane.borderColor           #00000026  15%  HSLA   0   0   0 15    javax.swing.plaf.ColorUIResource [UI]
+TaskPane.contentInsets         10,10,10,10    javax.swing.plaf.InsetsUIResource [UI]
+TaskPane.specialTitleBackground #afafaf  HSL   0   0  69    javax.swing.plaf.ColorUIResource [UI]
+TaskPane.specialTitleForeground #222222  HSL   0   0  13    javax.swing.plaf.ColorUIResource [UI]
+TaskPane.specialTitleOver      #666666  HSL   0   0  40    javax.swing.plaf.ColorUIResource [UI]
+TaskPane.titleBackgroundGradientStart #dfdfdf  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+TaskPane.titleForeground       #222222  HSL   0   0  13    javax.swing.plaf.ColorUIResource [UI]
+TaskPane.titleOver             #666666  HSL   0   0  40    javax.swing.plaf.ColorUIResource [UI]
+
+
+#---- TaskPaneContainer ----
+
+TaskPaneContainer.background   #e6ebf0  HSL 210  25  92    javax.swing.plaf.ColorUIResource [UI]
+TaskPaneContainer.border       [lazy] 10,10,10,10  false    com.formdev.flatlaf.ui.FlatEmptyBorder [UI]
+
+
+#---- TextArea ----
+
+TextArea.background            #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+TextArea.border                [lazy] 0,0,0,0  false    com.formdev.flatlaf.ui.FlatMarginBorder [UI]
+TextArea.caretBlinkRate        500
+TextArea.caretForeground       #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
+TextArea.disabledBackground    #fafafa  HSL   0   0  98    javax.swing.plaf.ColorUIResource [UI]
+TextArea.font                  [active] $defaultFont [UI]
+TextArea.foreground            #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
+TextArea.inactiveBackground    #f6f6f6  HSL   0   0  96    javax.swing.plaf.ColorUIResource [UI]
+TextArea.inactiveForeground    #b6b6b6  HSL   0   0  71    javax.swing.plaf.ColorUIResource [UI]
+TextArea.margin                2,6,2,6    javax.swing.plaf.InsetsUIResource [UI]
+TextArea.selectionBackground   #b3d7ff  HSL 212 100  85    javax.swing.plaf.ColorUIResource [UI]
+TextArea.selectionForeground   #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
+TextAreaUI                     com.formdev.flatlaf.ui.FlatTextAreaUI
+
+
+#---- TextComponent ----
+
+TextComponent.arc              0
+TextComponent.selectAllOnFocusPolicy once
+TextComponent.selectAllOnMouseClick false
+
+
+#---- TextField ----
+
+TextField.background           #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+TextField.border               [lazy] 3,3,3,3  false    com.formdev.flatlaf.ui.FlatTextBorder [UI]
+TextField.caretBlinkRate       500
+TextField.caretForeground      #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
+TextField.darkShadow           #00000026  15%  HSLA   0   0   0 15    javax.swing.plaf.ColorUIResource [UI]
+TextField.disabledBackground   #fafafa  HSL   0   0  98    javax.swing.plaf.ColorUIResource [UI]
+TextField.font                 [active] $defaultFont [UI]
+TextField.foreground           #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
+TextField.highlight            #40404026  15%  HSLA   0   0  25 15    javax.swing.plaf.ColorUIResource [UI]
+TextField.iconTextGap          4
+TextField.inactiveBackground   #f6f6f6  HSL   0   0  96    javax.swing.plaf.ColorUIResource [UI]
+TextField.inactiveForeground   #b6b6b6  HSL   0   0  71    javax.swing.plaf.ColorUIResource [UI]
+TextField.light                #1f1f1f26  15%  HSLA   0   0  12 15    javax.swing.plaf.ColorUIResource [UI]
+TextField.margin               2,6,2,6    javax.swing.plaf.InsetsUIResource [UI]
+TextField.placeholderForeground #b6b6b6  HSL   0   0  71    javax.swing.plaf.ColorUIResource [UI]
+TextField.selectionBackground  #b3d7ff  HSL 212 100  85    javax.swing.plaf.ColorUIResource [UI]
+TextField.selectionForeground  #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
+TextField.shadow               #00000026  15%  HSLA   0   0   0 15    javax.swing.plaf.ColorUIResource [UI]
+TextFieldUI                    com.formdev.flatlaf.ui.FlatTextFieldUI
+
+
+#---- TextPane ----
+
+TextPane.background            #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+TextPane.border                [lazy] 0,0,0,0  false    com.formdev.flatlaf.ui.FlatMarginBorder [UI]
+TextPane.caretBlinkRate        500
+TextPane.caretForeground       #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
+TextPane.disabledBackground    #fafafa  HSL   0   0  98    javax.swing.plaf.ColorUIResource [UI]
+TextPane.font                  [active] $defaultFont [UI]
+TextPane.foreground            #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
+TextPane.inactiveBackground    #f6f6f6  HSL   0   0  96    javax.swing.plaf.ColorUIResource [UI]
+TextPane.inactiveForeground    #b6b6b6  HSL   0   0  71    javax.swing.plaf.ColorUIResource [UI]
+TextPane.margin                2,6,2,6    javax.swing.plaf.InsetsUIResource [UI]
+TextPane.selectionBackground   #b3d7ff  HSL 212 100  85    javax.swing.plaf.ColorUIResource [UI]
+TextPane.selectionForeground   #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
+TextPaneUI                     com.formdev.flatlaf.ui.FlatTextPaneUI
+
+
+#---- TitlePane ----
+
+TitlePane.background           #ececec  HSL   0   0  93    javax.swing.plaf.ColorUIResource [UI]
+TitlePane.buttonHoverBackground #d3d3d3  HSL   0   0  83    com.formdev.flatlaf.util.DerivedColor [UI]    darken(10% autoInverse)
+TitlePane.buttonMaximizedHeight 22
+TitlePane.buttonPressedBackground #d8d8d8  HSL   0   0  85    com.formdev.flatlaf.util.DerivedColor [UI]    darken(8% autoInverse)
+TitlePane.buttonSize           44,30    javax.swing.plaf.DimensionUIResource [UI]
+TitlePane.centerTitle          false
+TitlePane.centerTitleIfMenuBarEmbedded true
+TitlePane.closeHoverBackground #c42b1c  HSL   5  75  44    javax.swing.plaf.ColorUIResource [UI]
+TitlePane.closeHoverForeground #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+TitlePane.closeIcon            [lazy] 44,30    com.formdev.flatlaf.icons.FlatWindowCloseIcon [UI]
+TitlePane.closePressedBackground #c42b1ce6  90%  HSLA   5  75  44 90    javax.swing.plaf.ColorUIResource [UI]
+TitlePane.closePressedForeground #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+TitlePane.embeddedForeground   #7f7f7f  HSL   0   0  50    javax.swing.plaf.ColorUIResource [UI]
+TitlePane.foreground           #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
+TitlePane.icon                 [lazy] 16,16    sun.swing.ImageIconUIResource [UI]  (sun.awt.image.ToolkitImage)
+TitlePane.iconMargins          3,8,3,8    javax.swing.plaf.InsetsUIResource [UI]
+TitlePane.iconSize             16,16    javax.swing.plaf.DimensionUIResource [UI]
+TitlePane.iconifyIcon          [lazy] 44,30    com.formdev.flatlaf.icons.FlatWindowIconifyIcon [UI]
+TitlePane.inactiveBackground   #ececec  HSL   0   0  93    javax.swing.plaf.ColorUIResource [UI]
+TitlePane.inactiveForeground   #b6b6b6  HSL   0   0  71    javax.swing.plaf.ColorUIResource [UI]
+TitlePane.maximizeIcon         [lazy] 44,30    com.formdev.flatlaf.icons.FlatWindowMaximizeIcon [UI]
+TitlePane.menuBarEmbedded      true
+TitlePane.menuBarTitleGap      20
+TitlePane.noIconLeftGap        8
+TitlePane.restoreIcon          [lazy] 44,30    com.formdev.flatlaf.icons.FlatWindowRestoreIcon [UI]
+TitlePane.showIcon             true
+TitlePane.titleMargins         3,0,3,0    javax.swing.plaf.InsetsUIResource [UI]
+TitlePane.unifiedBackground    true
+TitlePane.useWindowDecorations true
+
+
+#---- TitledBorder ----
+
+TitledBorder.border            [lazy] 1,1,1,1  false    com.formdev.flatlaf.ui.FlatLineBorder [UI]    lineColor=#00000019  10%  HSLA   0   0   0 10    javax.swing.plaf.ColorUIResource [UI]    lineThickness=1.000000
+TitledBorder.font              [active] $defaultFont [UI]
+TitledBorder.titleColor        #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
+
+
+#---- TitledPanel ----
+
+TitledPanelUI                  com.formdev.flatlaf.swingx.ui.FlatTitledPanelUI
+
+
+#---- ToggleButton ----
+
+ToggleButton.background        #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+ToggleButton.border            [lazy] 3,3,3,3  false    com.formdev.flatlaf.ui.FlatButtonBorder [UI]
+ToggleButton.darkShadow        #00000026  15%  HSLA   0   0   0 15    javax.swing.plaf.ColorUIResource [UI]
+ToggleButton.disabledBackground #fafafa  HSL   0   0  98    javax.swing.plaf.ColorUIResource [UI]
+ToggleButton.disabledSelectedBackground #dedede  HSL   0   0  87    com.formdev.flatlaf.util.DerivedColor [UI]    darken(13% autoInverse)
+ToggleButton.disabledText      #b6b6b6  HSL   0   0  71    javax.swing.plaf.ColorUIResource [UI]
+ToggleButton.font              [active] $defaultFont [UI]
+ToggleButton.foreground        #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
+ToggleButton.highlight         #40404026  15%  HSLA   0   0  25 15    javax.swing.plaf.ColorUIResource [UI]
+ToggleButton.iconTextGap       4
+ToggleButton.light             #1f1f1f26  15%  HSLA   0   0  12 15    javax.swing.plaf.ColorUIResource [UI]
+ToggleButton.margin            2,14,2,14    javax.swing.plaf.InsetsUIResource [UI]
+ToggleButton.pressedBackground #e6e6e6  HSL   0   0  90    com.formdev.flatlaf.util.DerivedColor [UI]    darken(10% autoInverse)
+ToggleButton.rollover          true
+ToggleButton.selectedBackground #cccccc  HSL   0   0  80    com.formdev.flatlaf.util.DerivedColor [UI]    darken(20% autoInverse)
+ToggleButton.selectedForeground #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
+ToggleButton.shadow            #00000026  15%  HSLA   0   0   0 15    javax.swing.plaf.ColorUIResource [UI]
+ToggleButton.tab.disabledUnderlineColor #afafaf  HSL   0   0  69    javax.swing.plaf.ColorUIResource [UI]
+ToggleButton.tab.focusBackground #dde7f4  HSL 214  51  91    javax.swing.plaf.ColorUIResource [UI]
+ToggleButton.tab.hoverBackground #e4e4e4  HSL   0   0  89    com.formdev.flatlaf.util.DerivedColor [UI]    darken(7% autoInverse)
+ToggleButton.tab.underlineColor #007aff  HSL 211 100  50    javax.swing.plaf.ColorUIResource [UI]
+ToggleButton.tab.underlineHeight 2
+ToggleButton.textIconGap       4
+ToggleButton.textShiftOffset   0
+ToggleButton.toolbar.hoverBackground #e0e0e0  HSL   0   0  88    com.formdev.flatlaf.util.DerivedColor [UI]    darken(12% autoInverse)
+ToggleButton.toolbar.pressedBackground #d9d9d9  HSL   0   0  85    com.formdev.flatlaf.util.DerivedColor [UI]    darken(15% autoInverse)
+ToggleButton.toolbar.selectedBackground #cccccc  HSL   0   0  80    com.formdev.flatlaf.util.DerivedColor [UI]    darken(20% autoInverse)
+ToggleButtonUI                 com.formdev.flatlaf.ui.FlatToggleButtonUI
+
+
+#---- ToolBar ----
+
+ToolBar.arrowKeysOnlyNavigation true
+ToolBar.background             #f6f6f6  HSL   0   0  96    javax.swing.plaf.ColorUIResource [UI]
+ToolBar.border                 [lazy] 2,2,2,2  false    com.formdev.flatlaf.ui.FlatToolBarBorder [UI]
+ToolBar.borderMargins          2,2,2,2    javax.swing.plaf.InsetsUIResource [UI]
+ToolBar.darkShadow             #00000026  15%  HSLA   0   0   0 15    javax.swing.plaf.ColorUIResource [UI]
+ToolBar.dockingBackground      #e9e9e9  HSL   0   0  91    javax.swing.plaf.ColorUIResource [UI]
+ToolBar.dockingForeground      #00000026  15%  HSLA   0   0   0 15    javax.swing.plaf.ColorUIResource [UI]
+ToolBar.floatable              false
+ToolBar.floatingBackground     #f6f6f6  HSL   0   0  96    javax.swing.plaf.ColorUIResource [UI]
+ToolBar.floatingForeground     #00000026  15%  HSLA   0   0   0 15    javax.swing.plaf.ColorUIResource [UI]
+ToolBar.focusableButtons       false
+ToolBar.font                   [active] $defaultFont [UI]
+ToolBar.foreground             #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
+ToolBar.gripColor              #b4b4b4  HSL   0   0  71    javax.swing.plaf.ColorUIResource [UI]
+ToolBar.highlight              #40404026  15%  HSLA   0   0  25 15    javax.swing.plaf.ColorUIResource [UI]
+ToolBar.isRollover             true
+ToolBar.light                  #1f1f1f26  15%  HSLA   0   0  12 15    javax.swing.plaf.ColorUIResource [UI]
+ToolBar.separatorColor         #00000019  10%  HSLA   0   0   0 10    javax.swing.plaf.ColorUIResource [UI]
+ToolBar.separatorWidth         7
+ToolBar.shadow                 #00000026  15%  HSLA   0   0   0 15    javax.swing.plaf.ColorUIResource [UI]
+ToolBar.spacingBorder          [lazy] 1,2,1,2  false    com.formdev.flatlaf.ui.FlatEmptyBorder [UI]
+
+
+#---- ToolBarSeparator ----
+
+ToolBarSeparatorUI             com.formdev.flatlaf.ui.FlatToolBarSeparatorUI
+
+
+#---- ToolBar ----
+
+ToolBarUI                      com.formdev.flatlaf.ui.FlatToolBarUI
+
+
+#---- ToolTip ----
+
+ToolTip.background             #fefefe  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+ToolTip.border                 [lazy] 4,6,4,6  false    com.formdev.flatlaf.ui.FlatLineBorder [UI]    lineColor=#949494  HSL   0   0  58    javax.swing.plaf.ColorUIResource [UI]    lineThickness=1.000000
+ToolTip.font                   [active] $defaultFont [UI]
+ToolTip.foreground             #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
+
+
+#---- ToolTipManager ----
+
+ToolTipManager.enableToolTipMode activeApplication
+
+
+#---- ToolTip ----
+
+ToolTipUI                      com.formdev.flatlaf.ui.FlatToolTipUI
+
+
+#---- Tree ----
+
+Tree.background                #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+Tree.border                    [lazy] 1,1,1,1  false    com.formdev.flatlaf.ui.FlatEmptyBorder [UI]
+Tree.changeSelectionWithFocus  true
+Tree.closedIcon                [lazy] 16,16    com.formdev.flatlaf.icons.FlatTreeClosedIcon [UI]
+Tree.collapsedIcon             [lazy] 11,11    com.formdev.flatlaf.icons.FlatTreeCollapsedIcon [UI]
+Tree.drawsFocusBorderAroundIcon false
+Tree.dropCellBackground        [lazy] #157cff  HSL 214 100  54    javax.swing.plaf.ColorUIResource [UI]
+Tree.dropCellForeground        [lazy] #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+Tree.dropLineColor             [lazy] #4899ff  HSL 213 100  64    javax.swing.plaf.ColorUIResource [UI]
+Tree.editorBorder              [lazy] 1,1,1,1  false    com.formdev.flatlaf.ui.FlatLineBorder [UI]    lineColor=#000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]    lineThickness=1.000000
+Tree.expandedIcon              [lazy] 11,11    com.formdev.flatlaf.icons.FlatTreeExpandedIcon [UI]
+Tree.font                      [active] $defaultFont [UI]
+Tree.foreground                #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
+Tree.hash                      #e6e6e6  HSL   0   0  90    javax.swing.plaf.ColorUIResource [UI]
+Tree.icon.closedColor          #b4b4b4  HSL   0   0  71    javax.swing.plaf.ColorUIResource [UI]
+Tree.icon.collapsedColor       #b4b4b4  HSL   0   0  71    javax.swing.plaf.ColorUIResource [UI]
+Tree.icon.expandedColor        #b4b4b4  HSL   0   0  71    javax.swing.plaf.ColorUIResource [UI]
+Tree.icon.leafColor            #b4b4b4  HSL   0   0  71    javax.swing.plaf.ColorUIResource [UI]
+Tree.icon.openColor            #b4b4b4  HSL   0   0  71    javax.swing.plaf.ColorUIResource [UI]
+Tree.leafIcon                  [lazy] 16,16    com.formdev.flatlaf.icons.FlatTreeLeafIcon [UI]
+Tree.leftChildIndent           7
+Tree.lineTypeDashed            false
+Tree.openIcon                  [lazy] 16,16    com.formdev.flatlaf.icons.FlatTreeOpenIcon [UI]
+Tree.paintLines                false
+Tree.rendererFillBackground    false
+Tree.rendererMargins           1,2,1,2    javax.swing.plaf.InsetsUIResource [UI]
+Tree.repaintWholeRow           true
+Tree.rightChildIndent          11
+Tree.rowHeight                 0
+Tree.scrollsOnExpand           true
+Tree.selectionBackground       #0063e1  HSL 214 100  44    javax.swing.plaf.ColorUIResource [UI]
+Tree.selectionBorderColor      #000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]
+Tree.selectionForeground       #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+Tree.selectionInactiveBackground #dcdcdc  HSL   0   0  86    javax.swing.plaf.ColorUIResource [UI]
+Tree.selectionInactiveForeground #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
+Tree.showCellFocusIndicator    false
+Tree.textBackground            #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+Tree.textForeground            #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
+Tree.timeFactor                1000
+Tree.wideSelection             true
+TreeUI                         com.formdev.flatlaf.ui.FlatTreeUI
+
+
+#---- TristateCheckBox ----
+
+TristateCheckBox.clearMixed.clientProperty length=2    [Ljava.lang.Object;
+    [0] JButton.selectedState
+    [1] null
+TristateCheckBox.setMixed.clientProperty length=2    [Ljava.lang.Object;
+    [0] JButton.selectedState
+    [1] indeterminate
+
+
+#---- UIColorHighlighter ----
+
+UIColorHighlighter.stripingBackground #f2f2f2  HSL   0   0  95    javax.swing.plaf.ColorUIResource [UI]
+
+
+#---- Viewport ----
+
+Viewport.background            #f6f6f6  HSL   0   0  96    javax.swing.plaf.ColorUIResource [UI]
+Viewport.font                  [active] $defaultFont [UI]
+Viewport.foreground            #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
+ViewportUI                     com.formdev.flatlaf.ui.FlatViewportUI
+
+
+#---- [style] ----
+
+[style].h00                    font: $h00.font
+[style].h0                     font: $h0.font
+[style].h1.regular             font: $h1.regular.font
+[style].h1                     font: $h1.font
+[style].h2.regular             font: $h2.regular.font
+[style].h2                     font: $h2.font
+[style].h3.regular             font: $h3.regular.font
+[style].h3                     font: $h3.font
+[style].h4                     font: $h4.font
+[style].large                  font: $large.font
+[style].light                  font: $light.font
+[style].medium                 font: $medium.font
+[style].mini                   font: $mini.font
+[style].monospaced             font: $monospaced.font
+[style].semibold               font: $semibold.font
+[style].small                  font: $small.font
+
+
+#---- [style]Button ----
+
+[style]Button.clearButton      icon: com.formdev.flatlaf.icons.FlatClearIcon; focusable: false; toolbar.margin: 1,1,1,1; toolbar.spacingInsets: 1,1,1,1; toolbar.hoverBackground: null; toolbar.pressedBackground: null
+[style]Button.inTextField      focusable: false; toolbar.margin: 1,1,1,1; toolbar.spacingInsets: 1,1,1,1; toolbar.hoverBackground: darken($TextField.background,4%); toolbar.pressedBackground: darken($TextField.background,8%); toolbar.selectedBackground: darken($TextField.background,12%)
+
+
+#---- [style]ToggleButton ----
+
+[style]ToggleButton.inTextField focusable: false; toolbar.margin: 1,1,1,1; toolbar.spacingInsets: 1,1,1,1; toolbar.hoverBackground: darken($TextField.background,4%); toolbar.pressedBackground: darken($TextField.background,8%); toolbar.selectedBackground: darken($TextField.background,12%)
+
+
+#---- [style]ToolBar ----
+
+[style]ToolBar.inTextField     floatable: false; opaque: false; borderMargins: 0,0,0,0
+
+
+#---- [style]ToolBarSeparator ----
+
+[style]ToolBarSeparator.inTextField separatorWidth: 3
+
+
+#----  ----
+
+activeCaption                  #99b4d1  HSL 211  38  71    javax.swing.plaf.ColorUIResource [UI]
+activeCaptionBorder            #99b4d1  HSL 211  38  71    javax.swing.plaf.ColorUIResource [UI]
+activeCaptionText              #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
+control                        #f6f6f6  HSL   0   0  96    javax.swing.plaf.ColorUIResource [UI]
+controlDkShadow                #00000026  15%  HSLA   0   0   0 15    javax.swing.plaf.ColorUIResource [UI]
+controlHighlight               #1f1f1f26  15%  HSLA   0   0  12 15    javax.swing.plaf.ColorUIResource [UI]
+controlLtHighlight             #40404026  15%  HSLA   0   0  25 15    javax.swing.plaf.ColorUIResource [UI]
+controlShadow                  #00000026  15%  HSLA   0   0   0 15    javax.swing.plaf.ColorUIResource [UI]
+controlText                    #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
+defaultFont                    Segoe UI plain 12    javax.swing.plaf.FontUIResource [UI]
+desktop                        #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+
+
+#---- h0 ----
+
+h0.font                        [active] Segoe UI plain 30    javax.swing.plaf.FontUIResource [UI]
+
+
+#---- h00 ----
+
+h00.font                       [active] Segoe UI plain 36    javax.swing.plaf.FontUIResource [UI]
+
+
+#---- h1 ----
+
+h1.font                        [active] Segoe UI Semibold plain 24    javax.swing.plaf.FontUIResource [UI]
+h1.regular.font                [active] Segoe UI plain 24    javax.swing.plaf.FontUIResource [UI]
+
+
+#---- h2 ----
+
+h2.font                        [active] Segoe UI Semibold plain 18    javax.swing.plaf.FontUIResource [UI]
+h2.regular.font                [active] Segoe UI plain 18    javax.swing.plaf.FontUIResource [UI]
+
+
+#---- h3 ----
+
+h3.font                        [active] Segoe UI Semibold plain 15    javax.swing.plaf.FontUIResource [UI]
+h3.regular.font                [active] Segoe UI plain 15    javax.swing.plaf.FontUIResource [UI]
+
+
+#---- h4 ----
+
+h4.font                        [active] Segoe UI bold 12    javax.swing.plaf.FontUIResource [UI]
+
+
+#---- html ----
+
+html.missingImage              [lazy] 38,38    sun.swing.ImageIconUIResource [UI]  (sun.awt.image.ToolkitImage)
+html.pendingImage              [lazy] 38,38    sun.swing.ImageIconUIResource [UI]  (sun.awt.image.ToolkitImage)
+
+
+#----  ----
+
+inactiveCaption                #bfcddb  HSL 210  28  80    javax.swing.plaf.ColorUIResource [UI]
+inactiveCaptionBorder          #bfcddb  HSL 210  28  80    javax.swing.plaf.ColorUIResource [UI]
+inactiveCaptionText            #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
+info                           #fefefe  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+infoText                       #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
+
+
+#---- laf ----
+
+laf.dark                       false
+laf.scaleFactor                [active] 1.0
+
+
+#---- large ----
+
+large.font                     [active] Segoe UI plain 14    javax.swing.plaf.FontUIResource [UI]
+
+
+#---- light ----
+
+light.font                     [active] Segoe UI Light plain 12    javax.swing.plaf.FontUIResource [UI]
+
+
+#---- medium ----
+
+medium.font                    [active] Segoe UI plain 11    javax.swing.plaf.FontUIResource [UI]
+
+
+#----  ----
+
+menu                           #f6f6f6  HSL   0   0  96    javax.swing.plaf.ColorUIResource [UI]
+menuText                       #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
+
+
+#---- mini ----
+
+mini.font                      [active] Segoe UI plain 9    javax.swing.plaf.FontUIResource [UI]
+
+
+#---- monospaced ----
+
+monospaced.font                [active] Consolas plain 12    javax.swing.plaf.FontUIResource [UI]
+
+
+#----  ----
+
+scrollbar                      #fafafa  HSL   0   0  98    javax.swing.plaf.ColorUIResource [UI]
+
+
+#---- semibold ----
+
+semibold.font                  [active] Segoe UI Semibold plain 12    javax.swing.plaf.FontUIResource [UI]
+
+
+#---- small ----
+
+small.font                     [active] Segoe UI plain 10    javax.swing.plaf.FontUIResource [UI]
+
+
+#---- swingx/TaskPane ----
+
+swingx/TaskPaneUI              com.formdev.flatlaf.swingx.ui.FlatTaskPaneUI
+
+
+#----  ----
+
+text                           #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+textHighlight                  #0063e1  HSL 214 100  44    javax.swing.plaf.ColorUIResource [UI]
+textHighlightText              #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+textInactiveText               #b6b6b6  HSL   0   0  71    javax.swing.plaf.ColorUIResource [UI]
+textText                       #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
+window                         #f6f6f6  HSL   0   0  96    javax.swing.plaf.ColorUIResource [UI]
+windowBorder                   #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
+windowText                     #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]

--- a/flatlaf-testing/misc/MacOSColorDump.playground/Contents.swift
+++ b/flatlaf-testing/misc/MacOSColorDump.playground/Contents.swift
@@ -1,0 +1,81 @@
+import Cocoa
+
+func colorToHex( color: NSColor ) -> String {
+    return String( format: (color.alphaComponent != 1 ? "#%02x%02x%02x%02x" : "#%02x%02x%02x"),
+                  Int( 255 * color.redComponent ),
+                  Int( 255 * color.greenComponent ),
+                  Int( 255 * color.blueComponent ),
+                  Int( 255 * color.alphaComponent ) )
+}
+
+func printColorHex( color: NSColor, space: NSColorSpace ) {
+    print( "@ns", color.colorNameComponent.prefix(1).capitalized, color.colorNameComponent.dropFirst(),
+           " = ", colorToHex( color: color.usingColorSpace( space )! ),
+           separator: "" )
+}
+
+func printColorsHex( space: NSColorSpace ) {
+    print( "#----", space, "----" )
+    
+    // order is the same as in Xcode color chooser (Color Palettes > Developer)
+
+    printColorHex( color: NSColor.labelColor, space: space )
+    printColorHex( color: NSColor.secondaryLabelColor, space: space )
+    printColorHex( color: NSColor.tertiaryLabelColor, space: space )
+    printColorHex( color: NSColor.quaternaryLabelColor, space: space )
+
+    printColorHex( color: NSColor.systemRed, space: space )
+    printColorHex( color: NSColor.systemGreen, space: space )
+    printColorHex( color: NSColor.systemBlue, space: space )
+    printColorHex( color: NSColor.systemOrange, space: space )
+    printColorHex( color: NSColor.systemYellow, space: space )
+    printColorHex( color: NSColor.systemBrown, space: space )
+    printColorHex( color: NSColor.systemPink, space: space )
+    printColorHex( color: NSColor.systemPurple, space: space )
+    printColorHex( color: NSColor.systemTeal, space: space )
+    printColorHex( color: NSColor.systemIndigo, space: space )
+    printColorHex( color: NSColor.systemMint, space: space )
+    printColorHex( color: NSColor.systemCyan, space: space )
+    printColorHex( color: NSColor.systemGray, space: space )
+
+    printColorHex( color: NSColor.linkColor, space: space )
+    printColorHex( color: NSColor.placeholderTextColor, space: space )
+    printColorHex( color: NSColor.windowFrameTextColor, space: space )
+    printColorHex( color: NSColor.selectedMenuItemTextColor, space: space )
+    printColorHex( color: NSColor.alternateSelectedControlTextColor, space: space )
+    printColorHex( color: NSColor.headerTextColor, space: space )
+
+    printColorHex( color: NSColor.separatorColor, space: space )
+    printColorHex( color: NSColor.gridColor, space: space )
+
+    printColorHex( color: NSColor.textColor, space: space )
+    printColorHex( color: NSColor.textBackgroundColor, space: space )
+    printColorHex( color: NSColor.selectedTextColor, space: space )
+    printColorHex( color: NSColor.selectedTextBackgroundColor, space: space )
+    printColorHex( color: NSColor.unemphasizedSelectedTextBackgroundColor, space: space )
+    printColorHex( color: NSColor.unemphasizedSelectedTextColor, space: space )
+
+    printColorHex( color: NSColor.windowBackgroundColor, space: space )
+    printColorHex( color: NSColor.underPageBackgroundColor, space: space )
+    printColorHex( color: NSColor.controlBackgroundColor, space: space )
+
+    printColorHex( color: NSColor.selectedContentBackgroundColor, space: space )
+    printColorHex( color: NSColor.unemphasizedSelectedContentBackgroundColor, space: space )
+    print( "# alternatingContentBackgroundColors =", NSColor.alternatingContentBackgroundColors )
+
+    printColorHex( color: NSColor.findHighlightColor, space: space )
+
+    printColorHex( color: NSColor.controlColor, space: space )
+    printColorHex( color: NSColor.controlTextColor, space: space )
+    printColorHex( color: NSColor.selectedControlColor, space: space )
+    printColorHex( color: NSColor.selectedControlTextColor, space: space )
+    printColorHex( color: NSColor.disabledControlTextColor, space: space )
+
+    printColorHex( color: NSColor.keyboardFocusIndicatorColor, space: space )
+    printColorHex( color: NSColor.controlAccentColor, space: space )
+
+    print()
+}
+
+// printColorsHex(  space: NSColorSpace.genericRGB )
+printColorsHex(  space: NSColorSpace.deviceRGB )

--- a/flatlaf-testing/misc/MacOSColorDump.playground/contents.xcplayground
+++ b/flatlaf-testing/misc/MacOSColorDump.playground/contents.xcplayground
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<playground version='5.0' target-platform='macos'>
+    <timeline fileName='timeline.xctimeline'/>
+</playground>

--- a/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatPaintingTest.java
+++ b/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatPaintingTest.java
@@ -1077,7 +1077,7 @@ public class FlatPaintingTest
 
 		private void paintArrow( Graphics2D g, int width, int height ) {
 			FlatUIUtils.paintArrow( g, 0, 0, width, height,
-				direction, chevron, arrowSize, xOffset, yOffset );
+				direction, chevron, arrowSize, 1, xOffset, yOffset );
 
 			if( button ) {
 				FlatArrowButton arrowButton = new FlatArrowButton( direction,

--- a/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/uidefaults/UIDefaultsDump.java
+++ b/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/uidefaults/UIDefaultsDump.java
@@ -65,6 +65,7 @@ import javax.swing.plaf.basic.BasicLookAndFeel;
 import com.formdev.flatlaf.*;
 import com.formdev.flatlaf.intellijthemes.FlatAllIJThemes;
 import com.formdev.flatlaf.testing.FlatTestLaf;
+import com.formdev.flatlaf.themes.*;
 import com.formdev.flatlaf.ui.FlatLineBorder;
 import com.formdev.flatlaf.ui.FlatUIUtils;
 import com.formdev.flatlaf.util.ColorFunctions.ColorFunction;
@@ -103,6 +104,9 @@ public class UIDefaultsDump
 		if( SystemInfo.isWindows ) {
 			dump( FlatIntelliJLaf.class.getName(), dir, false );
 			dump( FlatDarculaLaf.class.getName(), dir, false );
+
+			dump( FlatMacLightLaf.class.getName(), dir, false );
+			dump( FlatMacDarkLaf.class.getName(), dir, false );
 		}
 
 		dump( FlatTestLaf.class.getName(), dir, false );
@@ -463,9 +467,9 @@ public class UIDefaultsDump
 		if( resolvedColor != color && resolvedColor.getRGB() != color.getRGB() ) {
 			if( !isIntelliJTheme ) {
 				System.err.println( "Key '" + key + "': derived colors not equal" );
-				System.err.println( "  Default color:          " + dumpColorHexAndHSL( color ) );
-				System.err.println( "  Resolved color:         " + dumpColorHexAndHSL( resolvedColor ) );
-				System.err.println( "  Base of resolved color: " + dumpColorHexAndHSL( retBaseColor[0] ) );
+				System.err.println( "  Default color:  " + dumpColorHexAndHSL( color ) );
+				System.err.println( "  Resolved color: " + dumpColorHexAndHSL( resolvedColor ) );
+				System.err.println( "  Base color:     " + dumpColorHexAndHSL( retBaseColor[0] ) );
 			}
 
 			out.printf( "%s / ",

--- a/flatlaf-theme-editor/src/main/java/com/formdev/flatlaf/themeeditor/FlatThemePreviewAll.java
+++ b/flatlaf-theme-editor/src/main/java/com/formdev/flatlaf/themeeditor/FlatThemePreviewAll.java
@@ -515,13 +515,7 @@ class FlatThemePreviewAll
 			"bb",
 			"ccc",
 			"dd",
-			"e",
-			"ff",
-			"ggg",
-			"hh",
-			"i",
-			"jj",
-			"kkk"
+			"e"
 		}));
 		comboBox3.setMaximumRowCount(6);
 		comboBox3.putClientProperty("FlatLaf.styleClass", "flatlaf-preview-combobox");

--- a/flatlaf-theme-editor/src/main/java/com/formdev/flatlaf/themeeditor/FlatThemePreviewAll.jfd
+++ b/flatlaf-theme-editor/src/main/java/com/formdev/flatlaf/themeeditor/FlatThemePreviewAll.jfd
@@ -201,12 +201,6 @@ new FormModel {
 					addElement( "ccc" )
 					addElement( "dd" )
 					addElement( "e" )
-					addElement( "ff" )
-					addElement( "ggg" )
-					addElement( "hh" )
-					addElement( "i" )
-					addElement( "jj" )
-					addElement( "kkk" )
 				}
 				"maximumRowCount": 6
 				"$client.FlatLaf.styleClass": "flatlaf-preview-combobox"


### PR DESCRIPTION
This PR adds macOS light and dark themes that use macOS Monterey (v12.2) colors and style.

The intention was to create themes that **look similar** to native macOS applications.

![Screenshot 2022-05-13 at 14 26 40](https://user-images.githubusercontent.com/5604048/168284345-466b43d4-73b5-4f32-8f45-4b1850554471.png) ![Screenshot 2022-05-13 at 14 26 56](https://user-images.githubusercontent.com/5604048/168284356-f1088e5b-1140-4a15-8273-9a05df87ca84.png)

The popup of not editable combo boxes is positioned similar to native macOS `NSPopUpButton` controls:

![Screenshot 2022-05-13 at 14 30 09](https://user-images.githubusercontent.com/5604048/168284384-8a8ef307-e470-4e90-968d-eb3e16b80ede.png) ![Screenshot 2022-05-13 at 14 31 45](https://user-images.githubusercontent.com/5604048/168284391-709d99da-ead3-4fb0-b8e9-780585d5c317.png)

Known issues:
- changing accent color not yet supported
- tabbed pane style not macOS like
- selection in lists, tables, trees and menu items do not have round corners

To try it out, download the build artifacts from here: https://github.com/JFormDesigner/FlatLaf/actions/runs/2319472414

The new look and feel class names are:
- `com.formdev.flatlaf.themes.FlatMacLightLaf`
- `com.formdev.flatlaf.themes.FlatMacDarkLaf`