### PR TITLE
Windows on ARM Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ FlatLaf Change Log
 
 #### New features and improvements
 
+- FlatLaf window decorations: Support for Windows on ARM 64-bit. (issue #443, PR
+  #707)
 - Extras: Class `FlatSVGIcon` now uses [JSVG](https://github.com/weisJ/jsvg)
   library (instead of svgSalamander) for rendering. JSVG provides improved SVG
   rendering and uses less memory compared to svgSalamander. (PR #684)

--- a/flatlaf-core/build.gradle.kts
+++ b/flatlaf-core/build.gradle.kts
@@ -129,6 +129,7 @@ flatlafPublish {
 	nativeArtifacts = listOf(
 		NativeArtifact( "${natives}/flatlaf-windows-x86.dll",    "windows-x86",    "dll" ),
 		NativeArtifact( "${natives}/flatlaf-windows-x86_64.dll", "windows-x86_64", "dll" ),
+		NativeArtifact( "${natives}/flatlaf-windows-arm64.dll",  "windows-arm64",  "dll" ),
 		NativeArtifact( "${natives}/libflatlaf-linux-x86_64.so", "linux-x86_64",   "so" ),
 	)
 }

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatNativeLibrary.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatNativeLibrary.java
@@ -55,12 +55,12 @@ class FlatNativeLibrary
 
 		String classifier;
 		String ext;
-		if( SystemInfo.isWindows_10_orLater ) {
-			// Windows: requires Windows 10/11
+		if( SystemInfo.isWindows_10_orLater && (SystemInfo.isX86 || SystemInfo.isX86_64 || SystemInfo.isAARCH64) ) {
+			// Windows: requires Windows 10/11 (x86, x86_64 or aarch64)
 
-			if ( SystemInfo.isAARCH64 )
-				classifier = "windows-aarch64";
-			else if ( SystemInfo.isX86_64 )
+			if( SystemInfo.isAARCH64 )
+				classifier = "windows-arm64";
+			else if( SystemInfo.isX86_64 )
 				classifier = "windows-x86_64";
 			else
 				classifier = "windows-x86";

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatNativeLibrary.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatNativeLibrary.java
@@ -55,10 +55,16 @@ class FlatNativeLibrary
 
 		String classifier;
 		String ext;
-		if( SystemInfo.isWindows_10_orLater && (SystemInfo.isX86 || SystemInfo.isX86_64) ) {
-			// Windows: requires Windows 10/11 (x86 or x86_64)
+		if( SystemInfo.isWindows_10_orLater ) {
+			// Windows: requires Windows 10/11
 
-			classifier = SystemInfo.isX86_64 ? "windows-x86_64" : "windows-x86";
+			if ( SystemInfo.isAARCH64 )
+				classifier = "windows-aarch64";
+			else if ( SystemInfo.isX86_64 )
+				classifier = "windows-x86_64";
+			else
+				classifier = "windows-x86";
+
 			ext = "dll";
 
 			// Do not load jawt.dll (part of JRE) here explicitly because

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatWindowsNativeWindowBorder.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatWindowsNativeWindowBorder.java
@@ -88,10 +88,6 @@ class FlatWindowsNativeWindowBorder
 		if( !SystemInfo.isWindows_10_orLater )
 			return null;
 
-		// requires x86 architecture
-		if( !SystemInfo.isX86 && !SystemInfo.isX86_64 )
-			return null;
-
 		// check whether native library was successfully loaded
 		if( !FlatNativeLibrary.isLoaded() )
 			return null;

--- a/flatlaf-natives/flatlaf-natives-windows/build.gradle.kts
+++ b/flatlaf-natives/flatlaf-natives-windows/build.gradle.kts
@@ -29,7 +29,7 @@ flatlafJniHeaders {
 }
 
 library {
-	targetMachines.set( listOf( machines.windows.x86, machines.windows.x86_64, machines.windows.architecture("aarch64") ) )
+	targetMachines.set( listOf( machines.windows.x86, machines.windows.x86_64, machines.windows.architecture( "aarch64" ) ) )
 }
 
 var javaHome = System.getProperty( "java.home" )
@@ -71,7 +71,7 @@ tasks {
 		val nativesDir = project( ":flatlaf-core" ).projectDir.resolve( "src/main/resources/com/formdev/flatlaf/natives" )
 		val isX86 = name.contains("X86")
 		val is64Bit = name.contains( "64" )
-		val libraryName = if( is64Bit && isX86 ) "flatlaf-windows-x86_64.dll" else if( isX86 ) "flatlaf-windows-x86.dll" else "flatlaf-windows-aarch64.dll"
+		val libraryName = if( is64Bit && isX86 ) "flatlaf-windows-x86_64.dll" else if( isX86 ) "flatlaf-windows-x86.dll" else "flatlaf-windows-arm64.dll"
 
 		linkerArgs.addAll( toolChain.map {
 			when( it ) {

--- a/flatlaf-natives/flatlaf-natives-windows/build.gradle.kts
+++ b/flatlaf-natives/flatlaf-natives-windows/build.gradle.kts
@@ -29,7 +29,7 @@ flatlafJniHeaders {
 }
 
 library {
-	targetMachines.set( listOf( machines.windows.x86, machines.windows.x86_64 ) )
+	targetMachines.set( listOf( machines.windows.x86, machines.windows.x86_64, machines.windows.architecture("aarch64") ) )
 }
 
 var javaHome = System.getProperty( "java.home" )
@@ -42,7 +42,7 @@ tasks {
 		description = "Builds natives"
 
 		if( org.gradle.internal.os.OperatingSystem.current().isWindows() )
-			dependsOn( "linkReleaseX86", "linkReleaseX86-64" )
+			dependsOn( "linkReleaseX86", "linkReleaseX86-64", "linkReleaseAarch64" )
 	}
 
 	withType<CppCompile>().configureEach {
@@ -69,8 +69,9 @@ tasks {
 		onlyIf { name.contains( "Release" ) }
 
 		val nativesDir = project( ":flatlaf-core" ).projectDir.resolve( "src/main/resources/com/formdev/flatlaf/natives" )
+		val isX86 = name.contains("X86")
 		val is64Bit = name.contains( "64" )
-		val libraryName = if( is64Bit ) "flatlaf-windows-x86_64.dll" else "flatlaf-windows-x86.dll"
+		val libraryName = if( is64Bit && isX86 ) "flatlaf-windows-x86_64.dll" else if( isX86 ) "flatlaf-windows-x86.dll" else "flatlaf-windows-aarch64.dll"
 
 		linkerArgs.addAll( toolChain.map {
 			when( it ) {


### PR DESCRIPTION
Closes #443

This PR adds native library support for Windows on ARM.

Verification steps

1. Compile native libraries and build flatlaf-demo.
2. Observe embedded menu bars working on all Windows architectures (i.e., x86, x86_64, _and_ aarch64).