### PR TITLE
Menus: rounded selection

### DIFF
--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatMenuBarUI.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatMenuBarUI.java
@@ -70,6 +70,9 @@ public class FlatMenuBarUI
 	/** @since 2 */ @Styleable protected Insets itemMargins;
 
 	// used in FlatMenuUI
+	/** @since 3 */ @Styleable protected Insets selectionInsets;
+	/** @since 3 */ @Styleable protected Insets selectionEmbeddedInsets;
+	/** @since 3 */ @Styleable protected int selectionArc = -1;
 	/** @since 2 */ @Styleable protected Color hoverBackground;
 	/** @since 2 */ @Styleable protected Color underlineSelectionBackground;
 	/** @since 2 */ @Styleable protected Color underlineSelectionColor;

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatMenuBarUI.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatMenuBarUI.java
@@ -74,6 +74,8 @@ public class FlatMenuBarUI
 	/** @since 3 */ @Styleable protected Insets selectionEmbeddedInsets;
 	/** @since 3 */ @Styleable protected int selectionArc = -1;
 	/** @since 2 */ @Styleable protected Color hoverBackground;
+	/** @since 3 */ @Styleable protected Color selectionBackground;
+	/** @since 3 */ @Styleable protected Color selectionForeground;
 	/** @since 2 */ @Styleable protected Color underlineSelectionBackground;
 	/** @since 2 */ @Styleable protected Color underlineSelectionColor;
 	/** @since 2 */ @Styleable protected int underlineSelectionHeight = -1;

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatMenuItemRenderer.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatMenuItemRenderer.java
@@ -63,6 +63,8 @@ import com.formdev.flatlaf.util.SystemInfo;
  * @uiDefault MenuItem.acceleratorArrowGap							int
  * @uiDefault MenuItem.checkBackground								Color
  * @uiDefault MenuItem.checkMargins									Insets
+ * @uiDefault MenuItem.selectionInsets								Insets
+ * @uiDefault MenuItem.selectionArc									int
  * @uiDefault MenuItem.selectionType								String	null (default) or underline
  * @uiDefault MenuItem.underlineSelectionBackground					Color
  * @uiDefault MenuItem.underlineSelectionCheckBackground			Color
@@ -90,6 +92,9 @@ public class FlatMenuItemRenderer
 
 	@Styleable protected Color checkBackground = UIManager.getColor( "MenuItem.checkBackground" );
 	@Styleable protected Insets checkMargins = UIManager.getInsets( "MenuItem.checkMargins" );
+
+	/** @since 3 */ @Styleable protected Insets selectionInsets = UIManager.getInsets( "MenuItem.selectionInsets" );
+	/** @since 3 */ @Styleable protected int selectionArc = UIManager.getInt( "MenuItem.selectionArc" );
 
 	@Styleable protected Color underlineSelectionBackground = UIManager.getColor( "MenuItem.underlineSelectionBackground" );
 	@Styleable protected Color underlineSelectionCheckBackground = UIManager.getColor( "MenuItem.underlineSelectionCheckBackground" );
@@ -321,10 +326,16 @@ public class FlatMenuItemRenderer
 		g.setColor( Color.orange ); g.drawRect( arrowRect.x, arrowRect.y, arrowRect.width - 1, arrowRect.height - 1 );
 debug*/
 
+		boolean armedOrSelected = isArmedOrSelected( menuItem );
 		boolean underlineSelection = isUnderlineSelection();
-		paintBackground( g, underlineSelection ? underlineSelectionBackground : selectionBackground );
-		if( underlineSelection && isArmedOrSelected( menuItem ) )
-			paintUnderlineSelection( g, underlineSelectionColor, underlineSelectionHeight );
+
+		paintBackground( g );
+		if( armedOrSelected ) {
+			if( underlineSelection )
+				paintUnderlineSelection( g, underlineSelectionBackground, underlineSelectionColor, underlineSelectionHeight );
+			else
+				paintSelection( g, selectionBackground, selectionInsets, selectionArc );
+		}
 		paintIcon( g, iconRect, getIconForPainting(), underlineSelection ? underlineSelectionCheckBackground : checkBackground, selectionBackground );
 		paintText( g, textRect, menuItem.getText(), selectionForeground, disabledForeground );
 		paintAccelerator( g, accelRect, getAcceleratorText(), acceleratorForeground, acceleratorSelectionForeground, disabledForeground );
@@ -332,21 +343,39 @@ debug*/
 			paintArrowIcon( g, arrowRect, arrowIcon );
 	}
 
-	protected void paintBackground( Graphics g, Color selectionBackground ) {
-		boolean armedOrSelected = isArmedOrSelected( menuItem );
-		if( menuItem.isOpaque() || armedOrSelected ) {
-			// paint background
-			g.setColor( armedOrSelected
-				? deriveBackground( selectionBackground )
-				: menuItem.getBackground() );
+	/** @since 3 */
+	protected void paintBackground( Graphics g ) {
+		if( menuItem.isOpaque() ) {
+			g.setColor( menuItem.getBackground() );
 			g.fillRect( 0, 0, menuItem.getWidth(), menuItem.getHeight() );
 		}
 	}
 
-	protected void paintUnderlineSelection( Graphics g, Color underlineSelectionColor, int underlineSelectionHeight ) {
+	/** @since 3 */
+	protected void paintSelection( Graphics g, Color selectionBackground, Insets selectionInsets, int selectionArc ) {
+		Rectangle r = FlatUIUtils.subtractInsets( new Rectangle( menuItem.getSize() ), scale( selectionInsets ) );
+
+		g.setColor( deriveBackground( selectionBackground ) );
+		if( selectionArc > 0 ) {
+			Object[] oldRenderingHints = FlatUIUtils.setRenderingHints( g );
+			FlatUIUtils.paintComponentBackground( (Graphics2D) g, r.x, r.y, r.width, r.height, 0, scale( selectionArc ) );
+			FlatUIUtils.resetRenderingHints( g, oldRenderingHints );
+		} else
+			g.fillRect( r.x, r.y, r.width, r.height );
+	}
+
+	/** @since 3 */
+	protected void paintUnderlineSelection( Graphics g, Color underlineSelectionBackground,
+		Color underlineSelectionColor, int underlineSelectionHeight )
+	{
 		int width = menuItem.getWidth();
 		int height = menuItem.getHeight();
 
+		// paint background
+		g.setColor( deriveBackground( underlineSelectionBackground ) );
+		g.fillRect( 0, 0, width, height );
+
+		// paint underline
 		int underlineHeight = scale( underlineSelectionHeight );
 		g.setColor( underlineSelectionColor );
 		if( isTopLevelMenu( menuItem ) ) {

--- a/flatlaf-core/src/main/resources/com/formdev/flatlaf/FlatLaf.properties
+++ b/flatlaf-core/src/main/resources/com/formdev/flatlaf/FlatLaf.properties
@@ -422,6 +422,9 @@ MenuBar.border = com.formdev.flatlaf.ui.FlatMenuBarBorder
 MenuBar.background = @menuBackground
 MenuBar.hoverBackground = @menuHoverBackground
 MenuBar.itemMargins = 3,8,3,8
+MenuBar.selectionInsets = 0,0,0,0
+MenuBar.selectionEmbeddedInsets = 0,0,0,0
+MenuBar.selectionArc = 0
 
 
 #---- MenuItem ----
@@ -444,6 +447,8 @@ MenuItem.textNoAcceleratorGap = 6
 MenuItem.acceleratorArrowGap = 2
 MenuItem.acceleratorDelimiter = +
 [mac]MenuItem.acceleratorDelimiter = 
+MenuItem.selectionInsets = 0,0,0,0
+MenuItem.selectionArc = 0
 
 # for MenuItem.selectionType = underline
 MenuItem.underlineSelectionBackground = @menuHoverBackground

--- a/flatlaf-core/src/main/resources/com/formdev/flatlaf/FlatLaf.properties
+++ b/flatlaf-core/src/main/resources/com/formdev/flatlaf/FlatLaf.properties
@@ -422,9 +422,9 @@ MenuBar.border = com.formdev.flatlaf.ui.FlatMenuBarBorder
 MenuBar.background = @menuBackground
 MenuBar.hoverBackground = @menuHoverBackground
 MenuBar.itemMargins = 3,8,3,8
-MenuBar.selectionInsets = 0,0,0,0
-MenuBar.selectionEmbeddedInsets = 0,0,0,0
-MenuBar.selectionArc = 0
+MenuBar.selectionInsets = $MenuItem.selectionInsets
+MenuBar.selectionEmbeddedInsets = $MenuItem.selectionInsets
+MenuBar.selectionArc = $MenuItem.selectionArc
 
 
 #---- MenuItem ----

--- a/flatlaf-core/src/test/java/com/formdev/flatlaf/ui/TestFlatStyleableInfo.java
+++ b/flatlaf-core/src/test/java/com/formdev/flatlaf/ui/TestFlatStyleableInfo.java
@@ -271,6 +271,9 @@ public class TestFlatStyleableInfo
 
 		Map<String, Class<?>> expected = expectedMap(
 			"itemMargins", Insets.class,
+			"selectionInsets", Insets.class,
+			"selectionEmbeddedInsets", Insets.class,
+			"selectionArc", int.class,
 			"hoverBackground", Color.class,
 			"underlineSelectionBackground", Color.class,
 			"underlineSelectionColor", Color.class,
@@ -354,6 +357,9 @@ public class TestFlatStyleableInfo
 
 			"checkBackground", Color.class,
 			"checkMargins", Insets.class,
+
+			"selectionInsets", Insets.class,
+			"selectionArc", int.class,
 
 			"underlineSelectionBackground", Color.class,
 			"underlineSelectionCheckBackground", Color.class,

--- a/flatlaf-core/src/test/java/com/formdev/flatlaf/ui/TestFlatStyleableInfo.java
+++ b/flatlaf-core/src/test/java/com/formdev/flatlaf/ui/TestFlatStyleableInfo.java
@@ -275,6 +275,8 @@ public class TestFlatStyleableInfo
 			"selectionEmbeddedInsets", Insets.class,
 			"selectionArc", int.class,
 			"hoverBackground", Color.class,
+			"selectionBackground", Color.class,
+			"selectionForeground", Color.class,
 			"underlineSelectionBackground", Color.class,
 			"underlineSelectionColor", Color.class,
 			"underlineSelectionHeight", int.class,

--- a/flatlaf-core/src/test/java/com/formdev/flatlaf/ui/TestFlatStyling.java
+++ b/flatlaf-core/src/test/java/com/formdev/flatlaf/ui/TestFlatStyling.java
@@ -423,6 +423,9 @@ public class TestFlatStyling
 		FlatMenuBarUI ui = (FlatMenuBarUI) c.getUI();
 
 		ui.applyStyle( "itemMargins: 1,2,3,4" );
+		ui.applyStyle( "selectionInsets: 1,2,3,4" );
+		ui.applyStyle( "selectionEmbeddedInsets: 1,2,3,4" );
+		ui.applyStyle( "selectionArc: 8" );
 		ui.applyStyle( "hoverBackground: #fff" );
 		ui.applyStyle( "underlineSelectionBackground: #fff" );
 		ui.applyStyle( "underlineSelectionColor: #fff" );
@@ -508,6 +511,9 @@ public class TestFlatStyling
 
 		applyStyle.accept( "checkBackground: #fff" );
 		applyStyle.accept( "checkMargins: 1,2,3,4" );
+
+		applyStyle.accept( "selectionInsets: 1,2,3,4" );
+		applyStyle.accept( "selectionArc: 8" );
 
 		applyStyle.accept( "underlineSelectionBackground: #fff" );
 		applyStyle.accept( "underlineSelectionCheckBackground: #fff" );

--- a/flatlaf-core/src/test/java/com/formdev/flatlaf/ui/TestFlatStyling.java
+++ b/flatlaf-core/src/test/java/com/formdev/flatlaf/ui/TestFlatStyling.java
@@ -427,6 +427,8 @@ public class TestFlatStyling
 		ui.applyStyle( "selectionEmbeddedInsets: 1,2,3,4" );
 		ui.applyStyle( "selectionArc: 8" );
 		ui.applyStyle( "hoverBackground: #fff" );
+		ui.applyStyle( "selectionBackground: #fff" );
+		ui.applyStyle( "selectionForeground: #fff" );
 		ui.applyStyle( "underlineSelectionBackground: #fff" );
 		ui.applyStyle( "underlineSelectionColor: #fff" );
 		ui.applyStyle( "underlineSelectionHeight: 3" );

--- a/flatlaf-testing/dumps/uidefaults/FlatDarkLaf_1.8.0.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatDarkLaf_1.8.0.txt
@@ -593,6 +593,9 @@ MenuBar.foreground             #bbbbbb  HSL   0   0  73    javax.swing.plaf.Colo
 MenuBar.highlight              #232324  HSL 240   1  14    javax.swing.plaf.ColorUIResource [UI]
 MenuBar.hoverBackground        #484c4f  HSL 206   5  30    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(10% autoInverse)
 MenuBar.itemMargins            3,8,3,8    javax.swing.plaf.InsetsUIResource [UI]
+MenuBar.selectionArc           0
+MenuBar.selectionEmbeddedInsets 0,0,0,0    javax.swing.plaf.InsetsUIResource [UI]
+MenuBar.selectionInsets        0,0,0,0    javax.swing.plaf.InsetsUIResource [UI]
 MenuBar.shadow                 #616365  HSL 210   2  39    javax.swing.plaf.ColorUIResource [UI]
 MenuBar.windowBindings         length=2    [Ljava.lang.Object;
     [0] F10
@@ -621,8 +624,10 @@ MenuItem.margin                3,6,3,6    javax.swing.plaf.InsetsUIResource [UI]
 MenuItem.minimumIconSize       16,16    javax.swing.plaf.DimensionUIResource [UI]
 MenuItem.minimumWidth          72
 MenuItem.opaque                false
+MenuItem.selectionArc          0
 MenuItem.selectionBackground   #4b6eaf  HSL 219  40  49    javax.swing.plaf.ColorUIResource [UI]
 MenuItem.selectionForeground   #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+MenuItem.selectionInsets       0,0,0,0    javax.swing.plaf.InsetsUIResource [UI]
 MenuItem.textAcceleratorGap    24
 MenuItem.textNoAcceleratorGap  6
 MenuItem.underlineSelectionBackground #484c4f  HSL 206   5  30    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(10% autoInverse)

--- a/flatlaf-testing/dumps/uidefaults/FlatLightLaf_1.8.0.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatLightLaf_1.8.0.txt
@@ -598,6 +598,9 @@ MenuBar.foreground             #000000  HSL   0   0   0    javax.swing.plaf.Colo
 MenuBar.highlight              #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
 MenuBar.hoverBackground        #e6e6e6  HSL   0   0  90    com.formdev.flatlaf.util.DerivedColor [UI]    darken(10% autoInverse)
 MenuBar.itemMargins            3,8,3,8    javax.swing.plaf.InsetsUIResource [UI]
+MenuBar.selectionArc           0
+MenuBar.selectionEmbeddedInsets 0,0,0,0    javax.swing.plaf.InsetsUIResource [UI]
+MenuBar.selectionInsets        0,0,0,0    javax.swing.plaf.InsetsUIResource [UI]
 MenuBar.shadow                 #c2c2c2  HSL   0   0  76    javax.swing.plaf.ColorUIResource [UI]
 MenuBar.windowBindings         length=2    [Ljava.lang.Object;
     [0] F10
@@ -626,8 +629,10 @@ MenuItem.margin                3,6,3,6    javax.swing.plaf.InsetsUIResource [UI]
 MenuItem.minimumIconSize       16,16    javax.swing.plaf.DimensionUIResource [UI]
 MenuItem.minimumWidth          72
 MenuItem.opaque                false
+MenuItem.selectionArc          0
 MenuItem.selectionBackground   #2675bf  HSL 209  67  45    javax.swing.plaf.ColorUIResource [UI]
 MenuItem.selectionForeground   #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+MenuItem.selectionInsets       0,0,0,0    javax.swing.plaf.InsetsUIResource [UI]
 MenuItem.textAcceleratorGap    24
 MenuItem.textNoAcceleratorGap  6
 MenuItem.underlineSelectionBackground #e6e6e6  HSL   0   0  90    com.formdev.flatlaf.util.DerivedColor [UI]    darken(10% autoInverse)

--- a/flatlaf-testing/dumps/uidefaults/FlatTestLaf_1.8.0.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatTestLaf_1.8.0.txt
@@ -600,6 +600,9 @@ MenuBar.foreground             #ff0000  HSL   0 100  50    javax.swing.plaf.Colo
 MenuBar.highlight              #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
 MenuBar.hoverBackground        #ffdddd  HSL   0 100  93    javax.swing.plaf.ColorUIResource [UI]
 MenuBar.itemMargins            3,8,3,8    javax.swing.plaf.InsetsUIResource [UI]
+MenuBar.selectionArc           8
+MenuBar.selectionEmbeddedInsets 0,0,0,0    javax.swing.plaf.InsetsUIResource [UI]
+MenuBar.selectionInsets        1,3,1,3    javax.swing.plaf.InsetsUIResource [UI]
 MenuBar.shadow                 #a0a0a0  HSL   0   0  63    javax.swing.plaf.ColorUIResource [UI]
 MenuBar.underlineSelectionBackground #00ff00  HSL 120 100  50    javax.swing.plaf.ColorUIResource [UI]
 MenuBar.underlineSelectionColor #ffff00  HSL  60 100  50    javax.swing.plaf.ColorUIResource [UI]
@@ -631,8 +634,10 @@ MenuItem.margin                3,6,3,6    javax.swing.plaf.InsetsUIResource [UI]
 MenuItem.minimumIconSize       16,16    javax.swing.plaf.DimensionUIResource [UI]
 MenuItem.minimumWidth          72
 MenuItem.opaque                false
+MenuItem.selectionArc          8
 MenuItem.selectionBackground   #00aa00  HSL 120 100  33    javax.swing.plaf.ColorUIResource [UI]
 MenuItem.selectionForeground   #ffff00  HSL  60 100  50    javax.swing.plaf.ColorUIResource [UI]
+MenuItem.selectionInsets       0,3,0,3    javax.swing.plaf.InsetsUIResource [UI]
 MenuItem.textAcceleratorGap    24
 MenuItem.textNoAcceleratorGap  6
 MenuItem.underlineSelectionBackground #e6e6e6  HSL   0   0  90    javax.swing.plaf.ColorUIResource [UI]

--- a/flatlaf-testing/dumps/uidefaults/FlatTestLaf_1.8.0.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatTestLaf_1.8.0.txt
@@ -601,7 +601,9 @@ MenuBar.highlight              #ffffff  HSL   0   0 100    javax.swing.plaf.Colo
 MenuBar.hoverBackground        #ffdddd  HSL   0 100  93    javax.swing.plaf.ColorUIResource [UI]
 MenuBar.itemMargins            3,8,3,8    javax.swing.plaf.InsetsUIResource [UI]
 MenuBar.selectionArc           8
-MenuBar.selectionEmbeddedInsets 0,0,0,0    javax.swing.plaf.InsetsUIResource [UI]
+MenuBar.selectionBackground    #ff0000  HSL   0 100  50    javax.swing.plaf.ColorUIResource [UI]
+MenuBar.selectionEmbeddedInsets 2,3,2,3    javax.swing.plaf.InsetsUIResource [UI]
+MenuBar.selectionForeground    #00ff00  HSL 120 100  50    javax.swing.plaf.ColorUIResource [UI]
 MenuBar.selectionInsets        1,3,1,3    javax.swing.plaf.InsetsUIResource [UI]
 MenuBar.shadow                 #a0a0a0  HSL   0   0  63    javax.swing.plaf.ColorUIResource [UI]
 MenuBar.underlineSelectionBackground #00ff00  HSL 120 100  50    javax.swing.plaf.ColorUIResource [UI]

--- a/flatlaf-testing/src/main/resources/com/formdev/flatlaf/testing/FlatTestLaf.properties
+++ b/flatlaf-testing/src/main/resources/com/formdev/flatlaf/testing/FlatTestLaf.properties
@@ -242,10 +242,13 @@ Menu.icon.disabledArrowColor = #ABABAB
 #---- MenuBar ----
 
 MenuBar.selectionInsets = 1,3,1,3
+MenuBar.selectionEmbeddedInsets = 2,3,2,3
 MenuBar.selectionArc = 8
 
 MenuBar.borderColor = #44f
 MenuBar.hoverBackground = #fdd
+MenuBar.selectionBackground = #f00
+MenuBar.selectionForeground = #0f0
 
 MenuBar.underlineSelectionBackground = #0f0
 MenuBar.underlineSelectionColor = #ff0

--- a/flatlaf-testing/src/main/resources/com/formdev/flatlaf/testing/FlatTestLaf.properties
+++ b/flatlaf-testing/src/main/resources/com/formdev/flatlaf/testing/FlatTestLaf.properties
@@ -241,12 +241,22 @@ Menu.icon.disabledArrowColor = #ABABAB
 
 #---- MenuBar ----
 
+MenuBar.selectionInsets = 1,3,1,3
+MenuBar.selectionArc = 8
+
 MenuBar.borderColor = #44f
 MenuBar.hoverBackground = #fdd
 
 MenuBar.underlineSelectionBackground = #0f0
 MenuBar.underlineSelectionColor = #ff0
 MenuBar.underlineSelectionHeight = 5
+
+
+#---- MenuItem ----
+
+MenuItem.selectionInsets = 0,3,0,3
+MenuItem.selectionArc = 8
+
 
 #---- OptionPane ----
 

--- a/flatlaf-theme-editor/src/main/resources/com/formdev/flatlaf/themeeditor/FlatLafUIKeys.txt
+++ b/flatlaf-theme-editor/src/main/resources/com/formdev/flatlaf/themeeditor/FlatLafUIKeys.txt
@@ -462,6 +462,9 @@ MenuBar.foreground
 MenuBar.highlight
 MenuBar.hoverBackground
 MenuBar.itemMargins
+MenuBar.selectionArc
+MenuBar.selectionEmbeddedInsets
+MenuBar.selectionInsets
 MenuBar.shadow
 MenuBar.underlineSelectionBackground
 MenuBar.underlineSelectionColor
@@ -487,8 +490,10 @@ MenuItem.margin
 MenuItem.minimumIconSize
 MenuItem.minimumWidth
 MenuItem.opaque
+MenuItem.selectionArc
 MenuItem.selectionBackground
 MenuItem.selectionForeground
+MenuItem.selectionInsets
 MenuItem.textAcceleratorGap
 MenuItem.textNoAcceleratorGap
 MenuItem.underlineSelectionBackground

--- a/flatlaf-theme-editor/src/main/resources/com/formdev/flatlaf/themeeditor/FlatLafUIKeys.txt
+++ b/flatlaf-theme-editor/src/main/resources/com/formdev/flatlaf/themeeditor/FlatLafUIKeys.txt
@@ -463,7 +463,9 @@ MenuBar.highlight
 MenuBar.hoverBackground
 MenuBar.itemMargins
 MenuBar.selectionArc
+MenuBar.selectionBackground
 MenuBar.selectionEmbeddedInsets
+MenuBar.selectionForeground
 MenuBar.selectionInsets
 MenuBar.shadow
 MenuBar.underlineSelectionBackground


### PR DESCRIPTION
This PR enables using "rounded" selection for menu items.
It also enables using different selection colors for top-level `JMenu`s.

This is not yet used in any theme, but intended to be used
for macOS themes (see PR #533) and future Windows 11 style themes.

Perhaps this should also be used for existing themes to make menus look more beautiful.
Any opinions?

### Example

(left image shows rounded selection; right image shows default look)

![image](https://user-images.githubusercontent.com/5604048/168479127-aa40baec-1c5b-4727-bc8a-35b7ed8ecf38.png) ![image](https://user-images.githubusercontent.com/5604048/168479364-1e271e5d-f90a-4770-b2c2-7d6b836171c1.png)

UI properties for above screenshot (see [Application properties files](https://www.formdev.com/flatlaf/how-to-customize/#application_properties)):

~~~properties
# make menu item margins larger (default is 3,6,3,6)
@menuItemMargin = 3,9,3,9

MenuBar.selectionBackground = darken(@menuBackground,15%,derived)
MenuBar.selectionForeground = @foreground

MenuBar.selectionInsets = 1,0,1,0
MenuBar.selectionEmbeddedInsets = 3,0,3,0

MenuItem.selectionInsets = 0,3,0,3
MenuItem.selectionArc = 8
~~~