### PR TITLE
List: rounded selection

### DIFF
--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatTreeUI.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatTreeUI.java
@@ -318,12 +318,12 @@ public class FlatTreeUI
 					// same is done in BasicTreeUI.Handler.valueChanged()
 					tree.repaint();
 				} else {
-					int arcHeight = (int) Math.ceil( UIScale.scale( (float) selectionArc ) );
+					int arc = (int) Math.ceil( UIScale.scale( selectionArc / 2f ) );
 
 					for( TreePath path : changedPaths ) {
 						Rectangle r = getPathBounds( tree, path );
 						if( r != null )
-							tree.repaint( r.x, r.y - arcHeight, r.width, r.height + (arcHeight * 2) );
+							tree.repaint( r.x, r.y - arc, r.width, r.height + (arc * 2) );
 					}
 				}
 			}

--- a/flatlaf-core/src/main/resources/com/formdev/flatlaf/FlatLaf.properties
+++ b/flatlaf-core/src/main/resources/com/formdev/flatlaf/FlatLaf.properties
@@ -390,6 +390,8 @@ InternalFrameTitlePane.border = 0,8,0,0
 
 List.border = 0,0,0,0
 List.cellMargins = 1,6,1,6
+List.selectionInsets = 0,0,0,0
+List.selectionArc = 0
 List.cellFocusColor = @cellFocusColor
 List.cellNoFocusBorder = com.formdev.flatlaf.ui.FlatListCellBorder$Default
 List.focusCellHighlightBorder = com.formdev.flatlaf.ui.FlatListCellBorder$Focused
@@ -902,7 +904,6 @@ Tree.icon.collapsedColor = @icon
 Tree.icon.leafColor = @icon
 Tree.icon.closedColor = @icon
 Tree.icon.openColor = @icon
-
 
 
 #---- Styles ------------------------------------------------------------------

--- a/flatlaf-core/src/test/java/com/formdev/flatlaf/ui/TestFlatStyleableInfo.java
+++ b/flatlaf-core/src/test/java/com/formdev/flatlaf/ui/TestFlatStyleableInfo.java
@@ -254,6 +254,8 @@ public class TestFlatStyleableInfo
 			"selectionForeground", Color.class,
 			"selectionInactiveBackground", Color.class,
 			"selectionInactiveForeground", Color.class,
+			"selectionInsets", Insets.class,
+			"selectionArc", int.class,
 
 			// FlatListCellBorder
 			"cellMargins", Insets.class,

--- a/flatlaf-core/src/test/java/com/formdev/flatlaf/ui/TestFlatStyling.java
+++ b/flatlaf-core/src/test/java/com/formdev/flatlaf/ui/TestFlatStyling.java
@@ -401,6 +401,8 @@ public class TestFlatStyling
 		ui.applyStyle( "selectionForeground: #fff" );
 		ui.applyStyle( "selectionInactiveBackground: #fff" );
 		ui.applyStyle( "selectionInactiveForeground: #fff" );
+		ui.applyStyle( "selectionInsets: 1,2,3,4" );
+		ui.applyStyle( "selectionArc: 8" );
 
 		// FlatListCellBorder
 		ui.applyStyle( "cellMargins: 1,2,3,4" );

--- a/flatlaf-demo/src/main/java/com/formdev/flatlaf/demo/intellijthemes/IJThemesPanel.java
+++ b/flatlaf-demo/src/main/java/com/formdev/flatlaf/demo/intellijthemes/IJThemesPanel.java
@@ -19,6 +19,7 @@ package com.formdev.flatlaf.demo.intellijthemes;
 import java.awt.Component;
 import java.awt.Desktop;
 import java.awt.EventQueue;
+import java.awt.Graphics;
 import java.awt.Rectangle;
 import java.awt.Window;
 import java.awt.event.WindowAdapter;
@@ -40,6 +41,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.function.Predicate;
 import javax.swing.*;
+import javax.swing.border.Border;
 import javax.swing.border.CompoundBorder;
 import javax.swing.event.*;
 import com.formdev.flatlaf.FlatDarculaLaf;
@@ -52,6 +54,7 @@ import com.formdev.flatlaf.IntelliJTheme;
 import com.formdev.flatlaf.demo.DemoPrefs;
 import com.formdev.flatlaf.extras.FlatAnimatedLafChange;
 import com.formdev.flatlaf.extras.FlatSVGIcon;
+import com.formdev.flatlaf.ui.FlatListUI;
 import com.formdev.flatlaf.util.LoggingFacade;
 import com.formdev.flatlaf.util.StringUtils;
 import net.miginfocom.swing.*;
@@ -89,10 +92,18 @@ public class IJThemesPanel
 
 		// create renderer
 		themesList.setCellRenderer( new DefaultListCellRenderer() {
+			private int index;
+			private boolean isSelected;
+			private int titleHeight;
+
 			@Override
 			public Component getListCellRendererComponent( JList<?> list, Object value,
 				int index, boolean isSelected, boolean cellHasFocus )
 			{
+				this.index = index;
+				this.isSelected = isSelected;
+				this.titleHeight = 0;
+
 				String title = categories.get( index );
 				String name = ((IJThemeInfo)value).name;
 				int sep = name.indexOf( '/' );
@@ -101,9 +112,31 @@ public class IJThemesPanel
 
 				JComponent c = (JComponent) super.getListCellRendererComponent( list, name, index, isSelected, cellHasFocus );
 				c.setToolTipText( buildToolTip( (IJThemeInfo) value ) );
-				if( title != null )
-					c.setBorder( new CompoundBorder( new ListCellTitledBorder( themesList, title ), c.getBorder() ) );
+				if( title != null ) {
+					Border titledBorder = new ListCellTitledBorder( themesList, title );
+					c.setBorder( new CompoundBorder( titledBorder, c.getBorder() ) );
+					titleHeight = titledBorder.getBorderInsets( c ).top;
+				}
 				return c;
+			}
+
+			@Override
+			public boolean isOpaque() {
+				return !isSelectedTitle();
+			}
+
+			@Override
+			protected void paintComponent( Graphics g ) {
+				if( isSelectedTitle() ) {
+					g.setColor( getBackground() );
+					FlatListUI.paintCellSelection( themesList, g, index, 0, titleHeight, getWidth(), getHeight() - titleHeight );
+				}
+
+				super.paintComponent( g );
+			}
+
+			private boolean isSelectedTitle() {
+				return titleHeight > 0 && isSelected && UIManager.getLookAndFeel() instanceof FlatLaf;
 			}
 
 			private String buildToolTip( IJThemeInfo ti ) {

--- a/flatlaf-testing/dumps/uidefaults/FlatDarkLaf_1.8.0.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatDarkLaf_1.8.0.txt
@@ -545,10 +545,12 @@ List.focusSelectedCellHighlightBorder [lazy] 1,6,1,6  false    com.formdev.flatl
 List.font                      [active] $defaultFont [UI]
 List.foreground                #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
 List.noFocusBorder             1,1,1,1  false    javax.swing.plaf.BorderUIResource$EmptyBorderUIResource [UI]
+List.selectionArc              0
 List.selectionBackground       #4b6eaf  HSL 219  40  49    javax.swing.plaf.ColorUIResource [UI]
 List.selectionForeground       #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
 List.selectionInactiveBackground #0f2a3d  HSL 205  61  15    javax.swing.plaf.ColorUIResource [UI]
 List.selectionInactiveForeground #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+List.selectionInsets           0,0,0,0    javax.swing.plaf.InsetsUIResource [UI]
 List.showCellFocusIndicator    false
 List.timeFactor                1000
 ListUI                         com.formdev.flatlaf.ui.FlatListUI

--- a/flatlaf-testing/dumps/uidefaults/FlatLightLaf_1.8.0.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatLightLaf_1.8.0.txt
@@ -550,10 +550,12 @@ List.focusSelectedCellHighlightBorder [lazy] 1,6,1,6  false    com.formdev.flatl
 List.font                      [active] $defaultFont [UI]
 List.foreground                #000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]
 List.noFocusBorder             1,1,1,1  false    javax.swing.plaf.BorderUIResource$EmptyBorderUIResource [UI]
+List.selectionArc              0
 List.selectionBackground       #2675bf  HSL 209  67  45    javax.swing.plaf.ColorUIResource [UI]
 List.selectionForeground       #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
 List.selectionInactiveBackground #d3d3d3  HSL   0   0  83    javax.swing.plaf.ColorUIResource [UI]
 List.selectionInactiveForeground #000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]
+List.selectionInsets           0,0,0,0    javax.swing.plaf.InsetsUIResource [UI]
 List.showCellFocusIndicator    false
 List.timeFactor                1000
 ListUI                         com.formdev.flatlaf.ui.FlatListUI

--- a/flatlaf-testing/dumps/uidefaults/FlatTestLaf_1.8.0.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatTestLaf_1.8.0.txt
@@ -552,10 +552,12 @@ List.focusSelectedCellHighlightBorder [lazy] 1,6,1,6  false    com.formdev.flatl
 List.font                      [active] $defaultFont [UI]
 List.foreground                #ff0000  HSL   0 100  50    javax.swing.plaf.ColorUIResource [UI]
 List.noFocusBorder             1,1,1,1  false    javax.swing.plaf.BorderUIResource$EmptyBorderUIResource [UI]
+List.selectionArc              0
 List.selectionBackground       #00aa00  HSL 120 100  33    javax.swing.plaf.ColorUIResource [UI]
 List.selectionForeground       #ffff00  HSL  60 100  50    javax.swing.plaf.ColorUIResource [UI]
 List.selectionInactiveBackground #888888  HSL   0   0  53    javax.swing.plaf.ColorUIResource [UI]
 List.selectionInactiveForeground #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+List.selectionInsets           0,0,0,0    javax.swing.plaf.InsetsUIResource [UI]
 List.showCellFocusIndicator    false
 List.timeFactor                1000
 ListUI                         com.formdev.flatlaf.ui.FlatListUI

--- a/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatComponents2Test.jfd
+++ b/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatComponents2Test.jfd
@@ -318,7 +318,7 @@ new FormModel {
 			add( new FormContainer( "javax.swing.JPanel", new FormLayoutManager( class net.miginfocom.swing.MigLayout ) {
 				"$layoutConstraints": "hidemode 3"
 				"$columnConstraints": "[fill][fill]"
-				"$rowConstraints": "[]"
+				"$rowConstraints": "[][][]"
 			} ) {
 				name: "panel6"
 				"border": new javax.swing.border.TitledBorder( "JList Control" )
@@ -335,6 +335,7 @@ new FormModel {
 						addElement( "default" )
 						addElement( "defaultSubclass" )
 						addElement( "label" )
+						addElement( "labelRounded" )
 					}
 					auxiliary() {
 						"JavaCodeGenerator.variableLocal": false
@@ -342,6 +343,47 @@ new FormModel {
 					addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "listRendererChanged", false ) )
 				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
 					"value": "cell 1 0"
+				} )
+				add( new FormComponent( "javax.swing.JLabel" ) {
+					name: "listLayoutOrientationLabel"
+					"text": "Orientation:"
+				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+					"value": "cell 0 1"
+				} )
+				add( new FormComponent( "javax.swing.JComboBox" ) {
+					name: "listLayoutOrientationField"
+					"model": new javax.swing.DefaultComboBoxModel {
+						selectedItem: "vertical"
+						addElement( "vertical" )
+						addElement( "vertical wrap" )
+						addElement( "horzontal wrap" )
+					}
+					auxiliary() {
+						"JavaCodeGenerator.variableLocal": false
+						"JavaCodeGenerator.typeParameters": "String"
+					}
+					addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "listLayoutOrientationChanged", false ) )
+				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+					"value": "cell 1 1"
+				} )
+				add( new FormComponent( "javax.swing.JLabel" ) {
+					name: "listVisibleRowCountLabel"
+					"text": "Visible row count:"
+				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+					"value": "cell 0 2"
+				} )
+				add( new FormComponent( "javax.swing.JSpinner" ) {
+					name: "listVisibleRowCountSpinner"
+					"model": new javax.swing.SpinnerNumberModel {
+						minimum: 0
+						value: 8
+					}
+					auxiliary() {
+						"JavaCodeGenerator.variableLocal": false
+					}
+					addEvent( new FormEvent( "javax.swing.event.ChangeListener", "stateChanged", "listVisibleRowCountChanged", false ) )
+				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+					"value": "cell 1 2"
 				} )
 			}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
 				"value": "cell 0 4 4 1"

--- a/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatComponents2Test.jfd
+++ b/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatComponents2Test.jfd
@@ -1,4 +1,4 @@
-JFDML JFormDesigner: "7.0.5.0.382" Java: "16" encoding: "UTF-8"
+JFDML JFormDesigner: "7.0.5.0.404" Java: "17.0.2" encoding: "UTF-8"
 
 new FormModel {
 	contentType: "form/swing"
@@ -296,14 +296,14 @@ new FormModel {
 			} )
 			add( new FormContainer( "javax.swing.JPanel", new FormLayoutManager( class net.miginfocom.swing.MigLayout ) {
 				"$layoutConstraints": "hidemode 3"
-				"$columnConstraints": "[fill][fill]"
+				"$columnConstraints": "[fill]"
 				"$rowConstraints": "[]"
 			} ) {
 				name: "panel5"
 				"border": new javax.swing.border.TitledBorder( "General Control" )
 				add( new FormComponent( "javax.swing.JCheckBox" ) {
 					name: "dndCheckBox"
-					"text": "enable drag and drop"
+					"text": "drag and drop"
 					"mnemonic": 68
 					auxiliary() {
 						"JavaCodeGenerator.variableLocal": false
@@ -313,7 +313,38 @@ new FormModel {
 					"value": "cell 0 0"
 				} )
 			}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-				"value": "cell 1 4"
+				"value": "cell 0 4 4 1"
+			} )
+			add( new FormContainer( "javax.swing.JPanel", new FormLayoutManager( class net.miginfocom.swing.MigLayout ) {
+				"$layoutConstraints": "hidemode 3"
+				"$columnConstraints": "[fill][fill]"
+				"$rowConstraints": "[]"
+			} ) {
+				name: "panel6"
+				"border": new javax.swing.border.TitledBorder( "JList Control" )
+				add( new FormComponent( "javax.swing.JLabel" ) {
+					name: "listRendererLabel"
+					"text": "Renderer:"
+				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+					"value": "cell 0 0"
+				} )
+				add( new FormComponent( "javax.swing.JComboBox" ) {
+					name: "listRendererComboBox"
+					"model": new javax.swing.DefaultComboBoxModel {
+						selectedItem: "default"
+						addElement( "default" )
+						addElement( "defaultSubclass" )
+						addElement( "label" )
+					}
+					auxiliary() {
+						"JavaCodeGenerator.variableLocal": false
+					}
+					addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "listRendererChanged", false ) )
+				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+					"value": "cell 1 0"
+				} )
+			}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+				"value": "cell 0 4 4 1"
 			} )
 			add( new FormContainer( "javax.swing.JPanel", new FormLayoutManager( class net.miginfocom.swing.MigLayout ) {
 				"$layoutConstraints": "hidemode 3"
@@ -378,7 +409,7 @@ new FormModel {
 					"value": "cell 0 3"
 				} )
 			}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-				"value": "cell 2 4"
+				"value": "cell 0 4 4 1"
 			} )
 			add( new FormContainer( "javax.swing.JPanel", new FormLayoutManager( class net.miginfocom.swing.MigLayout ) {
 				"$layoutConstraints": "hidemode 3"

--- a/flatlaf-theme-editor/src/main/resources/com/formdev/flatlaf/themeeditor/FlatLafUIKeys.txt
+++ b/flatlaf-theme-editor/src/main/resources/com/formdev/flatlaf/themeeditor/FlatLafUIKeys.txt
@@ -424,10 +424,12 @@ List.focusSelectedCellHighlightBorder
 List.font
 List.foreground
 List.noFocusBorder
+List.selectionArc
 List.selectionBackground
 List.selectionForeground
 List.selectionInactiveBackground
 List.selectionInactiveForeground
+List.selectionInsets
 List.showCellFocusIndicator
 List.timeFactor
 ListUI


### PR DESCRIPTION
This PR enables using "rounded" selection for list selection.

This is not yet used in any theme, but intended to be used
for macOS themes (see PR #533) and future Windows 11 style themes.

### Examples

![grafik](https://user-images.githubusercontent.com/5604048/171998528-e7793303-7f46-428b-a8d5-7b9c8bce2e69.png)

UI properties for above screenshot (see [Application properties files](https://www.formdev.com/flatlaf/how-to-customize/#application_properties)):

~~~properties
List.selectionInsets = 0,1,0,1
List.selectionArc = 6
~~~

The problem with this is that there is no gap between the top border and the first selected item:

![grafik](https://user-images.githubusercontent.com/5604048/171998657-1d9246ea-650a-43a7-8988-23e723df0d9f.png)

To fix this, a empty border can be used instead of `selectionInsets`:

![grafik](https://user-images.githubusercontent.com/5604048/171998754-0f8af7ca-630e-42c2-8592-a5f26e1ccabe.png)

~~~properties
List.border = 1,1,1,1
List.selectionArc = 6
~~~

#### Layout orientation

Works also for layout orientations `VERTICAL_WRAP` and `HORIZONTAL_WRAP`:

![grafik](https://user-images.githubusercontent.com/5604048/171998510-bd41656a-301a-445a-b222-52a187baf9cf.png)

~~~properties
List.selectionInsets = 0,1,0,1
List.selectionArc = 6
~~~

With zero `selectionInsets` it looks like this:

![grafik](https://user-images.githubusercontent.com/5604048/171998454-0efcf86f-3a12-42bb-b660-941d236e3610.png)

~~~properties
List.border = 1,1,1,1
List.selectionArc = 6
~~~
