### PR TITLE
Window decorations: Title bar customizing

### DIFF
--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/FlatClientProperties.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/FlatClientProperties.java
@@ -346,7 +346,7 @@ public interface FlatClientProperties
 
 	/**
 	 * Specifies whether the window icon should be shown in the window title bar
-	 * (requires enabled window decorations).
+	 * (requires enabled window decorations). Default is UI property {@code TitlePane.showIcon}.
 	 * <p>
 	 * Setting this shows/hides the windows icon
 	 * for the {@code JFrame} or {@code JDialog} that contains the root pane.
@@ -361,6 +361,62 @@ public interface FlatClientProperties
 	 * @since 2
 	 */
 	String TITLE_BAR_SHOW_ICON = "JRootPane.titleBarShowIcon";
+
+	/**
+	 * Specifies whether the window title should be shown in the window title bar
+	 * (requires enabled window decorations). Default is {@code true}.
+	 * <p>
+	 * Setting this shows/hides the windows title
+	 * for the {@code JFrame} or {@code JDialog} that contains the root pane.
+	 * <p>
+	 * <strong>Component</strong> {@link javax.swing.JRootPane}<br>
+	 * <strong>Value type</strong> {@link java.lang.Boolean}
+	 *
+	 * @since 3
+	 */
+	String TITLE_BAR_SHOW_TITLE = "JRootPane.titleBarShowTitle";
+
+	/**
+	 * Specifies whether the "iconfify" button should be shown in the window title bar
+	 * (requires enabled window decorations). Default is {@code true}.
+	 * <p>
+	 * Setting this shows/hides the "iconfify" button
+	 * for the {@code JFrame} that contains the root pane.
+	 * <p>
+	 * <strong>Component</strong> {@link javax.swing.JRootPane}<br>
+	 * <strong>Value type</strong> {@link java.lang.Boolean}
+	 *
+	 * @since 3
+	 */
+	String TITLE_BAR_SHOW_ICONIFFY = "JRootPane.titleBarShowIconify";
+
+	/**
+	 * Specifies whether the "maximize/restore" button should be shown in the window title bar
+	 * (requires enabled window decorations). Default is {@code true}.
+	 * <p>
+	 * Setting this shows/hides the "maximize/restore" button
+	 * for the {@code JFrame} that contains the root pane.
+	 * <p>
+	 * <strong>Component</strong> {@link javax.swing.JRootPane}<br>
+	 * <strong>Value type</strong> {@link java.lang.Boolean}
+	 *
+	 * @since 3
+	 */
+	String TITLE_BAR_SHOW_MAXIMIZE = "JRootPane.titleBarShowMaximize";
+
+	/**
+	 * Specifies whether the "close" button should be shown in the window title bar
+	 * (requires enabled window decorations). Default is {@code true}.
+	 * <p>
+	 * Setting this shows/hides the "close" button
+	 * for the {@code JFrame} or {@code JDialog} that contains the root pane.
+	 * <p>
+	 * <strong>Component</strong> {@link javax.swing.JRootPane}<br>
+	 * <strong>Value type</strong> {@link java.lang.Boolean}
+	 *
+	 * @since 3
+	 */
+	String TITLE_BAR_SHOW_CLOSE = "JRootPane.titleBarShowClose";
 
 	/**
 	 * Background color of window title bar (requires enabled window decorations).

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatRootPaneUI.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatRootPaneUI.java
@@ -349,6 +349,14 @@ public class FlatRootPaneUI
 					titlePane.updateIcon();
 				break;
 
+			case FlatClientProperties.TITLE_BAR_SHOW_TITLE:
+			case FlatClientProperties.TITLE_BAR_SHOW_ICONIFFY:
+			case FlatClientProperties.TITLE_BAR_SHOW_MAXIMIZE:
+			case FlatClientProperties.TITLE_BAR_SHOW_CLOSE:
+				if( titlePane != null )
+					titlePane.updateVisibility();
+				break;
+
 			case FlatClientProperties.TITLE_BAR_BACKGROUND:
 			case FlatClientProperties.TITLE_BAR_FOREGROUND:
 				if( titlePane != null )

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatTitlePane.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatTitlePane.java
@@ -354,14 +354,11 @@ public class FlatTitlePane
 		if( window == null || rootPane.getWindowDecorationStyle() != JRootPane.FRAME )
 			return;
 
+		updateVisibility();
+
 		if( window instanceof Frame ) {
 			Frame frame = (Frame) window;
-			boolean resizable = frame.isResizable();
 			boolean maximized = ((frame.getExtendedState() & Frame.MAXIMIZED_BOTH) != 0);
-
-			iconifyButton.setVisible( true );
-			maximizeButton.setVisible( resizable && !maximized );
-			restoreButton.setVisible( resizable && maximized );
 
 			if( maximized &&
 				!(SystemInfo.isLinux && FlatNativeLinuxLibrary.isWMUtilsSupported( window )) &&
@@ -383,14 +380,27 @@ public class FlatTitlePane
 					frame.setExtendedState( oldExtendedState );
 				}
 			}
+		}
+	}
+
+	/** @since 3 */
+	protected void updateVisibility() {
+		titleLabel.setVisible( clientPropertyBoolean( rootPane, TITLE_BAR_SHOW_TITLE, true ) );
+		closeButton.setVisible( clientPropertyBoolean( rootPane, TITLE_BAR_SHOW_CLOSE, true ) );
+
+		if( window instanceof Frame ) {
+			Frame frame = (Frame) window;
+			boolean maximizable = frame.isResizable() && clientPropertyBoolean( rootPane, TITLE_BAR_SHOW_MAXIMIZE, true );
+			boolean maximized = ((frame.getExtendedState() & Frame.MAXIMIZED_BOTH) != 0);
+
+			iconifyButton.setVisible( clientPropertyBoolean( rootPane, TITLE_BAR_SHOW_ICONIFFY, true ) );
+			maximizeButton.setVisible( maximizable && !maximized );
+			restoreButton.setVisible( maximizable && maximized );
 		} else {
 			// hide buttons because they are only supported in frames
 			iconifyButton.setVisible( false );
 			maximizeButton.setVisible( false );
 			restoreButton.setVisible( false );
-
-			revalidate();
-			repaint();
 		}
 	}
 

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatTitlePane.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatTitlePane.java
@@ -107,6 +107,8 @@ import com.formdev.flatlaf.util.UIScale;
 public class FlatTitlePane
 	extends JComponent
 {
+	private static final String KEY_DEBUG_SHOW_RECTANGLES = "FlatLaf.debug.titlebar.showRectangles";
+
 	/** @since 2.5 */ protected final Font titleFont = UIManager.getFont( "TitlePane.font" );
 	protected final Color activeBackground = UIManager.getColor( "TitlePane.background" );
 	protected final Color inactiveBackground = UIManager.getColor( "TitlePane.inactiveBackground" );
@@ -576,10 +578,12 @@ public class FlatTitlePane
 		doLayout();
 	}
 
-/*debug
 	@Override
 	public void paint( Graphics g ) {
 		super.paint( g );
+
+		if( !UIManager.getBoolean( KEY_DEBUG_SHOW_RECTANGLES ) )
+			return;
 
 		if( debugTitleBarHeight > 0 ) {
 			g.setColor( Color.green );
@@ -604,7 +608,6 @@ public class FlatTitlePane
 		Point offset = SwingUtilities.convertPoint( this, 0, 0, window );
 		g.drawRect( r.x - offset.x, r.y - offset.y, r.width - 1, r.height - 1 );
 	}
-debug*/
 
 	@Override
 	protected void paintComponent( Graphics g ) {
@@ -933,15 +936,14 @@ debug*/
 		FlatNativeWindowBorder.setTitleBarHeightAndHitTestSpots( window, titleBarHeight,
 			hitTestSpots, appIconBounds, minimizeButtonBounds, maximizeButtonBounds, closeButtonBounds );
 
-/*debug
 		debugTitleBarHeight = titleBarHeight;
 		debugHitTestSpots = hitTestSpots;
 		debugAppIconBounds = appIconBounds;
 		debugMinimizeButtonBounds = minimizeButtonBounds;
 		debugMaximizeButtonBounds = maximizeButtonBounds;
 		debugCloseButtonBounds = closeButtonBounds;
-		repaint();
-debug*/
+		if( UIManager.getBoolean( KEY_DEBUG_SHOW_RECTANGLES ) )
+			repaint();
 	}
 
 	private Rectangle boundsInWindow( JComponent c ) {
@@ -960,14 +962,12 @@ debug*/
 		return r;
 	}
 
-/*debug
 	private int debugTitleBarHeight;
 	private List<Rectangle> debugHitTestSpots;
 	private Rectangle debugAppIconBounds;
 	private Rectangle debugMinimizeButtonBounds;
 	private Rectangle debugMaximizeButtonBounds;
 	private Rectangle debugCloseButtonBounds;
-debug*/
 
 	//---- class FlatTitlePaneBorder ------------------------------------------
 

--- a/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatNativeWindowBorderTest.java
+++ b/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatNativeWindowBorderTest.java
@@ -57,6 +57,7 @@ public class FlatNativeWindowBorderTest
 		SwingUtilities.invokeLater( () -> {
 			FlatLightLaf.setup();
 			FlatInspector.install( "ctrl shift alt X" );
+			UIManager.put( "FlatLaf.debug.titlebar.showRectangles", true );
 
 			mainFrame = showFrame();
 		} );

--- a/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatWindowDecorationsTest.java
+++ b/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatWindowDecorationsTest.java
@@ -446,6 +446,30 @@ debug*/
 			rootPane.putClientProperty( FlatClientProperties.TITLE_BAR_SHOW_ICON, showIconCheckBox.getChecked() );
 	}
 
+	private void showTitleChanged() {
+		JRootPane rootPane = getWindowRootPane();
+		if( rootPane != null )
+			rootPane.putClientProperty( FlatClientProperties.TITLE_BAR_SHOW_TITLE, showTitleCheckBox.isSelected() ? null : false );
+	}
+
+	private void showIconifyChanged() {
+		JRootPane rootPane = getWindowRootPane();
+		if( rootPane != null )
+			rootPane.putClientProperty( FlatClientProperties.TITLE_BAR_SHOW_ICONIFFY, showIconifyCheckBox.isSelected() ? null : false );
+	}
+
+	private void showMaximizeChanged() {
+		JRootPane rootPane = getWindowRootPane();
+		if( rootPane != null )
+			rootPane.putClientProperty( FlatClientProperties.TITLE_BAR_SHOW_MAXIMIZE, showMaximizeCheckBox.isSelected() ? null : false );
+	}
+
+	private void showCloseChanged() {
+		JRootPane rootPane = getWindowRootPane();
+		if( rootPane != null )
+			rootPane.putClientProperty( FlatClientProperties.TITLE_BAR_SHOW_CLOSE, showCloseCheckBox.isSelected() ? null : false );
+	}
+
 	private JRootPane getWindowRootPane() {
 		Window window = SwingUtilities.windowForComponent( this );
 		if( window instanceof JFrame )
@@ -495,7 +519,12 @@ debug*/
 		iconTestRandomRadioButton = new JRadioButton();
 		iconTestMRIRadioButton = new JRadioButton();
 		iconTestDynMRIRadioButton = new JRadioButton();
+		JPanel panel4 = new JPanel();
 		showIconCheckBox = new FlatTriStateCheckBox();
+		showTitleCheckBox = new JCheckBox();
+		showIconifyCheckBox = new JCheckBox();
+		showMaximizeCheckBox = new JCheckBox();
+		showCloseCheckBox = new JCheckBox();
 		JButton openDialogButton = new JButton();
 		JButton openFrameButton = new JButton();
 		menuBar = new JMenuBar();
@@ -771,13 +800,52 @@ debug*/
 			iconTestDynMRIRadioButton.setText("test dynamic multi-resolution (Java 9+)");
 			iconTestDynMRIRadioButton.addActionListener(e -> iconChanged());
 			panel2.add(iconTestDynMRIRadioButton, "cell 0 4");
+		}
+		add(panel2, "cell 1 8");
+
+		//======== panel4 ========
+		{
+			panel4.setLayout(new MigLayout(
+				"ltr,insets 0,hidemode 3,gap 0 0",
+				// columns
+				"[grow,left]",
+				// rows
+				"[]" +
+				"[]" +
+				"[]" +
+				"[]" +
+				"[]"));
 
 			//---- showIconCheckBox ----
 			showIconCheckBox.setText("show icon");
 			showIconCheckBox.addActionListener(e -> showIconChanged());
-			panel2.add(showIconCheckBox, "cell 0 5");
+			panel4.add(showIconCheckBox, "cell 0 0");
+
+			//---- showTitleCheckBox ----
+			showTitleCheckBox.setText("show title");
+			showTitleCheckBox.setSelected(true);
+			showTitleCheckBox.addActionListener(e -> showTitleChanged());
+			panel4.add(showTitleCheckBox, "cell 0 1");
+
+			//---- showIconifyCheckBox ----
+			showIconifyCheckBox.setText("show iconfiy");
+			showIconifyCheckBox.setSelected(true);
+			showIconifyCheckBox.addActionListener(e -> showIconifyChanged());
+			panel4.add(showIconifyCheckBox, "cell 0 2");
+
+			//---- showMaximizeCheckBox ----
+			showMaximizeCheckBox.setText("show maximize");
+			showMaximizeCheckBox.setSelected(true);
+			showMaximizeCheckBox.addActionListener(e -> showMaximizeChanged());
+			panel4.add(showMaximizeCheckBox, "cell 0 3");
+
+			//---- showCloseCheckBox ----
+			showCloseCheckBox.setText("show close");
+			showCloseCheckBox.setSelected(true);
+			showCloseCheckBox.addActionListener(e -> showCloseChanged());
+			panel4.add(showCloseCheckBox, "cell 0 4");
 		}
-		add(panel2, "cell 1 8");
+		add(panel4, "cell 2 8");
 
 		//---- openDialogButton ----
 		openDialogButton.setText("Open Dialog");
@@ -1015,6 +1083,10 @@ debug*/
 	private JRadioButton iconTestMRIRadioButton;
 	private JRadioButton iconTestDynMRIRadioButton;
 	private FlatTriStateCheckBox showIconCheckBox;
+	private JCheckBox showTitleCheckBox;
+	private JCheckBox showIconifyCheckBox;
+	private JCheckBox showMaximizeCheckBox;
+	private JCheckBox showCloseCheckBox;
 	private JMenuBar menuBar;
 	// JFormDesigner - End of variables declaration  //GEN-END:variables
 }

--- a/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatWindowDecorationsTest.java
+++ b/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatWindowDecorationsTest.java
@@ -49,6 +49,7 @@ public class FlatWindowDecorationsTest
 
 			FlatTestFrame frame = FlatTestFrame.create( args, "FlatWindowDecorationsTest" );
 			frame.applyComponentOrientationToFrame = true;
+			UIManager.put( "FlatLaf.debug.titlebar.showRectangles", true );
 
 			Class<?> cls = FlatWindowDecorationsTest.class;
 			List<Image> images = Arrays.asList(

--- a/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatWindowDecorationsTest.jfd
+++ b/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatWindowDecorationsTest.jfd
@@ -1,4 +1,4 @@
-JFDML JFormDesigner: "7.0.3.1.342" Java: "16" encoding: "UTF-8"
+JFDML JFormDesigner: "8.0.0.0.194" Java: "17.0.2" encoding: "UTF-8"
 
 new FormModel {
 	contentType: "form/swing"
@@ -398,6 +398,15 @@ new FormModel {
 				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
 					"value": "cell 0 4"
 				} )
+			}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+				"value": "cell 1 8"
+			} )
+			add( new FormContainer( "javax.swing.JPanel", new FormLayoutManager( class net.miginfocom.swing.MigLayout ) {
+				"$layoutConstraints": "ltr,insets 0,hidemode 3,gap 0 0"
+				"$columnConstraints": "[grow,left]"
+				"$rowConstraints": "[][][][][]"
+			} ) {
+				name: "panel4"
 				add( new FormComponent( "com.formdev.flatlaf.extras.components.FlatTriStateCheckBox" ) {
 					name: "showIconCheckBox"
 					"text": "show icon"
@@ -406,10 +415,54 @@ new FormModel {
 					}
 					addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "showIconChanged", false ) )
 				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-					"value": "cell 0 5"
+					"value": "cell 0 0"
+				} )
+				add( new FormComponent( "javax.swing.JCheckBox" ) {
+					name: "showTitleCheckBox"
+					"text": "show title"
+					"selected": true
+					auxiliary() {
+						"JavaCodeGenerator.variableLocal": false
+					}
+					addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "showTitleChanged", false ) )
+				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+					"value": "cell 0 1"
+				} )
+				add( new FormComponent( "javax.swing.JCheckBox" ) {
+					name: "showIconifyCheckBox"
+					"text": "show iconfiy"
+					"selected": true
+					auxiliary() {
+						"JavaCodeGenerator.variableLocal": false
+					}
+					addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "showIconifyChanged", false ) )
+				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+					"value": "cell 0 2"
+				} )
+				add( new FormComponent( "javax.swing.JCheckBox" ) {
+					name: "showMaximizeCheckBox"
+					"text": "show maximize"
+					"selected": true
+					auxiliary() {
+						"JavaCodeGenerator.variableLocal": false
+					}
+					addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "showMaximizeChanged", false ) )
+				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+					"value": "cell 0 3"
+				} )
+				add( new FormComponent( "javax.swing.JCheckBox" ) {
+					name: "showCloseCheckBox"
+					"text": "show close"
+					"selected": true
+					auxiliary() {
+						"JavaCodeGenerator.variableLocal": false
+					}
+					addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "showCloseChanged", false ) )
+				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+					"value": "cell 0 4"
 				} )
 			}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-				"value": "cell 1 8"
+				"value": "cell 2 8"
 			} )
 			add( new FormComponent( "javax.swing.JButton" ) {
 				name: "openDialogButton"


### PR DESCRIPTION
(work in progress)

Purpose of this PR is to improve customizing of title bar in FlatLaf window decorations (usually used on Windows 10/11).

### Done

- hide window title, iconify, maximize and close buttons
- hide window icon (since FlatLaf 2.0)
- change title bar background/foreground (since FlatLaf 1.1.2)

### To do

- fullWindowContent option (similar to macOS https://www.formdev.com/flatlaf/macos/#full_window_content)
- optionally place iconify, maximize and close buttons on left side (in reverse order), useful if fullWindowContent is enabled
- specify areas where the user can click-and-drag window (if fullWindowContent is enabled)
- TBD


# How to

### Hide window icon or title

~~~java
frameOrDialog.getRootPane().putClientProperty( FlatClientProperties.TITLE_BAR_SHOW_ICON, false );
frameOrDialog.getRootPane().putClientProperty( FlatClientProperties.TITLE_BAR_SHOW_TITLE, false );
~~~

### Hide iconify, maximize/restore  or close button

~~~java
frame.getRootPane().putClientProperty( FlatClientProperties.TITLE_BAR_SHOW_ICONIFFY, false );
frame.getRootPane().putClientProperty( FlatClientProperties.TITLE_BAR_SHOW_MAXIMIZE, false );
frameOrDialog.getRootPane().putClientProperty( FlatClientProperties.TITLE_BAR_SHOW_CLOSE, false );
~~~

### Change title bar background/foreground

~~~java
frameOrDialog.getRootPane().putClientProperty( FlatClientProperties.TITLE_BAR_BACKGROUND, Color.green );
frameOrDialog.getRootPane().putClientProperty( FlatClientProperties.TITLE_BAR_FOREGROUND, Color.blue );
~~~
