### PR TITLE
catch ScaledImageIcon npe

### DIFF
--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/util/ScaledImageIcon.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/util/ScaledImageIcon.java
@@ -100,8 +100,13 @@ debug*/
 		Image image = getResolutionVariant( destImageWidth, destImageHeight );
 
 		// size of image
-		int imageWidth = image.getWidth( null );
-		int imageHeight = image.getHeight( null );
+		int imageWidth = -1;
+		int imageHeight = -1;
+
+		if (image != null) {
+			imageWidth = image.getWidth( null );
+			imageHeight = image.getHeight( null );
+		}
 
 		// paint red rectangle if image has invalid size (e.g. not found)
 		if( imageWidth < 0 || imageHeight < 0 ) {


### PR DESCRIPTION
`Exception in thread "AWT-EventQueue-0" java.lang.NullPointerException: Cannot invoke "java.awt.Image.getWidth(java.awt.image.ImageObserver)" because "image" is null
	at com.formdev.flatlaf.util.ScaledImageIcon.paintIcon(ScaledImageIcon.java:103)
	at java.desktop/javax.swing.plaf.basic.BasicLabelUI.paint(BasicLabelUI.java:191)
	at com.formdev.flatlaf.ui.FlatLabelUI.paint(FlatLabelUI.java:254)
	at java.desktop/javax.swing.plaf.ComponentUI.update(ComponentUI.java:161)
	at java.desktop/javax.swing.JComponent.paintComponent(JComponent.java:852)
	at java.desktop/javax.swing.JComponent.paint(JComponent.java:1128)
	at java.desktop/javax.swing.JComponent.paintChildren(JComponent.java:961)
	at java.desktop/javax.swing.JComponent.paint(JComponent.java:1137)
	at java.desktop/javax.swing.JComponent.paintChildren(JComponent.java:961)
	at java.desktop/javax.swing.JComponent.paint(JComponent.java:1137)
	at java.desktop/javax.swing.JComponent.paintChildren(JComponent.java:961)
	at java.desktop/javax.swing.JComponent.paint(JComponent.java:1137)
	at java.desktop/javax.swing.JLayeredPane.paint(JLayeredPane.java:586)
	at java.desktop/javax.swing.JComponent.paintChildren(JComponent.java:961)
	at java.desktop/javax.swing.JComponent.paint(JComponent.java:1137)
	at java.desktop/javax.swing.JComponent.paintChildren(JComponent.java:961)
	at java.desktop/javax.swing.JComponent.paint(JComponent.java:1137)
	at java.desktop/javax.swing.JLayeredPane.paint(JLayeredPane.java:586)
	at com.formdev.flatlaf.extras.FlatAnimatedLafChange.showSnapshot(FlatAnimatedLafChange.java:100)
	at com.formdev.flatlaf.extras.FlatAnimatedLafChange.showSnapshot(FlatAnimatedLafChange.java:80)`

To be honest, I do not yet fully understand how it comes to this. It is not thrown when I start my application in Eclipse.
I'm on MacOS, where there is no Icon in the Titlebar anyways...
It is thrown when I export a runnable jar and run it. In any case, I reckon catching this NPE is a good start. In the current state my ui remains incomplete.