### PR TITLE
`systemColor()` function and support changing accent color in macOS themes

### DIFF
--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/FlatLaf.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/FlatLaf.java
@@ -98,6 +98,7 @@ public abstract class FlatLaf
 	private static List<Object> customDefaultsSources;
 	private static Map<String, String> globalExtraDefaults;
 	private Map<String, String> extraDefaults;
+	private static Function<String, Color> systemColorGetter;
 
 	private String desktopPropertyName;
 	private String desktopPropertyName2;
@@ -897,14 +898,14 @@ public abstract class FlatLaf
 	 * E.g. using {@link UIManager#setLookAndFeel(LookAndFeel)} or {@link #setup(LookAndFeel)}.
 	 * <p>
 	 * The global extra defaults are useful for smaller additional defaults that may change.
-	 * E.g. accent color. Otherwise, FlatLaf properties files should be used.
+	 * Otherwise, FlatLaf properties files should be used.
 	 * See {@link #registerCustomDefaultsSource(String)}.
 	 * <p>
 	 * The keys and values are strings in same format as in FlatLaf properties files.
 	 * <p>
-	 * Sample that setups "FlatLaf Light" theme with red accent color:
+	 * Sample that setups "FlatLaf Light" theme with white background color:
 	 * <pre>{@code
-	 * FlatLaf.setGlobalExtraDefaults( Collections.singletonMap( "@accentColor", "#f00" ) );
+	 * FlatLaf.setGlobalExtraDefaults( Collections.singletonMap( "@background", "#fff" ) );
 	 * FlatLightLaf.setup();
 	 * }</pre>
 	 *
@@ -929,15 +930,15 @@ public abstract class FlatLaf
 	 * E.g. using {@link UIManager#setLookAndFeel(LookAndFeel)} or {@link #setup(LookAndFeel)}.
 	 * <p>
 	 * The extra defaults are useful for smaller additional defaults that may change.
-	 * E.g. accent color. Otherwise, FlatLaf properties files should be used.
+	 * Otherwise, FlatLaf properties files should be used.
 	 * See {@link #registerCustomDefaultsSource(String)}.
 	 * <p>
 	 * The keys and values are strings in same format as in FlatLaf properties files.
 	 * <p>
-	 * Sample that setups "FlatLaf Light" theme with red accent color:
+	 * Sample that setups "FlatLaf Light" theme with white background color:
 	 * <pre>{@code
 	 * FlatLaf laf = new FlatLightLaf();
-	 * laf.setExtraDefaults( Collections.singletonMap( "@accentColor", "#f00" ) );
+	 * laf.setExtraDefaults( Collections.singletonMap( "@background", "#fff" ) );
 	 * FlatLaf.setup( laf );
 	 * }</pre>
 	 *
@@ -977,6 +978,36 @@ public abstract class FlatLaf
 			val = ((ActiveValue)val).createValue( null );
 
 		return val;
+	}
+
+	/**
+	 * Returns the system color getter function, or {@code null}.
+	 *
+	 * @since 3
+	 */
+	public static Function<String, Color> getSystemColorGetter() {
+		return systemColorGetter;
+	}
+
+	/**
+	 * Sets a system color getter function that is invoked when function
+	 * {@code systemColor()} is used in FlatLaf properties files.
+	 * <p>
+	 * The name of the system color is passed as parameter to the function.
+	 * The function should return {@code null} for unknown system colors.
+	 * <p>
+	 * Can be used to change the accent color:
+	 * <pre>{@code
+	 * FlatLaf.setSystemColorGetter( name -> {
+	 *     return name.equals( "accent" ) ? Color.red : null;
+	 * } );
+	 * FlatLightLaf.setup();
+	 * }</pre>
+	 *
+	 * @since 3
+	 */
+	public static void setSystemColorGetter( Function<String, Color> systemColorGetter ) {
+		FlatLaf.systemColorGetter = systemColorGetter;
 	}
 
 	private static void reSetLookAndFeel() {

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/IntelliJTheme.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/IntelliJTheme.java
@@ -302,7 +302,7 @@ public class IntelliJTheme
 
 		for( Map.Entry<String, String> e : colors.entrySet() ) {
 			String value = e.getValue();
-			ColorUIResource color = UIDefaultsLoader.parseColor( value );
+			ColorUIResource color = parseColor( value );
 			if( color != null ) {
 				String key = e.getKey();
 				namedColors.put( key, color );
@@ -448,7 +448,15 @@ public class IntelliJTheme
 		ColorUIResource color = namedColors.get( value );
 
 		// parse color
-		return (color != null) ? color : UIDefaultsLoader.parseColor( value );
+		return (color != null) ? color : parseColor( value );
+	}
+
+	private ColorUIResource parseColor( String value ) {
+		try {
+			return UIDefaultsLoader.parseColor( value );
+		} catch( IllegalArgumentException ex ) {
+			return null;
+		}
 	}
 
 	/**
@@ -540,7 +548,7 @@ public class IntelliJTheme
 				// radioFocused.svg and radioSelectedFocused.svg
 				// use opacity=".65" for the border
 				// --> add alpha to focused border colors
-				String[] focusedBorderColorKeys = new String[] {
+				String[] focusedBorderColorKeys = {
 					"CheckBox.icon.focusedBorderColor",
 					"CheckBox.icon.focusedSelectedBorderColor",
 					"CheckBox.icon[filled].focusedBorderColor",

--- a/flatlaf-core/src/main/resources/com/formdev/flatlaf/FlatDarkLaf.properties
+++ b/flatlaf-core/src/main/resources/com/formdev/flatlaf/FlatDarkLaf.properties
@@ -63,7 +63,7 @@
 # accent colors (blueish)
 #   set @accentColor to use single accent color or
 #   modify @accentBaseColor to use variations of accent base color
-@accentColor = null
+@accentColor = systemColor(accent,null)
 @accentBaseColor = #4B6EAF
 @accentBase2Color = lighten(saturate(spin(@accentBaseColor,-8),13%),5%)
 #   accent color variations

--- a/flatlaf-core/src/main/resources/com/formdev/flatlaf/FlatLightLaf.properties
+++ b/flatlaf-core/src/main/resources/com/formdev/flatlaf/FlatLightLaf.properties
@@ -63,7 +63,7 @@
 # accent colors (blueish)
 #   set @accentColor to use single accent color or
 #   modify @accentBaseColor to use variations of accent base color
-@accentColor = null
+@accentColor = systemColor(accent,null)
 @accentBaseColor = #2675BF
 @accentBase2Color = lighten(saturate(@accentBaseColor,10%),6%)
 #   accent color variations

--- a/flatlaf-core/src/main/resources/com/formdev/flatlaf/themes/FlatMacDarkLaf.properties
+++ b/flatlaf-core/src/main/resources/com/formdev/flatlaf/themes/FlatMacDarkLaf.properties
@@ -88,12 +88,12 @@
 @menuBackground = lighten(@background,8%)
 
 # selection
-@selectionBackground = @nsSelectedContentBackgroundColor
+@selectionBackground = if(systemColor(accent), shade(spin(systemColor(accent),4),20%), @nsSelectedContentBackgroundColor)
 @selectionForeground = @nsSelectedMenuItemTextColor
 @selectionInactiveBackground = @nsUnemphasizedSelectedContentBackgroundColor
 
 # text selection
-@textSelectionBackground = @nsSelectedTextBackgroundColor
+@textSelectionBackground = systemColor(highlight,if(systemColor(accent), darken(desaturate(systemColor(accent),60%),10%), @nsSelectedTextBackgroundColor))
 @textSelectionForeground = @nsSelectedTextColor
 
 # menu
@@ -101,8 +101,8 @@
 @menuItemMargin = 3,11,3,11
 
 # accent colors (blueish)
-@accentColor = @nsControlAccentColor
-@accentFocusColor = @nsKeyboardFocusIndicatorColor
+@accentColor = systemColor(accent,@nsControlAccentColor)
+@accentFocusColor = if(systemColor(accent), fade(spin(systemColor(accent),-10),50%), @nsKeyboardFocusIndicatorColor)
 
 
 #---- Button ----

--- a/flatlaf-core/src/main/resources/com/formdev/flatlaf/themes/FlatMacLightLaf.properties
+++ b/flatlaf-core/src/main/resources/com/formdev/flatlaf/themes/FlatMacLightLaf.properties
@@ -88,12 +88,12 @@
 @menuBackground = darken(@background,4%)
 
 # selection
-@selectionBackground = @nsSelectedContentBackgroundColor
+@selectionBackground = if(systemColor(accent), shade(spin(systemColor(accent),4),10%), @nsSelectedContentBackgroundColor)
 @selectionForeground = @nsSelectedMenuItemTextColor
 @selectionInactiveBackground = @nsUnemphasizedSelectedContentBackgroundColor
 
 # text selection
-@textSelectionBackground = @nsSelectedTextBackgroundColor
+@textSelectionBackground = systemColor(highlight,if(systemColor(accent), tint(systemColor(accent),70%), @nsSelectedTextBackgroundColor))
 @textSelectionForeground = @foreground
 
 # menu
@@ -102,8 +102,8 @@
 @menuItemMargin = 3,11,3,11
 
 # accent colors (blueish)
-@accentColor = @nsControlAccentColor
-@accentFocusColor = @nsKeyboardFocusIndicatorColor
+@accentColor = systemColor(accent,@nsControlAccentColor)
+@accentFocusColor = if(systemColor(accent), fade(spin(systemColor(accent),4),50%), @nsKeyboardFocusIndicatorColor)
 
 
 #---- Button ----

--- a/flatlaf-demo/src/main/java/com/formdev/flatlaf/demo/DemoFrame.java
+++ b/flatlaf-demo/src/main/java/com/formdev/flatlaf/demo/DemoFrame.java
@@ -24,7 +24,6 @@ import java.net.URISyntaxException;
 import java.time.Year;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.prefs.Preferences;
 import javax.swing.*;
 import javax.swing.text.DefaultEditorKit;
@@ -398,6 +397,7 @@ class DemoFrame
 	};
 	private final JToggleButton[] accentColorButtons = new JToggleButton[accentColorKeys.length];
 	private JLabel accentColorLabel;
+	private Color accentColor;
 
 	private void initAccentColors() {
 		accentColorLabel = new JLabel( "Accent color: " );
@@ -416,6 +416,10 @@ class DemoFrame
 
 		accentColorButtons[0].setSelected( true );
 
+		FlatLaf.setSystemColorGetter( name -> {
+			return name.equals( "accent" ) ? accentColor : null;
+		} );
+
 		UIManager.addPropertyChangeListener( e -> {
 			if( "lookAndFeel".equals( e.getPropertyName() ) )
 				updateAccentColorButtons();
@@ -424,17 +428,17 @@ class DemoFrame
 	}
 
 	private void accentColorChanged( ActionEvent e ) {
-		String accentColor = accentColorKeys[0];
+		String accentColorKey = null;
 		for( int i = 0; i < accentColorButtons.length; i++ ) {
 			if( accentColorButtons[i].isSelected() ) {
-				accentColor = accentColorKeys[i];
+				accentColorKey = accentColorKeys[i];
 				break;
 			}
 		}
 
-		FlatLaf.setGlobalExtraDefaults( (accentColor != accentColorKeys[0])
-			? Collections.singletonMap( "@accentColor", "$" + accentColor )
-			: null );
+		accentColor = (accentColorKey != null && accentColorKey != accentColorKeys[0])
+			? UIManager.getColor( accentColorKey )
+			: null;
 
 		Class<? extends LookAndFeel> lafClass = UIManager.getLookAndFeel().getClass();
 		try {

--- a/flatlaf-demo/src/main/java/com/formdev/flatlaf/demo/DemoFrame.java
+++ b/flatlaf-demo/src/main/java/com/formdev/flatlaf/demo/DemoFrame.java
@@ -44,6 +44,8 @@ import com.formdev.flatlaf.extras.FlatUIDefaultsInspector;
 import com.formdev.flatlaf.extras.components.FlatButton;
 import com.formdev.flatlaf.extras.components.FlatButton.ButtonType;
 import com.formdev.flatlaf.icons.FlatAbstractIcon;
+import com.formdev.flatlaf.themes.FlatMacDarkLaf;
+import com.formdev.flatlaf.themes.FlatMacLightLaf;
 import com.formdev.flatlaf.extras.FlatSVGUtils;
 import com.formdev.flatlaf.ui.FlatUIUtils;
 import com.formdev.flatlaf.ui.JBRCustomDecorations;
@@ -455,7 +457,9 @@ class DemoFrame
 			lafClass == FlatLightLaf.class ||
 			lafClass == FlatDarkLaf.class ||
 			lafClass == FlatIntelliJLaf.class ||
-			lafClass == FlatDarculaLaf.class;
+			lafClass == FlatDarculaLaf.class ||
+			lafClass == FlatMacLightLaf.class ||
+			lafClass == FlatMacDarkLaf.class;
 
 		accentColorLabel.setVisible( isAccentColorSupported );
 		for( int i = 0; i < accentColorButtons.length; i++ )

--- a/flatlaf-theme-editor/src/main/java/com/formdev/flatlaf/themeeditor/FlatCompletionProvider.java
+++ b/flatlaf-theme-editor/src/main/java/com/formdev/flatlaf/themeeditor/FlatCompletionProvider.java
@@ -410,6 +410,10 @@ class FlatCompletionProvider
 			addFunction( "lazy",
 				"uiKey", "UI key (without leading '$')" );
 
+			addFunction( "systemColor",
+				"name", "system color name",
+				"defaultValue", "default color value used if system color is not available" );
+
 			addFunction( "rgb",
 				"red", "0-255 or 0-100%",
 				"green", "0-255 or 0-100%",

--- a/flatlaf-theme-editor/src/main/java/com/formdev/flatlaf/themeeditor/FlatThemeTokenMaker.java
+++ b/flatlaf-theme-editor/src/main/java/com/formdev/flatlaf/themeeditor/FlatThemeTokenMaker.java
@@ -56,6 +56,7 @@ public class FlatThemeTokenMaker
 		tokenMap.put( "lazy", TOKEN_FUNCTION );
 
 		// color functions
+		tokenMap.put( "systemColor", TOKEN_FUNCTION );
 		tokenMap.put( "rgb", TOKEN_FUNCTION );
 		tokenMap.put( "rgba", TOKEN_FUNCTION );
 		tokenMap.put( "hsl", TOKEN_FUNCTION );

--- a/flatlaf-theme-editor/theme-editor-test.properties
+++ b/flatlaf-theme-editor/theme-editor-test.properties
@@ -49,6 +49,9 @@ Prop.ifColor = lighten(if(#000,#0f0,#dfd), 10%)
 Prop.ifColorVar = lighten(if(@varTrue,@varTrueValue,@varFalseValue), 10%)
 Prop.lazy = lazy(Prop.string)
 
+Prop.systemColor1 = systemColor(accent,null)
+Prop.systemColor2 = systemColor(accent,#f00)
+
 Prop.colorFunc1 = rgb(12,34,56)
 Prop.colorFunc2 = rgba(12,34,56,78)
 Prop.colorFunc3 = hsl(12,34%,56%)


### PR DESCRIPTION
This PR adds a `systemColor()` function to FlatLaf properties files, that can be used to change accent color (or other colors). It is also a preparation for getting accent color from operating system later.

Syntax: `systemColor(name[,defaultValue])`

Parameters:
  - `name`: system color name (this can be any name)
  - `defaultValue`: default color value used if system color is not available

E.g.
```properties
@accentColor = systemColor(accent,#00f)
```

Where does FlatLaf get the system color from?
Well, it does not get it from the operating system 😞 
You have to define a getter function that is invoked when a `systemColor()` function is found in FlatLaf properties.
E.g.:

```java
FlatLaf.setSystemColorGetter( name -> {
    return name.equals( "accent" ) ? Color.red : null;
} );
```

This must be done before invoking `FlatLightLaf.setup()`.


As soon as [light/dark switching feature](https://www.formdev.com/flatlaf/sponsor/#features) is implemented (**sponsors wanted** 😉 ),
above can be changed to following, which gets accent color from operating system:

```java
FlatLaf.setSystemColorGetter( name -> {
    switch( name ) {
        case "accent":    return SystemTheming.getAccentColor();
        case "highlight": return SystemTheming.getHighlightColor();
        default:          return null;
    }
} );
```


This PR also adds support for changing accent and highlight colors in macOS themes (PR #533):

![image](https://user-images.githubusercontent.com/5604048/199612294-bf8f51fb-1ac8-4991-9583-5bfb270d2dc0.png)

![image](https://user-images.githubusercontent.com/5604048/199612561-fae3fc53-a059-44cb-bed1-a855d58c84e6.png)
