### PR TITLE
ToolBar: hover effect for button groups

### DIFF
--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatButtonUI.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatButtonUI.java
@@ -20,6 +20,7 @@ import static com.formdev.flatlaf.FlatClientProperties.*;
 import static com.formdev.flatlaf.util.UIScale.scale;
 import java.awt.Color;
 import java.awt.Component;
+import java.awt.Container;
 import java.awt.Dimension;
 import java.awt.Font;
 import java.awt.FontMetrics;
@@ -45,8 +46,10 @@ import javax.swing.LookAndFeel;
 import javax.swing.SwingConstants;
 import javax.swing.SwingUtilities;
 import javax.swing.UIManager;
+import javax.swing.event.ChangeEvent;
 import javax.swing.plaf.ButtonUI;
 import javax.swing.plaf.ComponentUI;
+import javax.swing.plaf.ToolBarUI;
 import javax.swing.plaf.UIResource;
 import javax.swing.plaf.basic.BasicButtonListener;
 import javax.swing.plaf.basic.BasicButtonUI;
@@ -703,6 +706,21 @@ public class FlatButtonUI
 		public void propertyChange( PropertyChangeEvent e ) {
 			super.propertyChange( e );
 			FlatButtonUI.this.propertyChange( b, e );
+		}
+
+		@Override
+		public void stateChanged( ChangeEvent e ) {
+			super.stateChanged( e );
+
+			// if button is in toolbar, repaint button groups
+			AbstractButton b = (AbstractButton) e.getSource();
+			Container parent = b.getParent();
+			if( parent instanceof JToolBar ) {
+				JToolBar toolBar = (JToolBar) parent;
+				ToolBarUI ui = toolBar.getUI();
+				if( ui instanceof FlatToolBarUI )
+					((FlatToolBarUI)ui).repaintButtonGroup( b );
+			}
 		}
 	}
 }

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatToolBarUI.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatToolBarUI.java
@@ -20,15 +20,24 @@ import java.awt.Color;
 import java.awt.Component;
 import java.awt.Container;
 import java.awt.FocusTraversalPolicy;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
 import java.awt.Insets;
+import java.awt.Rectangle;
 import java.awt.event.ContainerEvent;
 import java.awt.event.ContainerListener;
 import java.beans.PropertyChangeListener;
+import java.util.ArrayList;
+import java.util.Enumeration;
 import java.util.Map;
 import javax.swing.AbstractButton;
+import javax.swing.ButtonGroup;
+import javax.swing.ButtonModel;
+import javax.swing.DefaultButtonModel;
 import javax.swing.InputMap;
 import javax.swing.JComboBox;
 import javax.swing.JComponent;
+import javax.swing.JToolBar;
 import javax.swing.LayoutFocusTraversalPolicy;
 import javax.swing.UIManager;
 import javax.swing.border.Border;
@@ -37,6 +46,7 @@ import javax.swing.plaf.basic.BasicToolBarUI;
 import com.formdev.flatlaf.ui.FlatStylingSupport.Styleable;
 import com.formdev.flatlaf.ui.FlatStylingSupport.StyleableUI;
 import com.formdev.flatlaf.util.LoggingFacade;
+import com.formdev.flatlaf.util.UIScale;
 
 /**
  * Provides the Flat LaF UI delegate for {@link javax.swing.JToolBar}.
@@ -58,6 +68,8 @@ import com.formdev.flatlaf.util.LoggingFacade;
  * @uiDefault ToolBar.focusableButtons					boolean
  * @uiDefault ToolBar.arrowKeysOnlyNavigation			boolean
  * @uiDefault ToolBar.floatable							boolean
+ * @uiDefault ToolBar.hoverButtonGroupArc				int
+ * @uiDefault ToolBar.hoverButtonGroupBackground		Color
  *
  * <!-- FlatToolBarBorder -->
  *
@@ -72,6 +84,8 @@ public class FlatToolBarUI
 {
 	/** @since 1.4 */ @Styleable protected boolean focusableButtons;
 	/** @since 2 */ @Styleable protected boolean arrowKeysOnlyNavigation;
+	/** @since 3 */ @Styleable protected int hoverButtonGroupArc;
+	/** @since 3 */ @Styleable protected Color hoverButtonGroupBackground;
 
 	// for FlatToolBarBorder
 	@Styleable protected Insets borderMargins;
@@ -119,6 +133,8 @@ public class FlatToolBarUI
 
 		focusableButtons = UIManager.getBoolean( "ToolBar.focusableButtons" );
 		arrowKeysOnlyNavigation = UIManager.getBoolean( "ToolBar.arrowKeysOnlyNavigation" );
+		hoverButtonGroupArc = UIManager.getInt( "ToolBar.hoverButtonGroupArc" );
+		hoverButtonGroupBackground = UIManager.getColor( "ToolBar.hoverButtonGroupBackground" );
 
 		// floatable
 		if( !UIManager.getBoolean( "ToolBar.floatable" ) ) {
@@ -131,6 +147,8 @@ public class FlatToolBarUI
 	@Override
 	protected void uninstallDefaults() {
 		super.uninstallDefaults();
+
+		hoverButtonGroupBackground = null;
 
 		if( oldFloatable != null ) {
 			toolBar.setFloatable( oldFloatable );
@@ -321,6 +339,99 @@ public class FlatToolBarUI
 		}
 
 		super.setOrientation( orientation );
+	}
+
+	@Override
+	public void paint( Graphics g, JComponent c ) {
+		super.paint( g, c );
+
+		paintButtonGroup( g );
+	}
+
+	/**@since 3 */
+	protected void paintButtonGroup( Graphics g ) {
+		if( hoverButtonGroupBackground == null )
+			return;
+
+		// find hovered button that is part of a button group
+		ButtonGroup group = null;
+		for( Component b : toolBar.getComponents() ) {
+			if( b instanceof AbstractButton && ((AbstractButton)b).getModel().isRollover() ) {
+				group = getButtonGroup( (AbstractButton) b );
+				if( group != null )
+					break;
+			}
+		}
+		if( group == null )
+			return;
+
+		// get bounds of buttons in group
+		ArrayList<Rectangle> rects = new ArrayList<>();
+		Enumeration<AbstractButton> e = group.getElements();
+		while( e.hasMoreElements() ) {
+			AbstractButton gb = e.nextElement();
+			if( gb.getParent() == toolBar )
+				rects.add( gb.getBounds() );
+		}
+
+		// sort button bounds
+		boolean horizontal = (toolBar.getOrientation() == JToolBar.HORIZONTAL);
+		rects.sort( (r1, r2) -> horizontal ? r1.x - r2.x : r1.y - r2.y );
+
+		Object[] oldRenderingHints = FlatUIUtils.setRenderingHints( g );
+		g.setColor( FlatUIUtils.deriveColor( hoverButtonGroupBackground, toolBar.getBackground() ) );
+
+		// paint button group hover background
+		int maxSepWidth = UIScale.scale( 10 );
+		Rectangle gr = null;
+		for( Rectangle r : rects ) {
+			if( gr == null ) {
+				// first button
+				gr = r;
+			} else if( horizontal ? (gr.x + gr.width + maxSepWidth >= r.x) : (gr.y + gr.height + maxSepWidth >= r.y) ) {
+				// button joins previous button
+				gr = gr.union( r );
+			} else {
+				// paint group
+				FlatUIUtils.paintComponentBackground( (Graphics2D) g, gr.x, gr.y, gr.width, gr.height, 0, UIScale.scale( hoverButtonGroupArc ) );
+				gr = r;
+			}
+		}
+		if( gr != null )
+			FlatUIUtils.paintComponentBackground( (Graphics2D) g, gr.x, gr.y, gr.width, gr.height, 0, UIScale.scale( hoverButtonGroupArc ) );
+
+		FlatUIUtils.resetRenderingHints( g, oldRenderingHints );
+	}
+
+	/**@since 3 */
+	protected void repaintButtonGroup( AbstractButton b ) {
+		if( hoverButtonGroupBackground == null )
+			return;
+
+		ButtonGroup group = getButtonGroup( b );
+		if( group == null )
+			return;
+
+		// compute union bounds of all buttons in group (including separators)
+		Rectangle gr = null;
+		Enumeration<AbstractButton> e = group.getElements();
+		while( e.hasMoreElements() ) {
+			AbstractButton gb = e.nextElement();
+			Container parent = gb.getParent();
+			if( parent == toolBar )
+				gr = (gr != null) ? gr.union( gb.getBounds() ) : gb.getBounds();
+		}
+
+		// repaint button group
+		if( gr != null )
+			toolBar.repaint( gr );
+	}
+
+	private ButtonGroup getButtonGroup( AbstractButton b ) {
+		ButtonModel model = b.getModel();
+		return (model instanceof DefaultButtonModel)
+			? ((DefaultButtonModel)model).getGroup()
+			: null;
 	}
 
 	//---- class FlatToolBarFocusTraversalPolicy ------------------------------

--- a/flatlaf-core/src/main/resources/com/formdev/flatlaf/FlatDarkLaf.properties
+++ b/flatlaf-core/src/main/resources/com/formdev/flatlaf/FlatDarkLaf.properties
@@ -349,6 +349,11 @@ ToggleButton.disabledSelectedBackground = lighten($ToggleButton.background,3%,de
 ToggleButton.toolbar.selectedBackground = lighten($ToggleButton.background,7%,derived)
 
 
+#---- ToolBar ----
+
+ToolBar.hoverButtonGroupBackground = lighten($ToolBar.background,3%,derived)
+
+
 #---- ToolTip ----
 
 ToolTip.border = 4,6,4,6

--- a/flatlaf-core/src/main/resources/com/formdev/flatlaf/FlatLaf.properties
+++ b/flatlaf-core/src/main/resources/com/formdev/flatlaf/FlatLaf.properties
@@ -840,6 +840,7 @@ ToolBar.borderMargins = 2,2,2,2
 ToolBar.isRollover = true
 ToolBar.focusableButtons = false
 ToolBar.arrowKeysOnlyNavigation = true
+ToolBar.hoverButtonGroupArc = 8
 ToolBar.floatable = false
 ToolBar.gripColor = @icon
 ToolBar.dockingBackground = darken($ToolBar.background,5%)

--- a/flatlaf-core/src/main/resources/com/formdev/flatlaf/FlatLightLaf.properties
+++ b/flatlaf-core/src/main/resources/com/formdev/flatlaf/FlatLightLaf.properties
@@ -356,6 +356,11 @@ ToggleButton.disabledSelectedBackground = darken($ToggleButton.background,13%,de
 ToggleButton.toolbar.selectedBackground = $ToggleButton.selectedBackground
 
 
+#---- ToolBar ----
+
+ToolBar.hoverButtonGroupBackground = darken($ToolBar.background,3%,derived)
+
+
 #---- ToolTip ----
 
 ToolTip.border = 4,6,4,6,shade(@background,40%)

--- a/flatlaf-core/src/test/java/com/formdev/flatlaf/ui/TestFlatStyleableInfo.java
+++ b/flatlaf-core/src/test/java/com/formdev/flatlaf/ui/TestFlatStyleableInfo.java
@@ -881,6 +881,8 @@ public class TestFlatStyleableInfo
 		Map<String, Class<?>> expected = expectedMap(
 			"focusableButtons", boolean.class,
 			"arrowKeysOnlyNavigation", boolean.class,
+			"hoverButtonGroupArc", int.class,
+			"hoverButtonGroupBackground", Color.class,
 
 			"borderMargins", Insets.class,
 			"gripColor", Color.class

--- a/flatlaf-core/src/test/java/com/formdev/flatlaf/ui/TestFlatStyling.java
+++ b/flatlaf-core/src/test/java/com/formdev/flatlaf/ui/TestFlatStyling.java
@@ -1084,6 +1084,8 @@ public class TestFlatStyling
 
 		ui.applyStyle( "focusableButtons: true" );
 		ui.applyStyle( "arrowKeysOnlyNavigation: true" );
+		ui.applyStyle( "hoverButtonGroupArc: 12" );
+		ui.applyStyle( "hoverButtonGroupBackground: #fff" );
 
 		ui.applyStyle( "borderMargins: 1,2,3,4" );
 		ui.applyStyle( "gripColor: #fff" );

--- a/flatlaf-demo/src/main/java/com/formdev/flatlaf/demo/MoreComponentsPanel.java
+++ b/flatlaf-demo/src/main/java/com/formdev/flatlaf/demo/MoreComponentsPanel.java
@@ -101,6 +101,11 @@ class MoreComponentsPanel
 		JButton button8 = new JButton();
 		JToggleButton toggleButton6 = new JToggleButton();
 		JButton button1 = new JButton();
+		JLabel label7 = new JLabel();
+		JToggleButton toggleButton1 = new JToggleButton();
+		JToggleButton toggleButton2 = new JToggleButton();
+		JToggleButton toggleButton3 = new JToggleButton();
+		JToggleButton toggleButton4 = new JToggleButton();
 		JLabel splitPaneLabel = new JLabel();
 		JSplitPane splitPane3 = new JSplitPane();
 		JSplitPane splitPane1 = new JSplitPane();
@@ -397,8 +402,30 @@ class MoreComponentsPanel
 			button1.setIcon(new ImageIcon(getClass().getResource("/com/formdev/flatlaf/demo/icons/intellij-showWriteAccess.png")));
 			button1.setEnabled(false);
 			toolBar1.add(button1);
+			toolBar1.addSeparator();
+
+			//---- label7 ----
+			label7.setText("Button group hover:");
+			toolBar1.add(label7);
+
+			//---- toggleButton1 ----
+			toggleButton1.setIcon(UIManager.getIcon("FileView.computerIcon"));
+			toggleButton1.setSelected(true);
+			toolBar1.add(toggleButton1);
+
+			//---- toggleButton2 ----
+			toggleButton2.setIcon(UIManager.getIcon("FileView.computerIcon"));
+			toolBar1.add(toggleButton2);
+
+			//---- toggleButton3 ----
+			toggleButton3.setIcon(UIManager.getIcon("FileView.computerIcon"));
+			toolBar1.add(toggleButton3);
+
+			//---- toggleButton4 ----
+			toggleButton4.setIcon(UIManager.getIcon("FileView.computerIcon"));
+			toolBar1.add(toggleButton4);
 		}
-		add(toolBar1, "cell 1 10 3 1,growx");
+		add(toolBar1, "cell 1 10 4 1,growx");
 
 		//---- splitPaneLabel ----
 		splitPaneLabel.setText("JSplitPane:");
@@ -474,6 +501,13 @@ class MoreComponentsPanel
 			splitPane3.setRightComponent(splitPane2);
 		}
 		add(splitPane3, "cell 1 11 4 1,grow");
+
+		//---- buttonGroup1 ----
+		ButtonGroup buttonGroup1 = new ButtonGroup();
+		buttonGroup1.add(toggleButton1);
+		buttonGroup1.add(toggleButton2);
+		buttonGroup1.add(toggleButton3);
+		buttonGroup1.add(toggleButton4);
 		// JFormDesigner - End of component initialization  //GEN-END:initComponents
 
 		if( FlatLafDemo.screenshotsMode ) {

--- a/flatlaf-demo/src/main/java/com/formdev/flatlaf/demo/MoreComponentsPanel.jfd
+++ b/flatlaf-demo/src/main/java/com/formdev/flatlaf/demo/MoreComponentsPanel.jfd
@@ -1,4 +1,4 @@
-JFDML JFormDesigner: "7.0.2.0.298" Java: "15" encoding: "UTF-8"
+JFDML JFormDesigner: "7.0.5.0.404" Java: "17.0.2" encoding: "UTF-8"
 
 new FormModel {
 	contentType: "form/swing"
@@ -355,8 +355,36 @@ new FormModel {
 					"icon": new com.jformdesigner.model.SwingIcon( 0, "/com/formdev/flatlaf/demo/icons/intellij-showWriteAccess.png" )
 					"enabled": false
 				} )
+				add( new FormComponent( "javax.swing.JToolBar$Separator" ) {
+					name: "separator6"
+				} )
+				add( new FormComponent( "javax.swing.JLabel" ) {
+					name: "label7"
+					"text": "Button group hover:"
+				} )
+				add( new FormComponent( "javax.swing.JToggleButton" ) {
+					name: "toggleButton1"
+					"icon": &SwingIcon3 new com.jformdesigner.model.SwingIcon( 2, "FileView.computerIcon" )
+					"$buttonGroup": new FormReference( "buttonGroup1" )
+					"selected": true
+				} )
+				add( new FormComponent( "javax.swing.JToggleButton" ) {
+					name: "toggleButton2"
+					"icon": #SwingIcon3
+					"$buttonGroup": new FormReference( "buttonGroup1" )
+				} )
+				add( new FormComponent( "javax.swing.JToggleButton" ) {
+					name: "toggleButton3"
+					"icon": #SwingIcon3
+					"$buttonGroup": new FormReference( "buttonGroup1" )
+				} )
+				add( new FormComponent( "javax.swing.JToggleButton" ) {
+					name: "toggleButton4"
+					"icon": #SwingIcon3
+					"$buttonGroup": new FormReference( "buttonGroup1" )
+				} )
 			}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-				"value": "cell 1 10 3 1,growx"
+				"value": "cell 1 10 4 1,growx"
 			} )
 			add( new FormComponent( "javax.swing.JLabel" ) {
 				name: "splitPaneLabel"
@@ -442,6 +470,11 @@ new FormModel {
 		}, new FormLayoutConstraints( null ) {
 			"location": new java.awt.Point( 0, 0 )
 			"size": new java.awt.Dimension( 700, 550 )
+		} )
+		add( new FormNonVisual( "javax.swing.ButtonGroup" ) {
+			name: "buttonGroup1"
+		}, new FormLayoutConstraints( null ) {
+			"location": new java.awt.Point( 0, 560 )
 		} )
 	}
 }

--- a/flatlaf-extras/src/main/resources/com/formdev/flatlaf/extras/resources/DerivedColorKeys.properties
+++ b/flatlaf-extras/src/main/resources/com/formdev/flatlaf/extras/resources/DerivedColorKeys.properties
@@ -218,6 +218,11 @@ ToggleButton.toolbar.selectedBackground = ToggleButton.background
 ToggleButton.tab.hoverBackground = null
 
 
+#---- ToolBar ----
+
+ToolBar.hoverButtonGroupBackground = ToolBar.background
+
+
 
 
 #---- JideButton ----

--- a/flatlaf-testing/dumps/uidefaults/FlatDarkLaf_1.8.0.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatDarkLaf_1.8.0.txt
@@ -1303,6 +1303,8 @@ ToolBar.font                   [active] $defaultFont [UI]
 ToolBar.foreground             #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
 ToolBar.gripColor              #aeaeae  HSL   0   0  68    javax.swing.plaf.ColorUIResource [UI]
 ToolBar.highlight              #232324  HSL 240   1  14    javax.swing.plaf.ColorUIResource [UI]
+ToolBar.hoverButtonGroupArc    8
+ToolBar.hoverButtonGroupBackground #434749  HSL 200   4  27    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(3% autoInverse)
 ToolBar.isRollover             true
 ToolBar.light                  #2f3031  HSL 210   2  19    javax.swing.plaf.ColorUIResource [UI]
 ToolBar.separatorColor         #505254  HSL 210   2  32    javax.swing.plaf.ColorUIResource [UI]

--- a/flatlaf-testing/dumps/uidefaults/FlatLightLaf_1.8.0.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatLightLaf_1.8.0.txt
@@ -1308,6 +1308,8 @@ ToolBar.font                   [active] $defaultFont [UI]
 ToolBar.foreground             #000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]
 ToolBar.gripColor              #b1b1b1  HSL   0   0  69    javax.swing.plaf.ColorUIResource [UI]
 ToolBar.highlight              #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+ToolBar.hoverButtonGroupArc    8
+ToolBar.hoverButtonGroupBackground #eaeaea  HSL   0   0  92    com.formdev.flatlaf.util.DerivedColor [UI]    darken(3% autoInverse)
 ToolBar.isRollover             true
 ToolBar.light                  #e1e1e1  HSL   0   0  88    javax.swing.plaf.ColorUIResource [UI]
 ToolBar.separatorColor         #cecece  HSL   0   0  81    javax.swing.plaf.ColorUIResource [UI]

--- a/flatlaf-testing/dumps/uidefaults/FlatTestLaf_1.8.0.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatTestLaf_1.8.0.txt
@@ -1325,6 +1325,8 @@ ToolBar.font                   [active] $defaultFont [UI]
 ToolBar.foreground             #ff0000  HSL   0 100  50    javax.swing.plaf.ColorUIResource [UI]
 ToolBar.gripColor              #afafaf  HSL   0   0  69    javax.swing.plaf.ColorUIResource [UI]
 ToolBar.highlight              #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+ToolBar.hoverButtonGroupArc    8
+ToolBar.hoverButtonGroupBackground #ffdddd  HSL   0 100  93    javax.swing.plaf.ColorUIResource [UI]
 ToolBar.isRollover             true
 ToolBar.light                  #e3e3e3  HSL   0   0  89    javax.swing.plaf.ColorUIResource [UI]
 ToolBar.separatorColor         #00bb00  HSL 120 100  37    javax.swing.plaf.ColorUIResource [UI]

--- a/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatComponentsTest.java
+++ b/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatComponentsTest.java
@@ -437,6 +437,14 @@ public class FlatComponentsTest
 		FlatButton button29 = new FlatButton();
 		FlatToggleButton toggleButton25 = new FlatToggleButton();
 		FlatToggleButton toggleButton26 = new FlatToggleButton();
+		JLabel label5 = new JLabel();
+		FlatComponentsTest.TestToolBar toolBar5 = new FlatComponentsTest.TestToolBar();
+		FlatToggleButton toggleButton27 = new FlatToggleButton();
+		FlatToggleButton toggleButton28 = new FlatToggleButton();
+		FlatToggleButton toggleButton29 = new FlatToggleButton();
+		FlatToggleButton toggleButton30 = new FlatToggleButton();
+		FlatToggleButton toggleButton31 = new FlatToggleButton();
+		FlatToggleButton toggleButton32 = new FlatToggleButton();
 
 		//======== this ========
 		setLayout(new MigLayout(
@@ -1538,11 +1546,11 @@ public class FlatComponentsTest
 			toggleButton17.setSelected(true);
 			toolBar1.add(toggleButton17);
 		}
-		add(toolBar1, "cell 1 23 5 1");
+		add(toolBar1, "cell 1 23 6 1");
 
 		//---- label3 ----
 		label3.setText("Square:");
-		add(label3, "cell 1 23 5 1");
+		add(label3, "cell 1 23 6 1");
 
 		//======== toolBar3 ========
 		{
@@ -1569,11 +1577,11 @@ public class FlatComponentsTest
 			toggleButton24.setButtonType(FlatButton.ButtonType.square);
 			toolBar3.add(toggleButton24);
 		}
-		add(toolBar3, "cell 1 23 5 1");
+		add(toolBar3, "cell 1 23 6 1");
 
 		//---- label4 ----
 		label4.setText("Round:");
-		add(label4, "cell 1 23 5 1");
+		add(label4, "cell 1 23 6 1");
 
 		//======== toolBar4 ========
 		{
@@ -1600,7 +1608,45 @@ public class FlatComponentsTest
 			toggleButton26.setButtonType(FlatButton.ButtonType.roundRect);
 			toolBar4.add(toggleButton26);
 		}
-		add(toolBar4, "cell 1 23 5 1");
+		add(toolBar4, "cell 1 23 6 1");
+
+		//---- label5 ----
+		label5.setText("Group:");
+		add(label5, "cell 1 23 6 1");
+
+		//======== toolBar5 ========
+		{
+
+			//---- toggleButton27 ----
+			toggleButton27.setIcon(UIManager.getIcon("FileView.computerIcon"));
+			toggleButton27.setSelected(true);
+			toolBar5.add(toggleButton27);
+
+			//---- toggleButton28 ----
+			toggleButton28.setIcon(UIManager.getIcon("FileView.computerIcon"));
+			toolBar5.add(toggleButton28);
+			toolBar5.addSeparator();
+
+			//---- toggleButton29 ----
+			toggleButton29.setIcon(UIManager.getIcon("FileView.computerIcon"));
+			toolBar5.add(toggleButton29);
+			toolBar5.addSeparator();
+
+			//---- toggleButton30 ----
+			toggleButton30.setIcon(UIManager.getIcon("FileView.floppyDriveIcon"));
+			toggleButton30.setSelected(true);
+			toolBar5.add(toggleButton30);
+
+			//---- toggleButton31 ----
+			toggleButton31.setIcon(UIManager.getIcon("FileView.floppyDriveIcon"));
+			toolBar5.add(toggleButton31);
+			toolBar5.addSeparator();
+
+			//---- toggleButton32 ----
+			toggleButton32.setIcon(UIManager.getIcon("FileView.computerIcon"));
+			toolBar5.add(toggleButton32);
+		}
+		add(toolBar5, "cell 1 23 6 1");
 
 		//---- buttonGroup1 ----
 		ButtonGroup buttonGroup1 = new ButtonGroup();
@@ -1609,6 +1655,18 @@ public class FlatComponentsTest
 		buttonGroup1.add(warningOutlineRadioButton);
 		buttonGroup1.add(magentaOutlineRadioButton);
 		buttonGroup1.add(magentaCyanOutlineRadioButton);
+
+		//---- buttonGroup2 ----
+		ButtonGroup buttonGroup2 = new ButtonGroup();
+		buttonGroup2.add(toggleButton27);
+		buttonGroup2.add(toggleButton28);
+		buttonGroup2.add(toggleButton29);
+		buttonGroup2.add(toggleButton32);
+
+		//---- buttonGroup3 ----
+		ButtonGroup buttonGroup3 = new ButtonGroup();
+		buttonGroup3.add(toggleButton30);
+		buttonGroup3.add(toggleButton31);
 		// JFormDesigner - End of component initialization  //GEN-END:initComponents
 
 		// Unicode surrogate character pair "script capital A"

--- a/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatComponentsTest.jfd
+++ b/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatComponentsTest.jfd
@@ -1,4 +1,4 @@
-JFDML JFormDesigner: "7.0.3.1.342" Java: "15" encoding: "UTF-8"
+JFDML JFormDesigner: "7.0.5.0.404" Java: "17.0.2" encoding: "UTF-8"
 
 new FormModel {
 	contentType: "form/swing"
@@ -121,7 +121,7 @@ new FormModel {
 			} )
 			add( new FormComponent( "javax.swing.JButton" ) {
 				name: "button13"
-				"icon": &SwingIcon0 new com.jformdesigner.model.SwingIcon( 2, "Tree.closedIcon" )
+				"icon": new com.jformdesigner.model.SwingIcon( 2, "Tree.closedIcon" )
 			}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
 				"value": "cell 5 1 2 1"
 			} )
@@ -272,7 +272,7 @@ new FormModel {
 			} )
 			add( new FormComponent( "com.formdev.flatlaf.extras.components.FlatToggleButton" ) {
 				name: "toggleButton22"
-				"icon": &SwingIcon0 new com.jformdesigner.model.SwingIcon( 2, "Tree.closedIcon" )
+				"icon": new com.jformdesigner.model.SwingIcon( 2, "Tree.closedIcon" )
 				"selected": true
 				"buttonType": enum com.formdev.flatlaf.extras.components.FlatButton$ButtonType borderless
 			}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
@@ -1463,13 +1463,13 @@ new FormModel {
 					"selected": true
 				} )
 			}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-				"value": "cell 1 23 5 1"
+				"value": "cell 1 23 6 1"
 			} )
 			add( new FormComponent( "javax.swing.JLabel" ) {
 				name: "label3"
 				"text": "Square:"
 			}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-				"value": "cell 1 23 5 1"
+				"value": "cell 1 23 6 1"
 			} )
 			add( new FormContainer( "com.formdev.flatlaf.testing.FlatComponentsTest$TestToolBar", new FormLayoutManager( class javax.swing.JToolBar ) ) {
 				name: "toolBar3"
@@ -1496,13 +1496,13 @@ new FormModel {
 					"buttonType": enum com.formdev.flatlaf.extras.components.FlatButton$ButtonType square
 				} )
 			}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-				"value": "cell 1 23 5 1"
+				"value": "cell 1 23 6 1"
 			} )
 			add( new FormComponent( "javax.swing.JLabel" ) {
 				name: "label4"
 				"text": "Round:"
 			}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-				"value": "cell 1 23 5 1"
+				"value": "cell 1 23 6 1"
 			} )
 			add( new FormContainer( "com.formdev.flatlaf.testing.FlatComponentsTest$TestToolBar", new FormLayoutManager( class javax.swing.JToolBar ) ) {
 				name: "toolBar4"
@@ -1529,7 +1529,59 @@ new FormModel {
 					"buttonType": enum com.formdev.flatlaf.extras.components.FlatButton$ButtonType roundRect
 				} )
 			}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-				"value": "cell 1 23 5 1"
+				"value": "cell 1 23 6 1"
+			} )
+			add( new FormComponent( "javax.swing.JLabel" ) {
+				name: "label5"
+				"text": "Group:"
+			}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+				"value": "cell 1 23 6 1"
+			} )
+			add( new FormContainer( "com.formdev.flatlaf.testing.FlatComponentsTest$TestToolBar", new FormLayoutManager( class javax.swing.JToolBar ) ) {
+				name: "toolBar5"
+				add( new FormComponent( "com.formdev.flatlaf.extras.components.FlatToggleButton" ) {
+					name: "toggleButton27"
+					"icon": #SwingIcon4
+					"selected": true
+					"$buttonGroup": new FormReference( "buttonGroup2" )
+				} )
+				add( new FormComponent( "com.formdev.flatlaf.extras.components.FlatToggleButton" ) {
+					name: "toggleButton28"
+					"icon": #SwingIcon4
+					"$buttonGroup": new FormReference( "buttonGroup2" )
+				} )
+				add( new FormComponent( "javax.swing.JToolBar$Separator" ) {
+					name: "separator6"
+				} )
+				add( new FormComponent( "com.formdev.flatlaf.extras.components.FlatToggleButton" ) {
+					name: "toggleButton29"
+					"icon": #SwingIcon4
+					"$buttonGroup": new FormReference( "buttonGroup2" )
+				} )
+				add( new FormComponent( "javax.swing.JToolBar$Separator" ) {
+					name: "separator8"
+				} )
+				add( new FormComponent( "com.formdev.flatlaf.extras.components.FlatToggleButton" ) {
+					name: "toggleButton30"
+					"icon": #SwingIcon5
+					"$buttonGroup": new FormReference( "buttonGroup3" )
+					"selected": true
+				} )
+				add( new FormComponent( "com.formdev.flatlaf.extras.components.FlatToggleButton" ) {
+					name: "toggleButton31"
+					"icon": #SwingIcon5
+					"$buttonGroup": new FormReference( "buttonGroup3" )
+				} )
+				add( new FormComponent( "javax.swing.JToolBar$Separator" ) {
+					name: "separator7"
+				} )
+				add( new FormComponent( "com.formdev.flatlaf.extras.components.FlatToggleButton" ) {
+					name: "toggleButton32"
+					"icon": #SwingIcon4
+					"$buttonGroup": new FormReference( "buttonGroup2" )
+				} )
+			}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+				"value": "cell 1 23 6 1"
 			} )
 		}, new FormLayoutConstraints( null ) {
 			"location": new java.awt.Point( 0, 0 )
@@ -1539,6 +1591,16 @@ new FormModel {
 			name: "buttonGroup1"
 		}, new FormLayoutConstraints( null ) {
 			"location": new java.awt.Point( 0, 810 )
+		} )
+		add( new FormNonVisual( "javax.swing.ButtonGroup" ) {
+			name: "buttonGroup2"
+		}, new FormLayoutConstraints( null ) {
+			"location": new java.awt.Point( 0, 862 )
+		} )
+		add( new FormNonVisual( "javax.swing.ButtonGroup" ) {
+			name: "buttonGroup3"
+		}, new FormLayoutConstraints( null ) {
+			"location": new java.awt.Point( 0, 914 )
 		} )
 	}
 }

--- a/flatlaf-testing/src/main/resources/com/formdev/flatlaf/testing/FlatTestLaf.properties
+++ b/flatlaf-testing/src/main/resources/com/formdev/flatlaf/testing/FlatTestLaf.properties
@@ -433,6 +433,7 @@ ToggleButton.toolbar.selectedBackground = #ddd
 #---- ToolBar ----
 
 ToolBar.focusableButtons = true
+ToolBar.hoverButtonGroupBackground = #fdd
 
 
 #---- ToolTip ----

--- a/flatlaf-theme-editor/src/main/java/com/formdev/flatlaf/themeeditor/FlatThemePreviewAll.java
+++ b/flatlaf-theme-editor/src/main/java/com/formdev/flatlaf/themeeditor/FlatThemePreviewAll.java
@@ -339,6 +339,7 @@ class FlatThemePreviewAll
 		JToggleButton button7 = new JToggleButton();
 		JToggleButton button8 = new JToggleButton();
 		JToggleButton button9 = new JToggleButton();
+		JToggleButton button10 = new JToggleButton();
 		JLabel tabbedPaneLabel = new JLabel();
 		tabbedPane1 = new FlatThemePreviewAll.PreviewTabbedPane();
 		JLabel listTreeLabel = new JLabel();
@@ -803,7 +804,6 @@ class FlatThemePreviewAll
 
 			//---- button8 ----
 			button8.setIcon(UIManager.getIcon("Tree.leafIcon"));
-			button8.setSelected(true);
 			button8.putClientProperty("FlatLaf.styleClass", "flatlaf-preview-toolbar-togglebutton");
 			toolBar1.add(button8);
 
@@ -812,6 +812,12 @@ class FlatThemePreviewAll
 			button9.setSelected(true);
 			button9.putClientProperty("FlatLaf.styleClass", "flatlaf-preview-toolbar-togglebutton");
 			toolBar1.add(button9);
+
+			//---- button10 ----
+			button10.setIcon(UIManager.getIcon("Tree.leafIcon"));
+			button10.setSelected(true);
+			button10.putClientProperty("FlatLaf.styleClass", "flatlaf-preview-toolbar-togglebutton");
+			toolBar1.add(button10);
 		}
 		add(toolBar1, "cell 1 20 2 1");
 
@@ -949,6 +955,12 @@ class FlatThemePreviewAll
 		ButtonGroup buttonGroup2 = new ButtonGroup();
 		buttonGroup2.add(radioButtonMenuItem4);
 		buttonGroup2.add(radioButtonMenuItem5);
+
+		//---- buttonGroup3 ----
+		ButtonGroup buttonGroup3 = new ButtonGroup();
+		buttonGroup3.add(button7);
+		buttonGroup3.add(button8);
+		buttonGroup3.add(button9);
 		// JFormDesigner - End of component initialization  //GEN-END:initComponents
 	}
 

--- a/flatlaf-theme-editor/src/main/java/com/formdev/flatlaf/themeeditor/FlatThemePreviewAll.jfd
+++ b/flatlaf-theme-editor/src/main/java/com/formdev/flatlaf/themeeditor/FlatThemePreviewAll.jfd
@@ -578,15 +578,23 @@ new FormModel {
 					name: "button7"
 					"icon": &SwingIcon0 new com.jformdesigner.model.SwingIcon( 2, "Tree.leafIcon" )
 					"$client.FlatLaf.styleClass": "flatlaf-preview-toolbar-togglebutton"
+					"$buttonGroup": new FormReference( "buttonGroup3" )
 				} )
 				add( new FormComponent( "javax.swing.JToggleButton" ) {
 					name: "button8"
 					"icon": #SwingIcon0
-					"selected": true
 					"$client.FlatLaf.styleClass": "flatlaf-preview-toolbar-togglebutton"
+					"$buttonGroup": new FormReference( "buttonGroup3" )
 				} )
 				add( new FormComponent( "javax.swing.JToggleButton" ) {
 					name: "button9"
+					"icon": #SwingIcon0
+					"selected": true
+					"$client.FlatLaf.styleClass": "flatlaf-preview-toolbar-togglebutton"
+					"$buttonGroup": new FormReference( "buttonGroup3" )
+				} )
+				add( new FormComponent( "javax.swing.JToggleButton" ) {
+					name: "button10"
 					"icon": #SwingIcon0
 					"selected": true
 					"$client.FlatLaf.styleClass": "flatlaf-preview-toolbar-togglebutton"
@@ -769,6 +777,11 @@ new FormModel {
 			name: "buttonGroup2"
 		}, new FormLayoutConstraints( null ) {
 			"location": new java.awt.Point( 0, 1145 )
+		} )
+		add( new FormNonVisual( "javax.swing.ButtonGroup" ) {
+			name: "buttonGroup3"
+		}, new FormLayoutConstraints( null ) {
+			"location": new java.awt.Point( 0, 1197 )
 		} )
 	}
 }

--- a/flatlaf-theme-editor/src/main/resources/com/formdev/flatlaf/themeeditor/FlatLafUIKeys.txt
+++ b/flatlaf-theme-editor/src/main/resources/com/formdev/flatlaf/themeeditor/FlatLafUIKeys.txt
@@ -1044,6 +1044,8 @@ ToolBar.font
 ToolBar.foreground
 ToolBar.gripColor
 ToolBar.highlight
+ToolBar.hoverButtonGroupArc
+ToolBar.hoverButtonGroupBackground
 ToolBar.isRollover
 ToolBar.light
 ToolBar.separatorColor


### PR DESCRIPTION
This PR adds a hover effect to button groups (`javax.swing.ButtonGroup`) in toolbars.
If mouse is over a button then all buttons in same button group are highlighted
and the user easily sees which buttons belong to hovered button.

Example from the FlatLaf Demo app:

![image](https://user-images.githubusercontent.com/5604048/168425688-618d2ea2-c332-4ad9-9b2f-d0408906881f.png)
