### PR TITLE
x86: Narrow version range for not using system icons

### DIFF
--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatFileChooserUI.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatFileChooserUI.java
@@ -348,10 +348,10 @@ public class FlatFileChooserUI
 
 	private boolean doNotUseSystemIcons() {
 		// Java 17 32bit craches on Windows when using system icons
-		// fixed in Java 18+ (see https://bugs.openjdk.java.net/browse/JDK-8277299)
+		// fixed in Java 18+, fix backported in Java 17.0.3+ (see https://bugs.openjdk.java.net/browse/JDK-8277299)
 		return SystemInfo.isWindows &&
 			SystemInfo.isX86 &&
-			(SystemInfo.isJava_17_orLater && !SystemInfo.isJava_18_orLater);
+			(SystemInfo.isJava_17_orLater && SystemInfo.javaVersion < SystemInfo.toVersion(17, 0, 3, 0));
 	}
 
 	//---- class FlatFileView -------------------------------------------------


### PR DESCRIPTION
Related: #403

The fix for [JDK-8277299](https://bugs.openjdk.org/browse/JDK-8277299) was backported to Java 17.0.3 (with https://github.com/openjdk/jdk17u-dev/pull/98) and using system icons in later subversions should not cause a crash. Thus, this PR amends the version range for disabling system icons.