### PR TITLE
macOS themes: make spinner look like macOS stepper

### DIFF
--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatRoundBorder.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatRoundBorder.java
@@ -17,7 +17,10 @@
 package com.formdev.flatlaf.ui;
 
 import java.awt.Component;
+import java.awt.Graphics;
+import javax.swing.JSpinner;
 import javax.swing.UIManager;
+import javax.swing.plaf.SpinnerUI;
 import com.formdev.flatlaf.ui.FlatStylingSupport.Styleable;
 
 /**
@@ -36,6 +39,19 @@ public class FlatRoundBorder
 	/** @since 2 */ @Styleable protected Boolean roundRect;
 
 	@Override
+	public void paintBorder( Component c, Graphics g, int x, int y, int width, int height ) {
+		// make mac style spinner border smaller (border does not surround arrow buttons)
+		if( isMacStyleSpinner( c ) ) {
+			int macStyleButtonsWidth = ((FlatSpinnerUI)((JSpinner)c).getUI()).getMacStyleButtonsWidth();
+			width -= macStyleButtonsWidth;
+			if( !c.getComponentOrientation().isLeftToRight() )
+				x += macStyleButtonsWidth;
+		}
+
+		super.paintBorder( c, g, x, y, width, height );
+	}
+
+	@Override
 	protected int getArc( Component c ) {
 		if( isCellEditor( c ) )
 			return 0;
@@ -43,6 +59,17 @@ public class FlatRoundBorder
 		Boolean roundRect = FlatUIUtils.isRoundRect( c );
 		if( roundRect == null )
 			roundRect = this.roundRect;
-		return roundRect != null ? (roundRect ? Short.MAX_VALUE : 0) : arc;
+		return roundRect != null
+			? (roundRect ? Short.MAX_VALUE : 0)
+			: (isMacStyleSpinner( c ) ? 0 : arc);
+	}
+
+	private boolean isMacStyleSpinner( Component c ) {
+		if( c instanceof JSpinner ) {
+			SpinnerUI ui = ((JSpinner)c).getUI();
+			if( ui instanceof FlatSpinnerUI )
+				return ((FlatSpinnerUI)ui).isMacStyle();
+		}
+		return false;
 	}
 }

--- a/flatlaf-core/src/main/resources/com/formdev/flatlaf/themes/FlatMacDarkLaf.properties
+++ b/flatlaf-core/src/main/resources/com/formdev/flatlaf/themes/FlatMacDarkLaf.properties
@@ -254,6 +254,8 @@ Spinner.buttonStyle = mac
 Spinner.disabledBackground = @disabledComponentBackground
 Spinner.buttonBackground = @buttonBackground
 Spinner.buttonArrowColor = @foreground
+Spinner.buttonHoverArrowColor = lighten($Spinner.buttonArrowColor,10%,derived noAutoInverse)
+Spinner.buttonPressedArrowColor = lighten($Spinner.buttonArrowColor,20%,derived noAutoInverse)
 Spinner.buttonSeparatorWidth = 0
 
 

--- a/flatlaf-core/src/main/resources/com/formdev/flatlaf/themes/FlatMacDarkLaf.properties
+++ b/flatlaf-core/src/main/resources/com/formdev/flatlaf/themes/FlatMacDarkLaf.properties
@@ -253,6 +253,7 @@ Slider.focusedColor = $Component.focusColor
 Spinner.buttonStyle = mac
 Spinner.disabledBackground = @disabledComponentBackground
 Spinner.buttonBackground = @buttonBackground
+Spinner.buttonArrowColor = @foreground
 Spinner.buttonSeparatorWidth = 0
 
 

--- a/flatlaf-testing/dumps/uidefaults/FlatMacDarkLaf_1.8.0.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatMacDarkLaf_1.8.0.txt
@@ -986,8 +986,8 @@ Spinner.buttonArrowColor       #dddddd  HSL   0   0  87    javax.swing.plaf.Colo
 Spinner.buttonBackground       #565656  HSL   0   0  34    javax.swing.plaf.ColorUIResource [UI]
 Spinner.buttonDisabledArrowColor #777777  HSL   0   0  47    javax.swing.plaf.ColorUIResource [UI]
 Spinner.buttonDisabledSeparatorColor #ffffff0c  5%  HSLA   0   0 100  5    javax.swing.plaf.ColorUIResource [UI]
-Spinner.buttonHoverArrowColor  #f7f7f7  HSL   0   0  97 / #d1d1d1  HSL   0   0  82    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(10%)
-Spinner.buttonPressedArrowColor #ffffff  HSL   0   0 100 / #eaeaea  HSL   0   0  92    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(20%)
+Spinner.buttonHoverArrowColor  #f7f7f7  HSL   0   0  97    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(10%)
+Spinner.buttonPressedArrowColor #ffffff  HSL   0   0 100    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(20%)
 Spinner.buttonSeparatorColor   #ffffff19  10%  HSLA   0   0 100 10    javax.swing.plaf.ColorUIResource [UI]
 Spinner.buttonSeparatorWidth   0
 Spinner.buttonStyle            mac

--- a/flatlaf-testing/dumps/uidefaults/FlatMacDarkLaf_1.8.0.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatMacDarkLaf_1.8.0.txt
@@ -982,12 +982,12 @@ SliderUI                       com.formdev.flatlaf.ui.FlatSliderUI
 Spinner.arrowButtonSize        16,5    java.awt.Dimension
 Spinner.background             #282828  HSL   0   0  16    javax.swing.plaf.ColorUIResource [UI]
 Spinner.border                 [lazy] 3,3,3,3  false    com.formdev.flatlaf.ui.FlatRoundBorder [UI]
-Spinner.buttonArrowColor       #b7b7b7  HSL   0   0  72    javax.swing.plaf.ColorUIResource [UI]
+Spinner.buttonArrowColor       #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 Spinner.buttonBackground       #565656  HSL   0   0  34    javax.swing.plaf.ColorUIResource [UI]
 Spinner.buttonDisabledArrowColor #777777  HSL   0   0  47    javax.swing.plaf.ColorUIResource [UI]
 Spinner.buttonDisabledSeparatorColor #ffffff0c  5%  HSLA   0   0 100  5    javax.swing.plaf.ColorUIResource [UI]
-Spinner.buttonHoverArrowColor  #d1d1d1  HSL   0   0  82    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(10%)
-Spinner.buttonPressedArrowColor #eaeaea  HSL   0   0  92    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(20%)
+Spinner.buttonHoverArrowColor  #f7f7f7  HSL   0   0  97 / #d1d1d1  HSL   0   0  82    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(10%)
+Spinner.buttonPressedArrowColor #ffffff  HSL   0   0 100 / #eaeaea  HSL   0   0  92    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(20%)
 Spinner.buttonSeparatorColor   #ffffff19  10%  HSLA   0   0 100 10    javax.swing.plaf.ColorUIResource [UI]
 Spinner.buttonSeparatorWidth   0
 Spinner.buttonStyle            mac

--- a/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatTextComponentsTest.java
+++ b/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatTextComponentsTest.java
@@ -45,6 +45,27 @@ public class FlatTextComponentsTest
 
 	FlatTextComponentsTest() {
 		initComponents();
+		updatePreferredSizes();
+	}
+
+	@Override
+	public void updateUI() {
+		super.updateUI();
+
+		if( comboBox5 != null )
+			updatePreferredSizes();
+	}
+
+	private void updatePreferredSizes() {
+		Dimension size40 = UIScale.scale( new Dimension( 60, 40 ) );
+		comboBox5.setPreferredSize( size40 );
+		spinner4.setPreferredSize( size40 );
+
+		Dimension size14 = UIScale.scale( new Dimension( 60, 14 ) );
+		comboBox6.setPreferredSize( size14 );
+		comboBox6.setMinimumSize( size14 );
+		spinner5.setPreferredSize( size14 );
+		spinner5.setMinimumSize( size14 );
 	}
 
 	private void editableChanged() {
@@ -216,18 +237,19 @@ public class FlatTextComponentsTest
 		JComboBox<String> comboBox3 = new JComboBox<>();
 		JLabel spinnerLabel = new JLabel();
 		JSpinner spinner1 = new JSpinner();
+		JSpinner spinner6 = new JSpinner();
 		JLabel label2 = new JLabel();
 		JComboBox<String> comboBox2 = new JComboBox<>();
 		JSpinner spinner2 = new JSpinner();
 		JLabel label1 = new JLabel();
-		JComboBox<String> comboBox5 = new JComboBox<>();
-		JSpinner spinner4 = new JSpinner();
+		comboBox5 = new JComboBox<>();
+		spinner4 = new JSpinner();
 		JLabel label3 = new JLabel();
 		JComboBox<String> comboBox4 = new JComboBox<>();
 		JSpinner spinner3 = new JSpinner();
 		JLabel label4 = new JLabel();
-		JComboBox<String> comboBox6 = new JComboBox<>();
-		JSpinner spinner5 = new JSpinner();
+		comboBox6 = new JComboBox<>();
+		spinner5 = new JSpinner();
 		JLabel label5 = new JLabel();
 		textField = new JTextField();
 		dragEnabledCheckBox = new JCheckBox();
@@ -563,6 +585,10 @@ public class FlatTextComponentsTest
 		spinner1.setComponentPopupMenu(popupMenu1);
 		add(spinner1, "cell 1 7,growx");
 
+		//---- spinner6 ----
+		spinner6.setBorder(BorderFactory.createEmptyBorder());
+		add(spinner6, "cell 2 7,growx");
+
 		//---- label2 ----
 		label2.setText("<html>Large row height:<br>(default pref height)</html>");
 		add(label2, "cell 0 8,aligny top,growy 0");
@@ -690,6 +716,10 @@ public class FlatTextComponentsTest
 	private JCheckBox trailingComponentVisibleCheckBox;
 	private JCheckBox showClearButtonCheckBox;
 	private JCheckBox showRevealButtonCheckBox;
+	private JComboBox<String> comboBox5;
+	private JSpinner spinner4;
+	private JComboBox<String> comboBox6;
+	private JSpinner spinner5;
 	private JTextField textField;
 	private JCheckBox dragEnabledCheckBox;
 	private JTextArea textArea;

--- a/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatTextComponentsTest.jfd
+++ b/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatTextComponentsTest.jfd
@@ -403,6 +403,12 @@ new FormModel {
 			}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
 				"value": "cell 1 7,growx"
 			} )
+			add( new FormComponent( "javax.swing.JSpinner" ) {
+				name: "spinner6"
+				"border": new javax.swing.border.EmptyBorder( 0, 0, 0, 0 )
+			}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+				"value": "cell 2 7,growx"
+			} )
 			add( new FormComponent( "javax.swing.JLabel" ) {
 				name: "label2"
 				"text": "<html>Large row height:<br>(default pref height)</html>"
@@ -435,6 +441,7 @@ new FormModel {
 				"editable": true
 				auxiliary() {
 					"JavaCodeGenerator.typeParameters": "String"
+					"JavaCodeGenerator.variableLocal": false
 				}
 			}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
 				"value": "cell 1 10,growx"
@@ -442,6 +449,9 @@ new FormModel {
 			add( new FormComponent( "javax.swing.JSpinner" ) {
 				name: "spinner4"
 				"preferredSize": new java.awt.Dimension( 60, 40 )
+				auxiliary() {
+					"JavaCodeGenerator.variableLocal": false
+				}
 			}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
 				"value": "cell 1 11,growx"
 			} )
@@ -478,6 +488,7 @@ new FormModel {
 				"minimumSize": new java.awt.Dimension( 60, 14 )
 				auxiliary() {
 					"JavaCodeGenerator.typeParameters": "String"
+					"JavaCodeGenerator.variableLocal": false
 				}
 			}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
 				"value": "cell 1 14,growx"
@@ -486,6 +497,9 @@ new FormModel {
 				name: "spinner5"
 				"minimumSize": new java.awt.Dimension( 60, 14 )
 				"preferredSize": new java.awt.Dimension( 60, 14 )
+				auxiliary() {
+					"JavaCodeGenerator.variableLocal": false
+				}
 			}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
 				"value": "cell 1 15,growx,hmax 14"
 			} )


### PR DESCRIPTION
This is a supplement for PR #533.

This PR makes the spinner component in macOS themes look more similar to native macOS stepper.

Old:

![image](https://user-images.githubusercontent.com/5604048/201934960-9fffa411-bc0e-465b-9ad8-8eb2c56a4c69.png) ![image](https://user-images.githubusercontent.com/5604048/201935022-0b99cc6b-47ac-46fb-a0e1-3426ac907d0e.png) ![image](https://user-images.githubusercontent.com/5604048/201935089-ea77b501-621f-4d1b-b8ec-317dd0726e6e.png)


New:

![image](https://user-images.githubusercontent.com/5604048/201934627-9cf5a39b-c5bf-4989-93f1-f0b33585e1c8.png) ![image](https://user-images.githubusercontent.com/5604048/201934666-4334eb61-58ab-46d9-91d5-eecc1630e7b2.png) ![image](https://user-images.githubusercontent.com/5604048/201934683-7f2c58cf-bf43-4e15-a9fa-aa09349a2798.png)


Native macOS stepper:

![image](https://user-images.githubusercontent.com/5604048/201933992-c86f4cdb-d01e-41ce-a277-a1c545e145f2.png) ![image](https://user-images.githubusercontent.com/5604048/201934028-224eef1b-b4f8-4268-a42e-92e55e302076.png) ![image](https://user-images.githubusercontent.com/5604048/201934043-1990b3d0-f0d7-4334-b50f-23179f1a25fe.png)

(screenshot from Xcode > Preferences > Text Editing > Display > Line wrapping)