### PR TITLE
ComboBox: support rounded selection

### DIFF
--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatComboBoxUI.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatComboBoxUI.java
@@ -114,6 +114,9 @@ import com.formdev.flatlaf.util.SystemInfo;
  * @uiDefault ComboBox.buttonHoverArrowColor	Color
  * @uiDefault ComboBox.buttonPressedArrowColor	Color
  * @uiDefault ComboBox.popupBackground			Color	optional
+ * @uiDefault ComboBox.popupInsets				Insets
+ * @uiDefault ComboBox.selectionInsets			Insets
+ * @uiDefault ComboBox.selectionArc				int
  *
  * @author Karl Tauber
  */
@@ -144,6 +147,9 @@ public class FlatComboBoxUI
 	@Styleable protected Color buttonPressedArrowColor;
 
 	@Styleable protected Color popupBackground;
+	/** @since 3 */ @Styleable protected Insets popupInsets;
+	/** @since 3 */ @Styleable protected Insets selectionInsets;
+	/** @since 3 */ @Styleable protected int selectionArc;
 
 	private MouseListener hoverListener;
 	protected boolean hover;
@@ -239,6 +245,9 @@ public class FlatComboBoxUI
 		buttonPressedArrowColor = UIManager.getColor( "ComboBox.buttonPressedArrowColor" );
 
 		popupBackground = UIManager.getColor( "ComboBox.popupBackground" );
+		popupInsets = UIManager.getInsets( "ComboBox.popupInsets" );
+		selectionInsets = UIManager.getInsets( "ComboBox.selectionInsets" );
+		selectionArc = UIManager.getInt( "ComboBox.selectionArc" );
 
 		// set maximumRowCount
 		int maximumRowCount = UIManager.getInt( "ComboBox.maximumRowCount" );
@@ -818,17 +827,12 @@ public class FlatComboBoxUI
 			// make opaque to avoid that background shines thru border (e.g. at 150% scaling)
 			setOpaque( true );
 
-	        // set popup border
-	        // use non-UIResource to avoid that it is overwritten when making
-	        // popup visible (see JPopupMenu.setInvoker()) in theme editor preview
+			// set popup border
+			// use non-UIResource to avoid that it is overwritten when making
+			// popup visible (see JPopupMenu.setInvoker()) in theme editor preview
 			Border border = UIManager.getBorder( "PopupMenu.border" );
 			if( border != null )
 				setBorder( FlatUIUtils.nonUIResource( border ) );
-		}
-
-		@Override
-		protected void configureList() {
-			super.configureList();
 
 			list.setCellRenderer( new PopupListCellRenderer() );
 			updateStyle();
@@ -836,12 +840,21 @@ public class FlatComboBoxUI
 
 		void updateStyle() {
 			if( popupBackground != null )
-		        list.setBackground( popupBackground );
+				list.setBackground( popupBackground );
 
-	        // set popup background because it may shine thru when scaled (e.g. at 150%)
-	        // use non-UIResource to avoid that it is overwritten when making
-	        // popup visible (see JPopupMenu.setInvoker()) in theme editor preview
-	        setBackground( FlatUIUtils.nonUIResource( list.getBackground() ) );
+			// set popup background because it may shine thru when scaled (e.g. at 150%)
+			// use non-UIResource to avoid that it is overwritten when making
+			// popup visible (see JPopupMenu.setInvoker()) in theme editor preview
+			setBackground( FlatUIUtils.nonUIResource( list.getBackground() ) );
+
+			scroller.setViewportBorder( (popupInsets != null) ? new FlatEmptyBorder( popupInsets ) : null );
+			scroller.setOpaque( false );
+
+			if( list.getUI() instanceof FlatListUI ) {
+				FlatListUI ui = (FlatListUI) list.getUI();
+				ui.selectionInsets = selectionInsets;
+				ui.selectionArc = selectionArc;
+			}
 		}
 
 		@Override

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatListUI.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatListUI.java
@@ -37,6 +37,7 @@ import javax.swing.ListSelectionModel;
 import javax.swing.UIManager;
 import javax.swing.event.ListSelectionListener;
 import javax.swing.plaf.ComponentUI;
+import javax.swing.plaf.basic.BasicComboBoxRenderer;
 import javax.swing.plaf.basic.BasicListUI;
 import com.formdev.flatlaf.FlatClientProperties;
 import com.formdev.flatlaf.ui.FlatStylingSupport.Styleable;
@@ -306,7 +307,8 @@ public class FlatListUI
 		// rounded selection or selection insets
 		if( isSelected &&
 			!isFileList && // rounded selection is not supported for file list
-			rendererComponent instanceof DefaultListCellRenderer &&
+			(rendererComponent instanceof DefaultListCellRenderer ||
+			 rendererComponent instanceof BasicComboBoxRenderer) &&
 			(selectionArc > 0 ||
 			 (selectionInsets != null &&
 			  (selectionInsets.top != 0 || selectionInsets.left != 0 || selectionInsets.bottom != 0 || selectionInsets.right != 0))) )

--- a/flatlaf-core/src/main/resources/com/formdev/flatlaf/FlatLaf.properties
+++ b/flatlaf-core/src/main/resources/com/formdev/flatlaf/FlatLaf.properties
@@ -285,6 +285,10 @@ ComboBox.buttonDisabledArrowColor = @buttonDisabledArrowColor
 ComboBox.buttonHoverArrowColor = @buttonHoverArrowColor
 ComboBox.buttonPressedArrowColor = @buttonPressedArrowColor
 
+ComboBox.popupInsets = 0,0,0,0
+ComboBox.selectionInsets = 0,0,0,0
+ComboBox.selectionArc = 0
+
 
 #---- Component ----
 

--- a/flatlaf-core/src/test/java/com/formdev/flatlaf/ui/TestFlatStyleableInfo.java
+++ b/flatlaf-core/src/test/java/com/formdev/flatlaf/ui/TestFlatStyleableInfo.java
@@ -173,7 +173,10 @@ public class TestFlatStyleableInfo
 			"buttonHoverArrowColor", Color.class,
 			"buttonPressedArrowColor", Color.class,
 
-			"popupBackground", Color.class
+			"popupBackground", Color.class,
+			"popupInsets", Insets.class,
+			"selectionInsets", Insets.class,
+			"selectionArc", int.class
 		);
 
 		// border

--- a/flatlaf-core/src/test/java/com/formdev/flatlaf/ui/TestFlatStyling.java
+++ b/flatlaf-core/src/test/java/com/formdev/flatlaf/ui/TestFlatStyling.java
@@ -304,6 +304,9 @@ public class TestFlatStyling
 		ui.applyStyle( "buttonPressedArrowColor: #fff" );
 
 		ui.applyStyle( "popupBackground: #fff" );
+		ui.applyStyle( "popupInsets: 1,2,3,4" );
+		ui.applyStyle( "selectionInsets: 1,2,3,4" );
+		ui.applyStyle( "selectionArc: 8" );
 
 		// border
 		flatRoundBorder( style -> ui.applyStyle( style ) );

--- a/flatlaf-testing/dumps/uidefaults/FlatDarkLaf_1.8.0.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatDarkLaf_1.8.0.txt
@@ -220,8 +220,11 @@ ComboBox.maximumRowCount       15
 ComboBox.minimumWidth          72
 ComboBox.noActionOnKeyNavigation false
 ComboBox.padding               2,6,2,6    javax.swing.plaf.InsetsUIResource [UI]
+ComboBox.popupInsets           0,0,0,0    javax.swing.plaf.InsetsUIResource [UI]
+ComboBox.selectionArc          0
 ComboBox.selectionBackground   #4b6eaf  HSL 219  40  49    javax.swing.plaf.ColorUIResource [UI]
 ComboBox.selectionForeground   #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+ComboBox.selectionInsets       0,0,0,0    javax.swing.plaf.InsetsUIResource [UI]
 ComboBox.timeFactor            1000
 ComboBoxUI                     com.formdev.flatlaf.ui.FlatComboBoxUI
 

--- a/flatlaf-testing/dumps/uidefaults/FlatLightLaf_1.8.0.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatLightLaf_1.8.0.txt
@@ -224,8 +224,11 @@ ComboBox.maximumRowCount       15
 ComboBox.minimumWidth          72
 ComboBox.noActionOnKeyNavigation false
 ComboBox.padding               2,6,2,6    javax.swing.plaf.InsetsUIResource [UI]
+ComboBox.popupInsets           0,0,0,0    javax.swing.plaf.InsetsUIResource [UI]
+ComboBox.selectionArc          0
 ComboBox.selectionBackground   #2675bf  HSL 209  67  45    javax.swing.plaf.ColorUIResource [UI]
 ComboBox.selectionForeground   #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
+ComboBox.selectionInsets       0,0,0,0    javax.swing.plaf.InsetsUIResource [UI]
 ComboBox.timeFactor            1000
 ComboBoxUI                     com.formdev.flatlaf.ui.FlatComboBoxUI
 

--- a/flatlaf-testing/dumps/uidefaults/FlatTestLaf_1.8.0.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatTestLaf_1.8.0.txt
@@ -231,8 +231,11 @@ ComboBox.minimumWidth          72
 ComboBox.noActionOnKeyNavigation false
 ComboBox.padding               2,6,2,6    javax.swing.plaf.InsetsUIResource [UI]
 ComboBox.popupBackground       #ffffcc  HSL  60 100  90    javax.swing.plaf.ColorUIResource [UI]
+ComboBox.popupInsets           0,0,0,0    javax.swing.plaf.InsetsUIResource [UI]
+ComboBox.selectionArc          0
 ComboBox.selectionBackground   #00aa00  HSL 120 100  33    javax.swing.plaf.ColorUIResource [UI]
 ComboBox.selectionForeground   #ffff00  HSL  60 100  50    javax.swing.plaf.ColorUIResource [UI]
+ComboBox.selectionInsets       0,0,0,0    javax.swing.plaf.InsetsUIResource [UI]
 ComboBox.timeFactor            1000
 ComboBoxUI                     com.formdev.flatlaf.ui.FlatComboBoxUI
 

--- a/flatlaf-theme-editor/src/main/resources/com/formdev/flatlaf/themeeditor/FlatLafUIKeys.txt
+++ b/flatlaf-theme-editor/src/main/resources/com/formdev/flatlaf/themeeditor/FlatLafUIKeys.txt
@@ -196,8 +196,11 @@ ComboBox.minimumWidth
 ComboBox.noActionOnKeyNavigation
 ComboBox.padding
 ComboBox.popupBackground
+ComboBox.popupInsets
+ComboBox.selectionArc
 ComboBox.selectionBackground
 ComboBox.selectionForeground
+ComboBox.selectionInsets
 ComboBox.timeFactor
 ComboBoxUI
 Component.accentColor


### PR DESCRIPTION
This PR enables using "rounded" selection for combo box popup list.

This is not yet used in any theme, but intended to be used
for macOS themes (see PR #533) and future Windows 11 style themes.

### Example

![grafik](https://user-images.githubusercontent.com/5604048/172027793-1e35b5ce-f330-4402-99a7-ab42d8bc26bd.png)

UI properties for above screenshot (see [Application properties files](https://www.formdev.com/flatlaf/how-to-customize/#application_properties)):

~~~properties
ComboBox.popupInsets = 1,0,1,0
ComboBox.selectionInsets = 0,1,0,1
ComboBox.selectionArc = 6
~~~
