### PR TITLE
Use gradle-build-action in Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,14 +41,19 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
           distribution: temurin  # Java 8, 11 and 17 are pre-installed on ubuntu-latest
-          cache: gradle
 
       - name: Check with Error Prone
         if: matrix.java == '11'
-        run: ./gradlew errorprone clean -Dtoolchain=${{ matrix.toolchain }}
+        uses: gradle/gradle-build-action@v2
+        with:
+          gradle-version: wrapper
+          arguments: errorprone clean -Dtoolchain=${{ matrix.toolchain }}
 
       - name: Build with Gradle
-        run: ./gradlew build -Dtoolchain=${{ matrix.toolchain }}
+        uses: gradle/gradle-build-action@v2
+        with:
+          gradle-version: wrapper
+          arguments: build -Dtoolchain=${{ matrix.toolchain }}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
@@ -78,10 +83,12 @@ jobs:
         with:
           java-version: 11
           distribution: temurin  # pre-installed on ubuntu-latest
-          cache: gradle
 
       - name: Publish snapshot to oss.sonatype.org
-        run: ./gradlew publish :flatlaf-theme-editor:build -PskipFonts -Dorg.gradle.internal.publish.checksums.insecure=true -Dorg.gradle.parallel=false
+        uses: gradle/gradle-build-action@v2
+        with:
+          gradle-version: wrapper
+          arguments: publish :flatlaf-theme-editor:build -PskipFonts -Dorg.gradle.internal.publish.checksums.insecure=true -Dorg.gradle.parallel=false
         env:
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
@@ -114,10 +121,12 @@ jobs:
         with:
           java-version: 11
           distribution: temurin  # pre-installed on ubuntu-latest
-          cache: gradle
 
       - name: Release a new stable version to Maven Central
-        run: ./gradlew publish :flatlaf-demo:build :flatlaf-theme-editor:build -PskipFonts -Prelease -Dorg.gradle.parallel=false
+        uses: gradle/gradle-build-action@v2
+        with:
+          gradle-version: wrapper
+          arguments: publish :flatlaf-demo:build :flatlaf-theme-editor:build -PskipFonts -Prelease -Dorg.gradle.parallel=false
         env:
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,18 +42,18 @@ jobs:
           java-version: ${{ matrix.java }}
           distribution: temurin  # Java 8, 11 and 17 are pre-installed on ubuntu-latest
 
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          gradle-version: wrapper
+          gradle-home-cache-excludes: |
+            caches/jars-*/*
       - name: Check with Error Prone
         if: matrix.java == '11'
-        uses: gradle/gradle-build-action@v2
-        with:
-          gradle-version: wrapper
-          arguments: errorprone clean -Dtoolchain=${{ matrix.toolchain }}
+        run: ./gradlew errorprone clean -Dtoolchain=${{ matrix.toolchain }}
 
       - name: Build with Gradle
-        uses: gradle/gradle-build-action@v2
-        with:
-          gradle-version: wrapper
-          arguments: build -Dtoolchain=${{ matrix.toolchain }}
+        run: ./gradlew build -Dtoolchain=${{ matrix.toolchain }}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3
@@ -88,6 +88,8 @@ jobs:
         uses: gradle/gradle-build-action@v2
         with:
           gradle-version: wrapper
+          gradle-home-cache-excludes: |
+            caches/jars-*/*
           arguments: publish :flatlaf-theme-editor:build -PskipFonts -Dorg.gradle.internal.publish.checksums.insecure=true -Dorg.gradle.parallel=false
         env:
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}

--- a/.github/workflows/fonts.yml
+++ b/.github/workflows/fonts.yml
@@ -37,21 +37,29 @@ jobs:
               with:
                   java-version: 11
                   distribution: temurin  # pre-installed on ubuntu-latest
-                  cache: gradle
 
             - name: Build with Gradle
-              run: ./gradlew :flatlaf-fonts-${{ matrix.font }}:build
+              uses: gradle/gradle-build-action@v2
+              with:
+                gradle-version: wrapper
+                arguments: :flatlaf-fonts-${{ matrix.font }}:build
               if: startsWith( github.ref, format( 'refs/tags/fonts/{0}-', matrix.font ) ) != true
 
             - name: Publish snapshot to oss.sonatype.org
-              run: ./gradlew :flatlaf-fonts-${{ matrix.font }}:publish -Dorg.gradle.internal.publish.checksums.insecure=true
+              uses: gradle/gradle-build-action@v2
+              with:
+                gradle-version: wrapper
+                arguments: :flatlaf-fonts-${{ matrix.font }}:publish -Dorg.gradle.internal.publish.checksums.insecure=true
               env:
                   OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
                   OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
               if: github.ref == 'refs/heads/main' || startsWith( github.ref, 'refs/heads/develop-' )
 
             - name: Release a new stable version to Maven Central
-              run: ./gradlew :flatlaf-fonts-${{ matrix.font }}:build :flatlaf-fonts-${{ matrix.font }}:publish -Prelease
+              uses: gradle/gradle-build-action@v2
+              with:
+                gradle-version: wrapper
+                arguments: :flatlaf-fonts-${{ matrix.font }}:build :flatlaf-fonts-${{ matrix.font }}:publish -Prelease
               env:
                   OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
                   OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}

--- a/.github/workflows/natives.yml
+++ b/.github/workflows/natives.yml
@@ -34,12 +34,14 @@ jobs:
               with:
                   java-version: 11
                   distribution: temurin
-                  cache: gradle
 
             - name: Build with Gradle
               # --no-daemon is necessary on Windows otherwise caching Gradle would fail with:
               #   tar.exe: Couldn't open ~/.gradle/caches/modules-2/modules-2.lock: Permission denied
-              run: ./gradlew build-natives --no-daemon
+              uses: gradle/gradle-build-action@v2
+              with:
+                gradle-version: wrapper
+                arguments: build-natives --no-daemon
 
             - name: Upload artifacts
               uses: actions/upload-artifact@v3

--- a/.github/workflows/natives.yml
+++ b/.github/workflows/natives.yml
@@ -36,12 +36,10 @@ jobs:
                   distribution: temurin
 
             - name: Build with Gradle
-              # --no-daemon is necessary on Windows otherwise caching Gradle would fail with:
-              #   tar.exe: Couldn't open ~/.gradle/caches/modules-2/modules-2.lock: Permission denied
               uses: gradle/gradle-build-action@v2
               with:
                 gradle-version: wrapper
-                arguments: build-natives --no-daemon
+                arguments: build-natives
 
             - name: Upload artifacts
               uses: actions/upload-artifact@v3


### PR DESCRIPTION
This PR modifies the Actions workflows to use [`gradle/gradle-build-action`](https://github.com/gradle/gradle-build-action) for running gradle instead of invoking it from CLI.

Changes include:
- Modifying workflows to use `gradle/gradle-build-action`
- Disabling caching provided by [`actions/setup-java`](https://github.com/actions/setup-java) to take advantage of finer-grain caching provided by `gradle/gradle-build-action`.
- Removing `--no-daemon` argument in native libraries workflow (handled by `gradle/gradle-build-action` action - see [documentation](https://github.com/gradle/gradle-build-action#stopping-the-gradle-daemon))