### PR TITLE
Issue 689 system.get property security exception

### DIFF
--- a/flatlaf-core/build.gradle.kts
+++ b/flatlaf-core/build.gradle.kts
@@ -47,7 +47,9 @@ tasks {
 
 	jar {
 		archiveBaseName.set( "flatlaf" )
-
+		manifest {
+			attributes["Permissions"] = "all-permissions"
+		}
 		doLast {
 			ReorderJarEntries.reorderJarEntries( outputs.files.singleFile );
 		}

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/FlatLaf.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/FlatLaf.java
@@ -749,7 +749,7 @@ public abstract class FlatLaf
 
 	private Object fallbackAATextInfo() {
 		// do nothing if explicitly overridden
-		if( System.getProperty( "awt.useSystemAAFontSettings" ) != null )
+		if( FlatSystemCachedProperties.getProperty( "awt.useSystemAAFontSettings" ) != null )
 			return null;
 
 		Object aaHint = null;

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/FlatSystemCachedProperties.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/FlatSystemCachedProperties.java
@@ -1,0 +1,101 @@
+package com.formdev.flatlaf;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+/**
+ * Caches system properties
+ * @author Ryan Cuprak
+ */
+public class FlatSystemCachedProperties
+{
+
+	/**
+	 * True if the cache is to be used
+	 */
+	private static boolean useCache = false;
+
+	/**
+	 * Cache Properties
+	 */
+	private final static Map<String,String> cachedSystemProperties = new HashMap<>();
+
+	/**
+	 * Environment properties
+	 */
+	private final static Map<String,String> envSystemProperties = new HashMap<>();
+
+	/**
+	 * Enables or disables using a cache
+	 * @param useCache - true if to use cache
+	 */
+	public static void setUseCache(boolean useCache) {
+		FlatSystemCachedProperties.useCache = useCache;
+		Properties properties = System.getProperties();
+		for(String str : properties.stringPropertyNames()) {
+			cachedSystemProperties.put(str,System.getProperty(str));
+		}
+		Map<String,String> props = System.getenv();
+		for(String str : props.keySet()) {
+			envSystemProperties.put( str , System.getenv(str) );
+		}
+	}
+
+	/**
+	 * Returns the property
+	 * @param property - property
+	 * @return property value
+	 */
+	public static String getProperty(String property, String defaultValue) {
+		if(useCache) {
+			return cachedSystemProperties.get( property ) == null ? defaultValue : cachedSystemProperties.get( property );
+		}
+		return System.getProperty( property , defaultValue );
+	}
+
+	public static String getProperty(String property) {
+		if(useCache) {
+			return cachedSystemProperties.get( property );
+		}
+		return System.getProperty( property );
+	}
+
+	/**
+	 * Returns an environment property
+	 * @param property - property
+	 * @return String
+	 */
+	public static String getenv(String property) {
+		if(useCache) {
+			return envSystemProperties.get( property );
+		}
+		return System.getenv(property);
+	}
+
+	/**
+	 * Sets properties
+	 * @param property - property to be set
+	 * @param value - value of the property
+	 */
+	public static void setProperty(String property, String value) {
+		if(useCache) {
+			cachedSystemProperties.put( property,value );
+		} else {
+			System.setProperty( property , value );
+		}
+	}
+
+	/**
+	 * Clears the property
+	 * @param property - property
+	 */
+	public static void clearProperty ( String property ) {
+		if(useCache) {
+			cachedSystemProperties.remove( property );
+		} else {
+			System.clearProperty( property );
+		}
+	}
+}
+

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/FlatSystemProperties.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/FlatSystemProperties.java
@@ -179,7 +179,7 @@ public interface FlatSystemProperties
 	 * If the system property is not set, {@code defaultValue} is returned.
 	 */
 	static boolean getBoolean( String key, boolean defaultValue ) {
-		String value = System.getProperty( key );
+		String value = FlatSystemCachedProperties.getProperty( key );
 		return (value != null) ? Boolean.parseBoolean( value ) : defaultValue;
 	}
 
@@ -189,7 +189,7 @@ public interface FlatSystemProperties
 	 * is {@code "false"} (case-insensitive). Otherwise {@code defaultValue} is returned.
 	 */
 	static Boolean getBooleanStrict( String key, Boolean defaultValue ) {
-		String value = System.getProperty( key );
+		String value = FlatSystemCachedProperties.getProperty( key );
 		if( "true".equalsIgnoreCase( value ) )
 			return Boolean.TRUE;
 		if( "false".equalsIgnoreCase( value ) )

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/LinuxFontPolicy.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/LinuxFontPolicy.java
@@ -262,7 +262,7 @@ class LinuxFontPolicy
 
 	@SuppressWarnings( "MixedMutabilityReturnType" ) // Error Prone
 	private static List<String> readConfig( String filename ) {
-		File userHome = new File( System.getProperty( "user.home" ) );
+		File userHome = new File( FlatSystemCachedProperties.getProperty( "user.home" ) );
 
 		// search for config file
 		String[] configDirs = {

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatFileChooserUI.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatFileChooserUI.java
@@ -53,6 +53,7 @@ import javax.swing.plaf.ComponentUI;
 import javax.swing.plaf.metal.MetalFileChooserUI;
 import javax.swing.table.TableCellRenderer;
 import com.formdev.flatlaf.FlatClientProperties;
+import com.formdev.flatlaf.FlatSystemCachedProperties;
 import com.formdev.flatlaf.util.LoggingFacade;
 import com.formdev.flatlaf.util.ScaledImageIcon;
 import com.formdev.flatlaf.util.SystemInfo;
@@ -490,7 +491,7 @@ public class FlatFileChooserUI
 					File[] files = (File[]) m.invoke( fsv );
 
 					// on macOS and Linux, files consists only of the user home directory
-					if( files.length == 1 && files[0].equals( new File( System.getProperty( "user.home" ) ) ) )
+					if( files.length == 1 && files[0].equals( new File( FlatSystemCachedProperties.getProperty( "user.home" ) ) ) )
 						files = new File[0];
 
 					return files;

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatNativeLibrary.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatNativeLibrary.java
@@ -19,6 +19,7 @@ package com.formdev.flatlaf.ui;
 import java.io.File;
 import java.net.URL;
 import java.security.CodeSource;
+import com.formdev.flatlaf.FlatSystemCachedProperties;
 import com.formdev.flatlaf.FlatSystemProperties;
 import com.formdev.flatlaf.util.LoggingFacade;
 import com.formdev.flatlaf.util.NativeLibrary;
@@ -86,7 +87,7 @@ class FlatNativeLibrary
 		String libraryName = "flatlaf-" + classifier;
 
 		// load from "java.library.path" or from path specified in system property "flatlaf.nativeLibraryPath"
-		String libraryPath = System.getProperty( FlatSystemProperties.NATIVE_LIBRARY_PATH );
+		String libraryPath = FlatSystemCachedProperties.getProperty( FlatSystemProperties.NATIVE_LIBRARY_PATH );
 		if( libraryPath != null ) {
 			if( "system".equals( libraryPath ) ) {
 				NativeLibrary library = new NativeLibrary( libraryName, true );

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/util/HiDPIUtils.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/util/HiDPIUtils.java
@@ -24,6 +24,7 @@ import java.awt.geom.AffineTransform;
 import java.awt.geom.Rectangle2D;
 import java.text.AttributedCharacterIterator;
 import javax.swing.JComponent;
+import com.formdev.flatlaf.FlatSystemCachedProperties;
 import com.formdev.flatlaf.FlatSystemProperties;
 
 /**
@@ -242,7 +243,7 @@ public class HiDPIUtils
 	private static float getUserScaleFactor() {
 		return !useDebugScaleFactor()
 			? UIScale.getUserScaleFactor()
-			: Float.parseFloat( System.getProperty( "FlatLaf.debug.HiDPIUtils.debugScaleFactor", "1" ) );
+			: Float.parseFloat( FlatSystemCachedProperties.getProperty( "FlatLaf.debug.HiDPIUtils.debugScaleFactor", "1" ) );
 	}
 
 	/**

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/util/NativeLibrary.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/util/NativeLibrary.java
@@ -16,6 +16,7 @@
 
 package com.formdev.flatlaf.util;
 
+import com.formdev.flatlaf.FlatSystemCachedProperties;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -220,7 +221,7 @@ public class NativeLibrary
 
 	private static Path getTempDir() throws IOException {
 		// get standard temporary directory
-		String tmpdir = System.getProperty( "java.io.tmpdir" );
+		String tmpdir = FlatSystemCachedProperties.getProperty( "java.io.tmpdir" );
 
 		if( SystemInfo.isWindows ) {
 			// On Windows, where File.delete() and File.deleteOnExit() does not work

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/util/SystemInfo.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/util/SystemInfo.java
@@ -18,6 +18,7 @@ package com.formdev.flatlaf.util;
 
 import java.util.Locale;
 import java.util.StringTokenizer;
+import com.formdev.flatlaf.FlatSystemCachedProperties;
 import com.formdev.flatlaf.ui.FlatNativeWindowsLibrary;
 
 /**
@@ -71,26 +72,26 @@ public class SystemInfo
 
 	static {
 		// platforms
-		String osName = System.getProperty( "os.name" ).toLowerCase( Locale.ENGLISH );
+		String osName = FlatSystemCachedProperties.getProperty("os.name" ).toLowerCase( Locale.ENGLISH );
 		isWindows = osName.startsWith( "windows" );
 		isMacOS = osName.startsWith( "mac" );
 		isLinux = osName.startsWith( "linux" );
 
 		// OS versions
-		osVersion = scanVersion( System.getProperty( "os.version" ) );
+		osVersion = scanVersion( FlatSystemCachedProperties.getProperty( "os.version" ) );
 		isWindows_10_orLater = (isWindows && osVersion >= toVersion( 10, 0, 0, 0 ));
 		isMacOS_10_11_ElCapitan_orLater = (isMacOS && osVersion >= toVersion( 10, 11, 0, 0 ));
 		isMacOS_10_14_Mojave_orLater = (isMacOS && osVersion >= toVersion( 10, 14, 0, 0 ));
 		isMacOS_10_15_Catalina_orLater = (isMacOS && osVersion >= toVersion( 10, 15, 0, 0 ));
 
 		// OS architecture
-		String osArch = System.getProperty( "os.arch" );
+		String osArch = FlatSystemCachedProperties.getProperty( "os.arch" );
 		isX86 = osArch.equals( "x86" );
 		isX86_64 = osArch.equals( "amd64" ) || osArch.equals( "x86_64" );
 		isAARCH64 = osArch.equals( "aarch64" );
 
 		// Java versions
-		javaVersion = scanVersion( System.getProperty( "java.version" ) );
+		javaVersion = scanVersion( FlatSystemCachedProperties.getProperty( "java.version" ) );
 		isJava_9_orLater = (javaVersion >= toVersion( 9, 0, 0, 0 ));
 		isJava_11_orLater = (javaVersion >= toVersion( 11, 0, 0, 0 ));
 		isJava_12_orLater = (javaVersion >= toVersion( 12, 0, 0, 0 ));
@@ -99,7 +100,7 @@ public class SystemInfo
 		isJava_18_orLater = (javaVersion >= toVersion( 18, 0, 0, 0 ));
 
 		// Java VMs
-		isJetBrainsJVM = System.getProperty( "java.vm.vendor", "Unknown" )
+		isJetBrainsJVM = FlatSystemCachedProperties.getProperty( "java.vm.vendor", "Unknown" )
 			.toLowerCase( Locale.ENGLISH ).contains( "jetbrains" );
 		isJetBrainsJVM_11_orLater = isJetBrainsJVM && isJava_11_orLater;
 
@@ -108,8 +109,8 @@ public class SystemInfo
 
 		// other
 		isProjector = Boolean.getBoolean( "org.jetbrains.projector.server.enable" );
-		isWebswing = (System.getProperty( "webswing.rootDir" ) != null);
-		isWinPE = isWindows && "X:\\Windows\\System32".equalsIgnoreCase( System.getProperty( "user.dir" ) );
+		isWebswing = (FlatSystemCachedProperties.getProperty( "webswing.rootDir" ) != null);
+		isWinPE = isWindows && "X:\\Windows\\System32".equalsIgnoreCase( FlatSystemCachedProperties.getProperty( "user.dir" ) );
 
 		// features
 		// available since Java 12; backported to Java 11.0.8 and 8u292

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/util/UIScale.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/util/UIScale.java
@@ -33,6 +33,7 @@ import javax.swing.plaf.DimensionUIResource;
 import javax.swing.plaf.FontUIResource;
 import javax.swing.plaf.InsetsUIResource;
 import javax.swing.plaf.UIResource;
+import com.formdev.flatlaf.FlatSystemCachedProperties;
 import com.formdev.flatlaf.FlatSystemProperties;
 
 /**
@@ -292,7 +293,7 @@ public class UIScale
 	 * Get custom scale factor specified in system property "flatlaf.uiScale".
 	 */
 	private static float getCustomScaleFactor() {
-		return parseScaleFactor( System.getProperty( FlatSystemProperties.UI_SCALE ) );
+		return parseScaleFactor( FlatSystemCachedProperties.getProperty( FlatSystemProperties.UI_SCALE ) );
 	}
 
 	/**


### PR DESCRIPTION
A proposed fix for Issue 689. I have added a class FlatSystemCachedProperties which caches values returned by calls to System.getProperty(). Use of the cache can be turned on/off. So if you are going to be executing code with a security manager, you can enable it and cached values will be used. 