### PR TITLE
Tree: hide default closed/opened/leaf icons by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ FlatLaf Change Log
 - List: Support rounded selection. (PR #547)
 - Menus: Support rounded selection. (PR #536)
 - Tree: Support rounded selection. (PR #546)
+- Tree: Hide default closed/opened/leaf icons by default. Set UI value
+  `Tree.showDefaultIcons` to `true` to show them.
 - Icons: New modern rounded outlined icons for `JFileChooser`, `JOptionPane`,
   `JPasswordField` and `JTree`. (PR #577)
 

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatTreeUI.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatTreeUI.java
@@ -105,6 +105,7 @@ import com.formdev.flatlaf.util.UIScale;
  * @uiDefault Tree.selectionArc						int
  * @uiDefault Tree.wideSelection					boolean
  * @uiDefault Tree.showCellFocusIndicator			boolean
+ * @uiDefault Tree.showDefaultIcons					boolean
  *
  * <!-- FlatTreeExpandedIcon -->
  *
@@ -143,6 +144,7 @@ public class FlatTreeUI
 	/** @since 3 */ @Styleable protected int selectionArc;
 	@Styleable protected boolean wideSelection;
 	@Styleable protected boolean showCellFocusIndicator;
+	/** @since 3 */ protected boolean showDefaultIcons;
 
 	// for icons
 	// (needs to be public because icon classes are in another package)
@@ -189,6 +191,7 @@ public class FlatTreeUI
 		selectionArc = UIManager.getInt( "Tree.selectionArc" );
 		wideSelection = UIManager.getBoolean( "Tree.wideSelection" );
 		showCellFocusIndicator = UIManager.getBoolean( "Tree.showCellFocusIndicator" );
+		showDefaultIcons = UIManager.getBoolean( "Tree.showDefaultIcons" );
 
 		paintLines = UIManager.getBoolean( "Tree.paintLines" );
 		defaultCellNonSelectionBackground = UIManager.getColor( "Tree.textBackground" );
@@ -221,6 +224,19 @@ public class FlatTreeUI
 		defaultSelectionForeground = null;
 		defaultSelectionBorderColor = null;
 		oldStyleValues = null;
+	}
+
+	@Override
+	protected void updateRenderer() {
+		super.updateRenderer();
+
+		// remove default leaf/closed/opened icons
+		if( !showDefaultIcons && currentCellRenderer instanceof DefaultTreeCellRenderer ) {
+			DefaultTreeCellRenderer renderer = (DefaultTreeCellRenderer) currentCellRenderer;
+			renderer.setLeafIcon( null );
+			renderer.setClosedIcon( null );
+			renderer.setOpenIcon( null );
+		}
 	}
 
 	@Override

--- a/flatlaf-core/src/main/resources/com/formdev/flatlaf/FlatLaf.properties
+++ b/flatlaf-core/src/main/resources/com/formdev/flatlaf/FlatLaf.properties
@@ -901,6 +901,7 @@ Tree.wideSelection = true
 Tree.repaintWholeRow = true
 Tree.paintLines = false
 Tree.showCellFocusIndicator = false
+Tree.showDefaultIcons = false
 Tree.leftChildIndent = 7
 Tree.rightChildIndent = 11
 Tree.rowHeight = 0

--- a/flatlaf-testing/dumps/uidefaults/FlatDarkLaf_1.8.0.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatDarkLaf_1.8.0.txt
@@ -1399,6 +1399,7 @@ Tree.selectionInactiveBackground #0f2a3d  HSL 205  61  15    javax.swing.plaf.Co
 Tree.selectionInactiveForeground #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
 Tree.selectionInsets           0,0,0,0    javax.swing.plaf.InsetsUIResource [UI]
 Tree.showCellFocusIndicator    false
+Tree.showDefaultIcons          false
 Tree.textBackground            #46494b  HSL 204   3  28    javax.swing.plaf.ColorUIResource [UI]
 Tree.textForeground            #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
 Tree.timeFactor                1000

--- a/flatlaf-testing/dumps/uidefaults/FlatLightLaf_1.8.0.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatLightLaf_1.8.0.txt
@@ -1404,6 +1404,7 @@ Tree.selectionInactiveBackground #d3d3d3  HSL   0   0  83    javax.swing.plaf.Co
 Tree.selectionInactiveForeground #000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]
 Tree.selectionInsets           0,0,0,0    javax.swing.plaf.InsetsUIResource [UI]
 Tree.showCellFocusIndicator    false
+Tree.showDefaultIcons          false
 Tree.textBackground            #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
 Tree.textForeground            #000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]
 Tree.timeFactor                1000

--- a/flatlaf-testing/dumps/uidefaults/FlatMacDarkLaf_1.8.0.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatMacDarkLaf_1.8.0.txt
@@ -1409,6 +1409,7 @@ Tree.selectionInactiveBackground #464646  HSL   0   0  27    javax.swing.plaf.Co
 Tree.selectionInactiveForeground #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 Tree.selectionInsets           0,0,0,0    javax.swing.plaf.InsetsUIResource [UI]
 Tree.showCellFocusIndicator    false
+Tree.showDefaultIcons          false
 Tree.textBackground            #282828  HSL   0   0  16    javax.swing.plaf.ColorUIResource [UI]
 Tree.textForeground            #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 Tree.timeFactor                1000

--- a/flatlaf-testing/dumps/uidefaults/FlatMacLightLaf_1.8.0.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatMacLightLaf_1.8.0.txt
@@ -1413,6 +1413,7 @@ Tree.selectionInactiveBackground #dcdcdc  HSL   0   0  86    javax.swing.plaf.Co
 Tree.selectionInactiveForeground #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
 Tree.selectionInsets           0,0,0,0    javax.swing.plaf.InsetsUIResource [UI]
 Tree.showCellFocusIndicator    false
+Tree.showDefaultIcons          false
 Tree.textBackground            #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
 Tree.textForeground            #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
 Tree.timeFactor                1000

--- a/flatlaf-testing/dumps/uidefaults/FlatTestLaf_1.8.0.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatTestLaf_1.8.0.txt
@@ -1450,6 +1450,7 @@ Tree.selectionInactiveBackground #888888  HSL   0   0  53    javax.swing.plaf.Co
 Tree.selectionInactiveForeground #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
 Tree.selectionInsets           0,0,0,0    javax.swing.plaf.InsetsUIResource [UI]
 Tree.showCellFocusIndicator    false
+Tree.showDefaultIcons          false
 Tree.textBackground            #fff0ff  HSL 300 100  97    javax.swing.plaf.ColorUIResource [UI]
 Tree.textForeground            #ff0000  HSL   0 100  50    javax.swing.plaf.ColorUIResource [UI]
 Tree.timeFactor                1000

--- a/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatComponents2Test.java
+++ b/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatComponents2Test.java
@@ -495,6 +495,13 @@ public class FlatComponents2Test
 			tree.setEditable( editable );
 	}
 
+	private void showDefaultIcons() {
+		boolean showDefaultIcons = showDefaultIconsCheckBox.isSelected();
+		UIManager.put( "Tree.showDefaultIcons", showDefaultIcons ? true : null );
+		for( JTree tree : allTrees )
+			tree.updateUI();
+	}
+
 	private void treeMouseClicked( MouseEvent e ) {
 		JTree tree = (JTree) e.getSource();
 		int x = e.getX();
@@ -594,6 +601,7 @@ public class FlatComponents2Test
 		treePaintLinesCheckBox = new JCheckBox();
 		treeRedLinesCheckBox = new JCheckBox();
 		treeEditableCheckBox = new JCheckBox();
+		showDefaultIconsCheckBox = new JCheckBox();
 		JPanel tableOptionsPanel = new JPanel();
 		JLabel autoResizeModeLabel = new JLabel();
 		autoResizeModeField = new JComboBox<>();
@@ -754,7 +762,6 @@ public class FlatComponents2Test
 
 			//---- tree1 ----
 			tree1.setShowsRootHandles(true);
-			tree1.setEditable(true);
 			tree1.addMouseListener(new MouseAdapter() {
 				@Override
 				public void mouseClicked(MouseEvent e) {
@@ -980,6 +987,11 @@ public class FlatComponents2Test
 			treeEditableCheckBox.setText("editable");
 			treeEditableCheckBox.addActionListener(e -> treeEditableChanged());
 			treeOptionsPanel.add(treeEditableCheckBox, "cell 0 4");
+
+			//---- showDefaultIconsCheckBox ----
+			showDefaultIconsCheckBox.setText("show default icons");
+			showDefaultIconsCheckBox.addActionListener(e -> showDefaultIcons());
+			treeOptionsPanel.add(showDefaultIconsCheckBox, "cell 0 4");
 		}
 		add(treeOptionsPanel, "cell 0 4 4 1");
 
@@ -1116,6 +1128,7 @@ public class FlatComponents2Test
 	private JCheckBox treePaintLinesCheckBox;
 	private JCheckBox treeRedLinesCheckBox;
 	private JCheckBox treeEditableCheckBox;
+	private JCheckBox showDefaultIconsCheckBox;
 	private JComboBox<String> autoResizeModeField;
 	private JComboBox<String> sortIconPositionComboBox;
 	private JCheckBox showHorizontalLinesCheckBox;

--- a/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatComponents2Test.jfd
+++ b/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatComponents2Test.jfd
@@ -184,7 +184,6 @@ new FormModel {
 				add( new FormComponent( "javax.swing.JTree" ) {
 					name: "tree1"
 					"showsRootHandles": true
-					"editable": true
 					auxiliary() {
 						"JavaCodeGenerator.variableLocal": false
 					}
@@ -473,6 +472,16 @@ new FormModel {
 						"JavaCodeGenerator.variableLocal": false
 					}
 					addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "treeEditableChanged", false ) )
+				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+					"value": "cell 0 4"
+				} )
+				add( new FormComponent( "javax.swing.JCheckBox" ) {
+					name: "showDefaultIconsCheckBox"
+					"text": "show default icons"
+					auxiliary() {
+						"JavaCodeGenerator.variableLocal": false
+					}
+					addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "showDefaultIcons", false ) )
 				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
 					"value": "cell 0 4"
 				} )

--- a/flatlaf-theme-editor/src/main/resources/com/formdev/flatlaf/themeeditor/FlatLafUIKeys.txt
+++ b/flatlaf-theme-editor/src/main/resources/com/formdev/flatlaf/themeeditor/FlatLafUIKeys.txt
@@ -1150,6 +1150,7 @@ Tree.selectionInactiveBackground
 Tree.selectionInactiveForeground
 Tree.selectionInsets
 Tree.showCellFocusIndicator
+Tree.showDefaultIcons
 Tree.textBackground
 Tree.textForeground
 Tree.timeFactor


### PR DESCRIPTION
For whatever reason, Swing's `JTree` shows closed/opened/leaf icons on all rows.
Other components like `JList` or `JTable` do not show such icons.

![image](https://user-images.githubusercontent.com/5604048/201679539-aabd4693-0309-4648-8205-9079b4655715.png)

Modern applications do not show such icons in trees.

So this PR removes those closed/opened/leaf icons from trees:

![image](https://user-images.githubusercontent.com/5604048/201679629-cddeba4c-bbf2-4e5a-a4bc-3027ef63fba4.png)

Note that icons set in custom tree cell renderers are still displayed. This PR affects only the default closed/opened/leaf icons.

If you prefer the old behavior use:

~~~properties
UIManager.put( "Tree.showDefaultIcons", true );
~~~
