### PR TITLE
Scrollpane rounded border

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 FlatLaf Change Log
 ==================
 
+## 3.3-SNAPSHOT
+
+#### Fixed bugs
+
+- ScrollPane: Styling ScrollPane border properties did not work if view
+  component is a Table.
+
+
 ## 3.2
 
 #### New features and improvements

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatBorder.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatBorder.java
@@ -28,7 +28,6 @@ import javax.swing.JComboBox;
 import javax.swing.JComponent;
 import javax.swing.JScrollPane;
 import javax.swing.JSpinner;
-import javax.swing.JViewport;
 import javax.swing.UIManager;
 import javax.swing.plaf.basic.BasicBorders;
 import com.formdev.flatlaf.FlatClientProperties;
@@ -195,8 +194,7 @@ public class FlatBorder
 	protected boolean isEnabled( Component c ) {
 		if( c instanceof JScrollPane ) {
 			// check whether view component is disabled
-			JViewport viewport = ((JScrollPane)c).getViewport();
-			Component view = (viewport != null) ? viewport.getView() : null;
+			Component view = FlatScrollPaneUI.getView( (JScrollPane) c );
 			if( view != null && !isEnabled( view ) )
 				return false;
 		}

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatScrollPaneBorder.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatScrollPaneBorder.java
@@ -41,11 +41,8 @@ public class FlatScrollPaneBorder
 
 		// if view is rounded, increase left and right insets to avoid that the viewport
 		// is painted over the rounded border on the corners
-		int arc = getArc( c );
-		if( arc > 0 ) {
-			// increase insets by radius minus lineWidth because radius is measured
-			// from the outside of the line, but insets from super include lineWidth
-			int padding = UIScale.scale( (arc / 2) - getLineWidth( c ) );
+		int padding = getLeftRightPadding( c );
+		if( padding > 0 ) {
 			insets.left += padding;
 			insets.right += padding;
 		}
@@ -59,5 +56,23 @@ public class FlatScrollPaneBorder
 			return 0;
 
 		return arc;
+	}
+
+	/**
+	 * Returns the scaled left/right padding used when arc is larger than zero.
+	 * <p>
+	 * This is the distance from the inside of the left border to the left side of the view component.
+	 * On the right side, this is the distance between the right side of the view component and
+	 * the vertical scrollbar. Or the inside of the right border if the scrollbar is hidden.
+	 */
+	public int getLeftRightPadding( Component c ) {
+		// Subtract lineWidth from radius because radius is given for the outside
+		// of the painted line, but insets from super already include lineWidth.
+		// Reduce padding by 10% to make padding slightly smaller because it is not recognizable
+		// when the view is minimally painted over the beginning of the border curve.
+		int arc = getArc( c );
+		return (arc > 0)
+			? Math.max( Math.round( UIScale.scale( ((arc / 2f) - getLineWidth( c )) * 0.9f ) ), 0 )
+			: 0;
 	}
 }

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatScrollPaneBorder.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatScrollPaneBorder.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2023 FormDev Software GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.formdev.flatlaf.ui;
+
+import java.awt.Component;
+import java.awt.Insets;
+import javax.swing.UIManager;
+import com.formdev.flatlaf.ui.FlatStylingSupport.Styleable;
+import com.formdev.flatlaf.util.UIScale;
+
+/**
+ * Border for {@link javax.swing.JScrollPane}.
+ *
+ * @uiDefault ScrollPane.arc				int
+
+ * @author Karl Tauber
+ * @since 3.3
+ */
+public class FlatScrollPaneBorder
+	extends FlatBorder
+{
+	@Styleable protected int arc = UIManager.getInt( "ScrollPane.arc" );
+
+	@Override
+	public Insets getBorderInsets( Component c, Insets insets ) {
+		insets = super.getBorderInsets( c, insets );
+
+		// if view is rounded, increase left and right insets to avoid that the viewport
+		// is painted over the rounded border on the corners
+		int arc = getArc( c );
+		if( arc > 0 ) {
+			// increase insets by radius minus lineWidth because radius is measured
+			// from the outside of the line, but insets from super include lineWidth
+			int padding = UIScale.scale( (arc / 2) - getLineWidth( c ) );
+			insets.left += padding;
+			insets.right += padding;
+		}
+
+		return insets;
+	}
+
+	@Override
+	protected int getArc( Component c ) {
+		if( isCellEditor( c ) )
+			return 0;
+
+		return arc;
+	}
+}

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatScrollPaneBorder.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatScrollPaneBorder.java
@@ -18,7 +18,12 @@ package com.formdev.flatlaf.ui;
 
 import java.awt.Component;
 import java.awt.Insets;
+import javax.swing.JList;
+import javax.swing.JScrollPane;
+import javax.swing.JTable;
+import javax.swing.JTree;
 import javax.swing.UIManager;
+import javax.swing.text.JTextComponent;
 import com.formdev.flatlaf.ui.FlatStylingSupport.Styleable;
 import com.formdev.flatlaf.util.UIScale;
 
@@ -26,6 +31,10 @@ import com.formdev.flatlaf.util.UIScale;
  * Border for {@link javax.swing.JScrollPane}.
  *
  * @uiDefault ScrollPane.arc				int
+ * @uiDefault ScrollPane.List.arc			int
+ * @uiDefault ScrollPane.Table.arc			int
+ * @uiDefault ScrollPane.TextComponent.arc	int
+ * @uiDefault ScrollPane.Tree.arc			int
 
  * @author Karl Tauber
  * @since 3.3
@@ -34,6 +43,22 @@ public class FlatScrollPaneBorder
 	extends FlatBorder
 {
 	@Styleable protected int arc = UIManager.getInt( "ScrollPane.arc" );
+
+	private boolean isArcStyled;
+	private final int listArc = FlatUIUtils.getUIInt( "ScrollPane.List.arc", -1 );
+	private final int tableArc = FlatUIUtils.getUIInt( "ScrollPane.Table.arc", -1 );
+	private final int textComponentArc = FlatUIUtils.getUIInt( "ScrollPane.TextComponent.arc", -1 );
+	private final int treeArc = FlatUIUtils.getUIInt( "ScrollPane.Tree.arc", -1 );
+
+	@Override
+	public Object applyStyleProperty( String key, Object value ) {
+		Object oldValue = super.applyStyleProperty( key, value );
+
+		if( "arc".equals( key ) )
+			isArcStyled = true;
+
+		return oldValue;
+	}
 
 	@Override
 	public Insets getBorderInsets( Component c, Insets insets ) {
@@ -54,6 +79,21 @@ public class FlatScrollPaneBorder
 	protected int getArc( Component c ) {
 		if( isCellEditor( c ) )
 			return 0;
+
+		if( isArcStyled )
+			return arc;
+
+		if( c instanceof JScrollPane ) {
+			Component view = FlatScrollPaneUI.getView( (JScrollPane) c );
+			if( listArc >= 0 && view instanceof JList )
+				return listArc;
+			if( tableArc >= 0 && view instanceof JTable )
+				return tableArc;
+			if( textComponentArc >= 0&& view instanceof JTextComponent )
+				return textComponentArc;
+			if( treeArc >= 0 && view instanceof JTree )
+				return treeArc;
+		}
 
 		return arc;
 	}

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatScrollPaneUI.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatScrollPaneUI.java
@@ -521,17 +521,19 @@ public class FlatScrollPaneUI
 			super.layoutContainer( parent );
 
 			JScrollPane scrollPane = (JScrollPane) parent;
-			float arc = getBorderArc( scrollPane );
-			if( arc > 0 ) {
+			Border border = scrollPane.getBorder();
+			int padding;
+			if( border instanceof FlatScrollPaneBorder &&
+				(padding = ((FlatScrollPaneBorder)border).getLeftRightPadding( scrollPane )) > 0 )
+			{
 				JScrollBar vsb = getVerticalScrollBar();
 				if( vsb != null && vsb.isVisible() ) {
 					// move vertical scrollbar to trailing edge
-					int padding = Math.round( (arc / 2) - FlatUIUtils.getBorderLineWidth( scrollPane ) );
-					Insets insets = parent.getInsets();
+					Insets insets = scrollPane.getInsets();
 					Rectangle r = vsb.getBounds();
 					int y = Math.max( r.y, insets.top + padding );
-					int y2 = Math.min( r.y + r.height, parent.getHeight() - insets.bottom - padding );
-					boolean ltr = parent.getComponentOrientation().isLeftToRight();
+					int y2 = Math.min( r.y + r.height, scrollPane.getHeight() - insets.bottom - padding );
+					boolean ltr = scrollPane.getComponentOrientation().isLeftToRight();
 
 					vsb.setBounds( r.x + (ltr ? padding : -padding), y, r.width, y2 - y );
 				}

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatScrollPaneUI.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatScrollPaneUI.java
@@ -330,6 +330,18 @@ public class FlatScrollPaneUI
 					scrollpane.revalidate();
 					scrollpane.repaint();
 					break;
+
+				case "border":
+					Object newBorder = e.getNewValue();
+					if( newBorder != null && newBorder == UIManager.getBorder( "Table.scrollPaneBorder" ) ) {
+						// JTable.configureEnclosingScrollPaneUI() replaces the scrollpane border
+						// with another one --> re-apply style on new border
+						borderShared = null;
+						installStyle();
+						scrollpane.revalidate();
+						scrollpane.repaint();
+					}
+					break;
 			}
 		};
 	}

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatScrollPaneUI.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatScrollPaneUI.java
@@ -496,7 +496,7 @@ public class FlatScrollPaneUI
 		return false;
 	}
 
-	private static Component getView( JScrollPane scrollPane ) {
+	static Component getView( JScrollPane scrollPane ) {
 		JViewport viewport = scrollPane.getViewport();
 		return (viewport != null) ? viewport.getView() : null;
 	}
@@ -537,13 +537,15 @@ public class FlatScrollPaneUI
 		@Override
 		public void focusGained( FocusEvent e ) {
 			// necessary to update focus border
-			scrollpane.repaint();
+			if( scrollpane.getBorder() instanceof FlatBorder )
+				scrollpane.repaint();
 		}
 
 		@Override
 		public void focusLost( FocusEvent e ) {
 			// necessary to update focus border
-			scrollpane.repaint();
+			if( scrollpane.getBorder() instanceof FlatBorder )
+				scrollpane.repaint();
 		}
 	}
 

--- a/flatlaf-core/src/main/resources/com/formdev/flatlaf/FlatLaf.properties
+++ b/flatlaf-core/src/main/resources/com/formdev/flatlaf/FlatLaf.properties
@@ -602,6 +602,10 @@ ScrollPane.background = $ScrollBar.track
 ScrollPane.fillUpperCorner = true
 ScrollPane.smoothScrolling = true
 ScrollPane.arc = 0
+#ScrollPane.List.arc = -1
+#ScrollPane.Table.arc = -1
+#ScrollPane.TextComponent.arc = -1
+#ScrollPane.Tree.arc = -1
 
 
 #---- SearchField ----

--- a/flatlaf-core/src/main/resources/com/formdev/flatlaf/FlatLaf.properties
+++ b/flatlaf-core/src/main/resources/com/formdev/flatlaf/FlatLaf.properties
@@ -597,10 +597,11 @@ ScrollBar.allowsAbsolutePositioning = true
 
 #---- ScrollPane ----
 
-ScrollPane.border = com.formdev.flatlaf.ui.FlatBorder
+ScrollPane.border = com.formdev.flatlaf.ui.FlatScrollPaneBorder
 ScrollPane.background = $ScrollBar.track
 ScrollPane.fillUpperCorner = true
 ScrollPane.smoothScrolling = true
+ScrollPane.arc = 0
 
 
 #---- SearchField ----
@@ -731,7 +732,7 @@ Table.showVerticalLines = false
 Table.showTrailingVerticalLine = false
 Table.consistentHomeEndKeyBehavior = true
 Table.intercellSpacing = 0,0
-Table.scrollPaneBorder = com.formdev.flatlaf.ui.FlatBorder
+Table.scrollPaneBorder = com.formdev.flatlaf.ui.FlatScrollPaneBorder
 Table.ascendingSortIcon = com.formdev.flatlaf.icons.FlatAscendingSortIcon
 Table.descendingSortIcon = com.formdev.flatlaf.icons.FlatDescendingSortIcon
 Table.sortIconColor = @icon

--- a/flatlaf-core/src/test/java/com/formdev/flatlaf/ui/TestFlatStyleableInfo.java
+++ b/flatlaf-core/src/test/java/com/formdev/flatlaf/ui/TestFlatStyleableInfo.java
@@ -601,7 +601,7 @@ public class TestFlatStyleableInfo
 		);
 
 		// border
-		flatBorder( expected );
+		flatScrollPaneBorder( expected );
 
 		assertMapEquals( expected, ui.getStyleableInfos( c ) );
 	}
@@ -1005,8 +1005,15 @@ public class TestFlatStyleableInfo
 
 		expectedMap( expected,
 			"arc", int.class,
-
 			"roundRect", Boolean.class
+		);
+	}
+
+	private void flatScrollPaneBorder( Map<String, Class<?>> expected ) {
+		flatBorder( expected );
+
+		expectedMap( expected,
+			"arc", int.class
 		);
 	}
 
@@ -1015,7 +1022,6 @@ public class TestFlatStyleableInfo
 
 		expectedMap( expected,
 			"arc", int.class,
-
 			"roundRect", Boolean.class
 		);
 	}

--- a/flatlaf-core/src/test/java/com/formdev/flatlaf/ui/TestFlatStyleableValue.java
+++ b/flatlaf-core/src/test/java/com/formdev/flatlaf/ui/TestFlatStyleableValue.java
@@ -625,7 +625,7 @@ public class TestFlatStyleableValue
 		FlatScrollPaneUI ui = (FlatScrollPaneUI) c.getUI();
 
 		// border
-		flatBorder( c, ui );
+		flatScrollPaneBorder( c, ui );
 
 		testBoolean( c, ui, "showButtons", true );
 	}
@@ -965,15 +965,19 @@ public class TestFlatStyleableValue
 		flatBorder( c, ui );
 
 		testInteger( c, ui, "arc", 123 );
-
 		testBoolean( c, ui, "roundRect", true );
+	}
+
+	private void flatScrollPaneBorder( JComponent c, StyleableUI ui ) {
+		flatBorder( c, ui );
+
+		testInteger( c, ui, "arc", 123 );
 	}
 
 	private void flatTextBorder( JComponent c, StyleableUI ui ) {
 		flatBorder( c, ui );
 
 		testInteger( c, ui, "arc", 123 );
-
 		testBoolean( c, ui, "roundRect", true );
 	}
 
@@ -1035,6 +1039,17 @@ public class TestFlatStyleableValue
 		flatBorder( border );
 
 		testValue( border, "arc", 6 );
+		testValue( border, "roundRect", true );
+	}
+
+	@Test
+	void flatScrollPaneBorder() {
+		FlatScrollPaneBorder border = new FlatScrollPaneBorder();
+
+		// FlatScrollPaneBorder extends FlatBorder
+		flatBorder( border );
+
+		testValue( border, "arc", 6 );
 	}
 
 	@Test
@@ -1045,6 +1060,7 @@ public class TestFlatStyleableValue
 		flatBorder( border );
 
 		testValue( border, "arc", 6 );
+		testValue( border, "roundRect", true );
 	}
 
 	@Test

--- a/flatlaf-core/src/test/java/com/formdev/flatlaf/ui/TestFlatStyling.java
+++ b/flatlaf-core/src/test/java/com/formdev/flatlaf/ui/TestFlatStyling.java
@@ -760,7 +760,7 @@ public class TestFlatStyling
 		FlatScrollPaneUI ui = (FlatScrollPaneUI) c.getUI();
 
 		// border
-		flatBorder( style -> ui.applyStyle( style ) );
+		flatScrollPaneBorder( style -> ui.applyStyle( style ) );
 
 		ui.applyStyle( "showButtons: true" );
 
@@ -1234,15 +1234,19 @@ public class TestFlatStyling
 		flatBorder( applyStyle );
 
 		applyStyle.accept( "arc: 6" );
-
 		applyStyle.accept( "roundRect: true" );
+	}
+
+	private void flatScrollPaneBorder( Consumer<String> applyStyle ) {
+		flatBorder( applyStyle );
+
+		applyStyle.accept( "arc: 6" );
 	}
 
 	private void flatTextBorder( Consumer<String> applyStyle ) {
 		flatBorder( applyStyle );
 
 		applyStyle.accept( "arc: 6" );
-
 		applyStyle.accept( "roundRect: true" );
 	}
 

--- a/flatlaf-testing/dumps/uidefaults/FlatDarculaLaf_1.8.0.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatDarculaLaf_1.8.0.txt
@@ -87,8 +87,8 @@
 
 #---- ScrollPane ----
 
-- ScrollPane.border              [lazy] 1,1,1,1  false    com.formdev.flatlaf.ui.FlatBorder [UI]
-+ ScrollPane.border              [lazy] 3,3,3,3  false    com.formdev.flatlaf.ui.FlatBorder [UI]
+- ScrollPane.border              [lazy] 1,1,1,1  false    com.formdev.flatlaf.ui.FlatScrollPaneBorder [UI]
++ ScrollPane.border              [lazy] 3,3,3,3  false    com.formdev.flatlaf.ui.FlatScrollPaneBorder [UI]
 
 
 #---- Spinner ----
@@ -99,8 +99,8 @@
 
 #---- Table ----
 
-- Table.scrollPaneBorder         [lazy] 1,1,1,1  false    com.formdev.flatlaf.ui.FlatBorder [UI]
-+ Table.scrollPaneBorder         [lazy] 3,3,3,3  false    com.formdev.flatlaf.ui.FlatBorder [UI]
+- Table.scrollPaneBorder         [lazy] 1,1,1,1  false    com.formdev.flatlaf.ui.FlatScrollPaneBorder [UI]
++ Table.scrollPaneBorder         [lazy] 3,3,3,3  false    com.formdev.flatlaf.ui.FlatScrollPaneBorder [UI]
 
 
 #---- TextField ----

--- a/flatlaf-testing/dumps/uidefaults/FlatDarkLaf_1.8.0.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatDarkLaf_1.8.0.txt
@@ -906,8 +906,9 @@ ScrollBarUI                    com.formdev.flatlaf.ui.FlatScrollBarUI
 
 #---- ScrollPane ----
 
+ScrollPane.arc                 0
 ScrollPane.background          #3e4244  HSL 200   5  25    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(1%)
-ScrollPane.border              [lazy] 1,1,1,1  false    com.formdev.flatlaf.ui.FlatBorder [UI]
+ScrollPane.border              [lazy] 1,1,1,1  false    com.formdev.flatlaf.ui.FlatScrollPaneBorder [UI]
 ScrollPane.fillUpperCorner     true
 ScrollPane.font                [active] $defaultFont [UI]
 ScrollPane.foreground          #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
@@ -1118,7 +1119,7 @@ Table.foreground               #bbbbbb  HSL   0   0  73    javax.swing.plaf.Colo
 Table.gridColor                #5a5e60  HSL 200   3  36    javax.swing.plaf.ColorUIResource [UI]
 Table.intercellSpacing         0,0    javax.swing.plaf.DimensionUIResource [UI]
 Table.rowHeight                20
-Table.scrollPaneBorder         [lazy] 1,1,1,1  false    com.formdev.flatlaf.ui.FlatBorder [UI]
+Table.scrollPaneBorder         [lazy] 1,1,1,1  false    com.formdev.flatlaf.ui.FlatScrollPaneBorder [UI]
 Table.selectionBackground      #4b6eaf  HSL 219  40  49    javax.swing.plaf.ColorUIResource [UI]
 Table.selectionForeground      #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
 Table.selectionInactiveBackground #0f2a3d  HSL 205  61  15    javax.swing.plaf.ColorUIResource [UI]

--- a/flatlaf-testing/dumps/uidefaults/FlatIntelliJLaf_1.8.0.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatIntelliJLaf_1.8.0.txt
@@ -107,8 +107,8 @@
 
 #---- ScrollPane ----
 
-- ScrollPane.border              [lazy] 1,1,1,1  false    com.formdev.flatlaf.ui.FlatBorder [UI]
-+ ScrollPane.border              [lazy] 3,3,3,3  false    com.formdev.flatlaf.ui.FlatBorder [UI]
+- ScrollPane.border              [lazy] 1,1,1,1  false    com.formdev.flatlaf.ui.FlatScrollPaneBorder [UI]
++ ScrollPane.border              [lazy] 3,3,3,3  false    com.formdev.flatlaf.ui.FlatScrollPaneBorder [UI]
 
 
 #---- Spinner ----
@@ -119,8 +119,8 @@
 
 #---- Table ----
 
-- Table.scrollPaneBorder         [lazy] 1,1,1,1  false    com.formdev.flatlaf.ui.FlatBorder [UI]
-+ Table.scrollPaneBorder         [lazy] 3,3,3,3  false    com.formdev.flatlaf.ui.FlatBorder [UI]
+- Table.scrollPaneBorder         [lazy] 1,1,1,1  false    com.formdev.flatlaf.ui.FlatScrollPaneBorder [UI]
++ Table.scrollPaneBorder         [lazy] 3,3,3,3  false    com.formdev.flatlaf.ui.FlatScrollPaneBorder [UI]
 
 
 #---- TextField ----

--- a/flatlaf-testing/dumps/uidefaults/FlatLightLaf_1.8.0.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatLightLaf_1.8.0.txt
@@ -911,8 +911,9 @@ ScrollBarUI                    com.formdev.flatlaf.ui.FlatScrollBarUI
 
 #---- ScrollPane ----
 
+ScrollPane.arc                 0
 ScrollPane.background          #f5f5f5  HSL   0   0  96    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(1%)
-ScrollPane.border              [lazy] 1,1,1,1  false    com.formdev.flatlaf.ui.FlatBorder [UI]
+ScrollPane.border              [lazy] 1,1,1,1  false    com.formdev.flatlaf.ui.FlatScrollPaneBorder [UI]
 ScrollPane.fillUpperCorner     true
 ScrollPane.font                [active] $defaultFont [UI]
 ScrollPane.foreground          #000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]
@@ -1123,7 +1124,7 @@ Table.foreground               #000000  HSL   0   0   0    javax.swing.plaf.Colo
 Table.gridColor                #ebebeb  HSL   0   0  92    javax.swing.plaf.ColorUIResource [UI]
 Table.intercellSpacing         0,0    javax.swing.plaf.DimensionUIResource [UI]
 Table.rowHeight                20
-Table.scrollPaneBorder         [lazy] 1,1,1,1  false    com.formdev.flatlaf.ui.FlatBorder [UI]
+Table.scrollPaneBorder         [lazy] 1,1,1,1  false    com.formdev.flatlaf.ui.FlatScrollPaneBorder [UI]
 Table.selectionBackground      #2675bf  HSL 209  67  45    javax.swing.plaf.ColorUIResource [UI]
 Table.selectionForeground      #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
 Table.selectionInactiveBackground #d3d3d3  HSL   0   0  83    javax.swing.plaf.ColorUIResource [UI]

--- a/flatlaf-testing/dumps/uidefaults/FlatMacDarkLaf_1.8.0.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatMacDarkLaf_1.8.0.txt
@@ -915,8 +915,9 @@ ScrollBarUI                    com.formdev.flatlaf.ui.FlatScrollBarUI
 
 #---- ScrollPane ----
 
+ScrollPane.arc                 0
 ScrollPane.background          #282828  HSL   0   0  16    javax.swing.plaf.ColorUIResource [UI]
-ScrollPane.border              [lazy] 3,3,3,3  false    com.formdev.flatlaf.ui.FlatBorder [UI]
+ScrollPane.border              [lazy] 3,3,3,3  false    com.formdev.flatlaf.ui.FlatScrollPaneBorder [UI]
 ScrollPane.fillUpperCorner     true
 ScrollPane.font                [active] $defaultFont [UI]
 ScrollPane.foreground          #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
@@ -1128,7 +1129,7 @@ Table.foreground               #dddddd  HSL   0   0  87    javax.swing.plaf.Colo
 Table.gridColor                #3c3c3c  HSL   0   0  24    javax.swing.plaf.ColorUIResource [UI]
 Table.intercellSpacing         0,0    javax.swing.plaf.DimensionUIResource [UI]
 Table.rowHeight                20
-Table.scrollPaneBorder         [lazy] 3,3,3,3  false    com.formdev.flatlaf.ui.FlatBorder [UI]
+Table.scrollPaneBorder         [lazy] 3,3,3,3  false    com.formdev.flatlaf.ui.FlatScrollPaneBorder [UI]
 Table.selectionBackground      #0054cc  HSL 215 100  40    javax.swing.plaf.ColorUIResource [UI]
 Table.selectionForeground      #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
 Table.selectionInactiveBackground #464646  HSL   0   0  27    javax.swing.plaf.ColorUIResource [UI]

--- a/flatlaf-testing/dumps/uidefaults/FlatMacLightLaf_1.8.0.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatMacLightLaf_1.8.0.txt
@@ -919,8 +919,9 @@ ScrollBarUI                    com.formdev.flatlaf.ui.FlatScrollBarUI
 
 #---- ScrollPane ----
 
+ScrollPane.arc                 0
 ScrollPane.background          #fafafa  HSL   0   0  98    javax.swing.plaf.ColorUIResource [UI]
-ScrollPane.border              [lazy] 3,3,3,3  false    com.formdev.flatlaf.ui.FlatBorder [UI]
+ScrollPane.border              [lazy] 3,3,3,3  false    com.formdev.flatlaf.ui.FlatScrollPaneBorder [UI]
 ScrollPane.fillUpperCorner     true
 ScrollPane.font                [active] $defaultFont [UI]
 ScrollPane.foreground          #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
@@ -1132,7 +1133,7 @@ Table.foreground               #262626  HSL   0   0  15    javax.swing.plaf.Colo
 Table.gridColor                #ebebeb  HSL   0   0  92    javax.swing.plaf.ColorUIResource [UI]
 Table.intercellSpacing         0,0    javax.swing.plaf.DimensionUIResource [UI]
 Table.rowHeight                20
-Table.scrollPaneBorder         [lazy] 3,3,3,3  false    com.formdev.flatlaf.ui.FlatBorder [UI]
+Table.scrollPaneBorder         [lazy] 3,3,3,3  false    com.formdev.flatlaf.ui.FlatScrollPaneBorder [UI]
 Table.selectionBackground      #005fe6  HSL 215 100  45    javax.swing.plaf.ColorUIResource [UI]
 Table.selectionForeground      #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
 Table.selectionInactiveBackground #dcdcdc  HSL   0   0  86    javax.swing.plaf.ColorUIResource [UI]

--- a/flatlaf-testing/dumps/uidefaults/FlatTestLaf_1.8.0.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatTestLaf_1.8.0.txt
@@ -934,7 +934,7 @@ ScrollBarUI                    com.formdev.flatlaf.ui.FlatScrollBarUI
 
 ScrollPane.arc                 20
 ScrollPane.background          #88ff88  HSL 120 100  77    javax.swing.plaf.ColorUIResource [UI]
-ScrollPane.border              [lazy] 1,10,1,10  false    com.formdev.flatlaf.ui.FlatScrollPaneBorder [UI]
+ScrollPane.border              [lazy] 1,9,1,9  false    com.formdev.flatlaf.ui.FlatScrollPaneBorder [UI]
 ScrollPane.fillUpperCorner     true
 ScrollPane.font                [active] $defaultFont [UI]
 ScrollPane.foreground          #ff0000  HSL   0 100  50    javax.swing.plaf.ColorUIResource [UI]
@@ -1155,7 +1155,7 @@ Table.foreground               #ff0000  HSL   0 100  50    javax.swing.plaf.Colo
 Table.gridColor                #00ffff  HSL 180 100  50    javax.swing.plaf.ColorUIResource [UI]
 Table.intercellSpacing         0,0    javax.swing.plaf.DimensionUIResource [UI]
 Table.rowHeight                25
-Table.scrollPaneBorder         [lazy] 1,10,1,10  false    com.formdev.flatlaf.ui.FlatScrollPaneBorder [UI]
+Table.scrollPaneBorder         [lazy] 1,9,1,9  false    com.formdev.flatlaf.ui.FlatScrollPaneBorder [UI]
 Table.selectionBackground      #00aa00  HSL 120 100  33    javax.swing.plaf.ColorUIResource [UI]
 Table.selectionForeground      #ffff00  HSL  60 100  50    javax.swing.plaf.ColorUIResource [UI]
 Table.selectionInactiveBackground #888888  HSL   0   0  53    javax.swing.plaf.ColorUIResource [UI]

--- a/flatlaf-testing/dumps/uidefaults/FlatTestLaf_1.8.0.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatTestLaf_1.8.0.txt
@@ -932,8 +932,9 @@ ScrollBarUI                    com.formdev.flatlaf.ui.FlatScrollBarUI
 
 #---- ScrollPane ----
 
+ScrollPane.arc                 20
 ScrollPane.background          #88ff88  HSL 120 100  77    javax.swing.plaf.ColorUIResource [UI]
-ScrollPane.border              [lazy] 1,1,1,1  false    com.formdev.flatlaf.ui.FlatBorder [UI]
+ScrollPane.border              [lazy] 1,10,1,10  false    com.formdev.flatlaf.ui.FlatScrollPaneBorder [UI]
 ScrollPane.fillUpperCorner     true
 ScrollPane.font                [active] $defaultFont [UI]
 ScrollPane.foreground          #ff0000  HSL   0 100  50    javax.swing.plaf.ColorUIResource [UI]
@@ -1154,7 +1155,7 @@ Table.foreground               #ff0000  HSL   0 100  50    javax.swing.plaf.Colo
 Table.gridColor                #00ffff  HSL 180 100  50    javax.swing.plaf.ColorUIResource [UI]
 Table.intercellSpacing         0,0    javax.swing.plaf.DimensionUIResource [UI]
 Table.rowHeight                25
-Table.scrollPaneBorder         [lazy] 1,1,1,1  false    com.formdev.flatlaf.ui.FlatBorder [UI]
+Table.scrollPaneBorder         [lazy] 1,10,1,10  false    com.formdev.flatlaf.ui.FlatScrollPaneBorder [UI]
 Table.selectionBackground      #00aa00  HSL 120 100  33    javax.swing.plaf.ColorUIResource [UI]
 Table.selectionForeground      #ffff00  HSL  60 100  50    javax.swing.plaf.ColorUIResource [UI]
 Table.selectionInactiveBackground #888888  HSL   0   0  53    javax.swing.plaf.ColorUIResource [UI]

--- a/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatRoundedScrollPaneTest.java
+++ b/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatRoundedScrollPaneTest.java
@@ -23,9 +23,11 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 import javax.swing.*;
+import javax.swing.border.Border;
 import javax.swing.table.AbstractTableModel;
 import javax.swing.tree.*;
 import com.formdev.flatlaf.FlatClientProperties;
+import com.formdev.flatlaf.ui.FlatScrollPaneBorder;
 import com.formdev.flatlaf.util.UIScale;
 import net.miginfocom.swing.*;
 
@@ -203,6 +205,11 @@ public class FlatRoundedScrollPaneTest
 		int arc = arcSlider.getValue();
 		for( JScrollPane scrollPane : allJScrollPanes )
 			scrollPane.putClientProperty( FlatClientProperties.STYLE, "arc: " + arc );
+
+		Border border = allJScrollPanes[0].getBorder();
+		paddingField.setText( border instanceof FlatScrollPaneBorder
+			? Integer.toString( ((FlatScrollPaneBorder)border).getLeftRightPadding( allJScrollPanes[0] ) )
+			: "?" );
 	}
 
 	private void initComponents() {
@@ -210,6 +217,8 @@ public class FlatRoundedScrollPaneTest
 		splitPane2 = new JSplitPane();
 		panel1 = new FlatTestPanel();
 		listLabel = new JLabel();
+		paddingLabel = new JLabel();
+		paddingField = new JLabel();
 		treeLabel = new JLabel();
 		tableLabel = new JLabel();
 		autoResizeModeCheckBox = new JCheckBox();
@@ -237,8 +246,8 @@ public class FlatRoundedScrollPaneTest
 		arcSlider = new JSlider();
 		cornersCheckBox = new JCheckBox();
 		columnHeaderCheckBox = new JCheckBox();
-		rowHeaderCheckBox = new JCheckBox();
 		horizontalScrollBarCheckBox = new JCheckBox();
+		rowHeaderCheckBox = new JCheckBox();
 		verticalScrollBarCheckBox = new JCheckBox();
 
 		//======== this ========
@@ -272,6 +281,14 @@ public class FlatRoundedScrollPaneTest
 				listLabel.setText("JList:");
 				listLabel.setHorizontalTextPosition(SwingConstants.LEADING);
 				panel1.add(listLabel, "cell 0 0,aligny top,growy 0");
+
+				//---- paddingLabel ----
+				paddingLabel.setText("Padding:");
+				panel1.add(paddingLabel, "cell 0 0,alignx trailing,growx 0");
+
+				//---- paddingField ----
+				paddingField.setText("0");
+				panel1.add(paddingField, "cell 0 0,alignx trailing,growx 0");
 
 				//---- treeLabel ----
 				treeLabel.setText("JTree:");
@@ -382,12 +399,11 @@ public class FlatRoundedScrollPaneTest
 				// columns
 				"[fill]" +
 				"[grow,fill]para" +
-				"[fill]" +
-				"[fill]" +
-				"[fill]" +
-				"[fill]" +
-				"[fill]",
+				"[]" +
+				"[]" +
+				"[]",
 				// rows
+				"[]" +
 				"[]"));
 
 			//---- arcLabel ----
@@ -403,7 +419,7 @@ public class FlatRoundedScrollPaneTest
 			arcSlider.setPaintTicks(true);
 			arcSlider.setPaintLabels(true);
 			arcSlider.addChangeListener(e -> arcSliderChanged());
-			panel3.add(arcSlider, "cell 1 0");
+			panel3.add(arcSlider, "cell 1 0 1 2");
 
 			//---- cornersCheckBox ----
 			cornersCheckBox.setText("Corners");
@@ -415,22 +431,22 @@ public class FlatRoundedScrollPaneTest
 			columnHeaderCheckBox.addActionListener(e -> columnHeaderChanged());
 			panel3.add(columnHeaderCheckBox, "cell 3 0");
 
-			//---- rowHeaderCheckBox ----
-			rowHeaderCheckBox.setText("Row Header");
-			rowHeaderCheckBox.addActionListener(e -> rowHeaderChanged());
-			panel3.add(rowHeaderCheckBox, "cell 4 0");
-
 			//---- horizontalScrollBarCheckBox ----
 			horizontalScrollBarCheckBox.setText("Horizontal ScrollBar");
 			horizontalScrollBarCheckBox.setSelected(true);
 			horizontalScrollBarCheckBox.addActionListener(e -> horizontalScrollBarChanged());
-			panel3.add(horizontalScrollBarCheckBox, "cell 5 0");
+			panel3.add(horizontalScrollBarCheckBox, "cell 4 0");
+
+			//---- rowHeaderCheckBox ----
+			rowHeaderCheckBox.setText("Row Header");
+			rowHeaderCheckBox.addActionListener(e -> rowHeaderChanged());
+			panel3.add(rowHeaderCheckBox, "cell 3 1");
 
 			//---- verticalScrollBarCheckBox ----
 			verticalScrollBarCheckBox.setText("Vertical ScrollBar");
 			verticalScrollBarCheckBox.setSelected(true);
 			verticalScrollBarCheckBox.addActionListener(e -> verticalScrollBarChanged());
-			panel3.add(verticalScrollBarCheckBox, "cell 6 0");
+			panel3.add(verticalScrollBarCheckBox, "cell 4 1");
 		}
 		add(panel3, "cell 0 1");
 		// JFormDesigner - End of component initialization  //GEN-END:initComponents
@@ -440,6 +456,8 @@ public class FlatRoundedScrollPaneTest
 	private JSplitPane splitPane2;
 	private FlatTestPanel panel1;
 	private JLabel listLabel;
+	private JLabel paddingLabel;
+	private JLabel paddingField;
 	private JLabel treeLabel;
 	private JLabel tableLabel;
 	private JCheckBox autoResizeModeCheckBox;
@@ -466,8 +484,8 @@ public class FlatRoundedScrollPaneTest
 	private JSlider arcSlider;
 	private JCheckBox cornersCheckBox;
 	private JCheckBox columnHeaderCheckBox;
-	private JCheckBox rowHeaderCheckBox;
 	private JCheckBox horizontalScrollBarCheckBox;
+	private JCheckBox rowHeaderCheckBox;
 	private JCheckBox verticalScrollBarCheckBox;
 	// JFormDesigner - End of variables declaration  //GEN-END:variables
 

--- a/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatRoundedScrollPaneTest.java
+++ b/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatRoundedScrollPaneTest.java
@@ -1,0 +1,488 @@
+/*
+ * Copyright 2023 FormDev Software GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.formdev.flatlaf.testing;
+
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+import javax.swing.*;
+import javax.swing.table.AbstractTableModel;
+import javax.swing.tree.*;
+import com.formdev.flatlaf.FlatClientProperties;
+import com.formdev.flatlaf.util.UIScale;
+import net.miginfocom.swing.*;
+
+/**
+ * @author Karl Tauber
+ */
+public class FlatRoundedScrollPaneTest
+	extends FlatTestPanel
+{
+	private JScrollPane[] allJScrollPanes;
+
+	public static void main( String[] args ) {
+		SwingUtilities.invokeLater( () -> {
+			FlatTestFrame frame = FlatTestFrame.create( args, "FlatRoundedScrollPaneTest" );
+			frame.useApplyComponentOrientation = true;
+			frame.showFrame( FlatRoundedScrollPaneTest::new );
+		} );
+	}
+
+	FlatRoundedScrollPaneTest() {
+		initComponents();
+
+		allJScrollPanes = new JScrollPane[] {
+			listScrollPane, treeScrollPane, tableScrollPane,
+			textAreaScrollPane, textPaneScrollPane, editorPaneScrollPane, customScrollPane
+		};
+
+		ArrayList<String> items = new ArrayList<>();
+		for( char ch = '0'; ch < 'z'; ch++ ) {
+			if( (ch > '9' && ch < 'A') || (ch > 'Z' && ch < 'a') )
+				continue;
+
+			char[] chars = new char[ch - '0' + 1];
+			Arrays.fill( chars, ch );
+			items.add( new String( chars ) );
+		}
+
+		// list model
+		list.setModel( new AbstractListModel<String>() {
+			@Override
+			public int getSize() {
+				return items.size();
+			}
+			@Override
+			public String getElementAt( int index ) {
+				return items.get( index );
+			}
+		} );
+
+		// tree model
+		DefaultMutableTreeNode root = new DefaultMutableTreeNode( items.get( 0 ) );
+		DefaultMutableTreeNode last = null;
+		for( int i = 1; i < items.size(); i++ ) {
+			DefaultMutableTreeNode node = new DefaultMutableTreeNode( items.get( i ) );
+			if( i % 5 == 1 ) {
+				root.add( node );
+				last = node;
+			} else
+				last.add( node );
+		}
+		tree.setModel( new DefaultTreeModel( root ) );
+		for( int row = tree.getRowCount() - 1; row >= 0; row-- )
+			tree.expandRow( row );
+
+		// table model
+		table.setModel( new AbstractTableModel() {
+			@Override
+			public int getRowCount() {
+				return items.size();
+			}
+			@Override
+			public int getColumnCount() {
+				return 4;
+			}
+			@Override
+			public Object getValueAt( int rowIndex, int columnIndex ) {
+				if( columnIndex > 0 )
+					rowIndex = (items.size() + rowIndex - ((items.size() / 4) * columnIndex)) % items.size();
+				return items.get( rowIndex );
+			}
+		} );
+
+		// select some rows to better see smooth scrolling issues
+		for( int i = 5; i < items.size(); i += 10 ) {
+			list.addSelectionInterval( i, i );
+			tree.addSelectionInterval( i, i );
+			table.addRowSelectionInterval( i, i );
+		}
+
+		// text components
+		String longText = items.stream().collect( Collectors.joining( " " ) ) + ' '
+			+ items.stream().limit( 20 ).collect( Collectors.joining( " " ) );
+		String text = items.stream().collect( Collectors.joining( "\n" ) ) + '\n';
+		textArea.setText( longText + '\n' + text );
+		textPane.setText( text );
+		editorPane.setText( text );
+
+		textArea.select( 0, 0 );
+		textPane.select( 0, 0 );
+		editorPane.select( 0, 0 );
+
+		arcSliderChanged();
+
+		EventQueue.invokeLater( () -> {
+			EventQueue.invokeLater( () -> {
+				list.requestFocusInWindow();
+			} );
+		} );
+	}
+
+	private void autoResizeModeChanged() {
+		table.setAutoResizeMode( autoResizeModeCheckBox.isSelected() ? JTable.AUTO_RESIZE_SUBSEQUENT_COLUMNS : JTable.AUTO_RESIZE_OFF );
+	}
+
+	private void cornersChanged() {
+		boolean sel = cornersCheckBox.isSelected();
+		for( JScrollPane scrollPane : allJScrollPanes ) {
+			scrollPane.setCorner( JScrollPane.UPPER_LEADING_CORNER, sel ? new Corner( Color.magenta ) : null );
+			scrollPane.setCorner( JScrollPane.UPPER_TRAILING_CORNER, sel ? new Corner( Color.red ) : null );
+			scrollPane.setCorner( JScrollPane.LOWER_LEADING_CORNER, sel ? new Corner( Color.cyan ) : null );
+			scrollPane.setCorner( JScrollPane.LOWER_TRAILING_CORNER, sel ? new Corner( Color.pink ) : null );
+		}
+	}
+
+	private void columnHeaderChanged() {
+		boolean sel = columnHeaderCheckBox.isSelected();
+		for( JScrollPane scrollPane : allJScrollPanes ) {
+			if( scrollPane == tableScrollPane )
+				continue;
+
+			JViewport header = null;
+			if( sel ) {
+				header = new JViewport();
+				Corner view = new Corner( Color.cyan );
+				view.setPreferredSize( new Dimension( 0, UIScale.scale( 20 ) ) );
+				header.setView( view );
+			}
+			scrollPane.setColumnHeader( header );
+		}
+	}
+
+	private void rowHeaderChanged() {
+		boolean sel = rowHeaderCheckBox.isSelected();
+		for( JScrollPane scrollPane : allJScrollPanes ) {
+			JViewport header = null;
+			if( sel ) {
+				header = new JViewport();
+				Corner view = new Corner( Color.yellow );
+				view.setPreferredSize( new Dimension( UIScale.scale( 20 ), 0 ) );
+				header.setView( view );
+			}
+			scrollPane.setRowHeader( header );
+		}
+	}
+
+	private void horizontalScrollBarChanged() {
+		int policy = horizontalScrollBarCheckBox.isSelected()
+			? JScrollPane.HORIZONTAL_SCROLLBAR_AS_NEEDED
+			: JScrollPane.HORIZONTAL_SCROLLBAR_NEVER;
+
+		for( JScrollPane scrollPane : allJScrollPanes )
+			scrollPane.setHorizontalScrollBarPolicy( policy );
+	}
+
+	private void verticalScrollBarChanged() {
+		int policy = verticalScrollBarCheckBox.isSelected()
+			? JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED
+			: JScrollPane.VERTICAL_SCROLLBAR_NEVER;
+
+		for( JScrollPane scrollPane : allJScrollPanes )
+			scrollPane.setVerticalScrollBarPolicy( policy );
+	}
+
+	private void arcSliderChanged() {
+		int arc = arcSlider.getValue();
+		for( JScrollPane scrollPane : allJScrollPanes )
+			scrollPane.putClientProperty( FlatClientProperties.STYLE, "arc: " + arc );
+	}
+
+	private void initComponents() {
+		// JFormDesigner - Component initialization - DO NOT MODIFY  //GEN-BEGIN:initComponents
+		splitPane2 = new JSplitPane();
+		panel1 = new FlatTestPanel();
+		listLabel = new JLabel();
+		treeLabel = new JLabel();
+		tableLabel = new JLabel();
+		autoResizeModeCheckBox = new JCheckBox();
+		listScrollPane = new JScrollPane();
+		list = new JList<>();
+		treeScrollPane = new JScrollPane();
+		tree = new JTree();
+		tableScrollPane = new JScrollPane();
+		table = new JTable();
+		panel2 = new FlatTestPanel();
+		textAreaLabel = new JLabel();
+		textPaneLabel = new JLabel();
+		editorPaneLabel = new JLabel();
+		customLabel = new JLabel();
+		textAreaScrollPane = new JScrollPane();
+		textArea = new JTextArea();
+		textPaneScrollPane = new JScrollPane();
+		textPane = new JTextPane();
+		editorPaneScrollPane = new JScrollPane();
+		editorPane = new JEditorPane();
+		customScrollPane = new JScrollPane();
+		button1 = new JButton();
+		panel3 = new JPanel();
+		JLabel arcLabel = new JLabel();
+		arcSlider = new JSlider();
+		cornersCheckBox = new JCheckBox();
+		columnHeaderCheckBox = new JCheckBox();
+		rowHeaderCheckBox = new JCheckBox();
+		horizontalScrollBarCheckBox = new JCheckBox();
+		verticalScrollBarCheckBox = new JCheckBox();
+
+		//======== this ========
+		setLayout(new MigLayout(
+			"ltr,insets dialog,hidemode 3",
+			// columns
+			"[200,grow,fill]",
+			// rows
+			"[grow,fill]" +
+			"[]"));
+
+		//======== splitPane2 ========
+		{
+			splitPane2.setOrientation(JSplitPane.VERTICAL_SPLIT);
+			splitPane2.setResizeWeight(0.5);
+
+			//======== panel1 ========
+			{
+				panel1.setLayout(new MigLayout(
+					"ltr,insets 3,hidemode 3",
+					// columns
+					"[200,grow,fill]" +
+					"[200,grow,fill]" +
+					"[200,grow,fill]" +
+					"[200,grow,fill]",
+					// rows
+					"[]0" +
+					"[200,grow,fill]"));
+
+				//---- listLabel ----
+				listLabel.setText("JList:");
+				listLabel.setHorizontalTextPosition(SwingConstants.LEADING);
+				panel1.add(listLabel, "cell 0 0,aligny top,growy 0");
+
+				//---- treeLabel ----
+				treeLabel.setText("JTree:");
+				treeLabel.setHorizontalTextPosition(SwingConstants.LEADING);
+				panel1.add(treeLabel, "cell 1 0");
+
+				//---- tableLabel ----
+				tableLabel.setText("JTable:");
+				tableLabel.setHorizontalTextPosition(SwingConstants.LEADING);
+				panel1.add(tableLabel, "cell 2 0 2 1");
+
+				//---- autoResizeModeCheckBox ----
+				autoResizeModeCheckBox.setText("Auto-resize mode");
+				autoResizeModeCheckBox.setSelected(true);
+				autoResizeModeCheckBox.addActionListener(e -> autoResizeModeChanged());
+				panel1.add(autoResizeModeCheckBox, "cell 2 0 2 1,alignx right,growx 0");
+
+				//======== listScrollPane ========
+				{
+					listScrollPane.setViewportView(list);
+				}
+				panel1.add(listScrollPane, "cell 0 1,growx");
+
+				//======== treeScrollPane ========
+				{
+					treeScrollPane.setViewportView(tree);
+				}
+				panel1.add(treeScrollPane, "cell 1 1");
+
+				//======== tableScrollPane ========
+				{
+					tableScrollPane.setViewportView(table);
+				}
+				panel1.add(tableScrollPane, "cell 2 1 2 1,width 100,height 100");
+			}
+			splitPane2.setTopComponent(panel1);
+
+			//======== panel2 ========
+			{
+				panel2.setLayout(new MigLayout(
+					"ltr,insets 3,hidemode 3",
+					// columns
+					"[200,grow,fill]" +
+					"[200,grow,fill]" +
+					"[200,grow,fill]" +
+					"[200,grow,fill]",
+					// rows
+					"[]0" +
+					"[200,grow,fill]"));
+
+				//---- textAreaLabel ----
+				textAreaLabel.setText("JTextArea:");
+				textAreaLabel.setHorizontalTextPosition(SwingConstants.LEADING);
+				panel2.add(textAreaLabel, "cell 0 0");
+
+				//---- textPaneLabel ----
+				textPaneLabel.setText("JTextPane:");
+				textPaneLabel.setHorizontalTextPosition(SwingConstants.LEADING);
+				panel2.add(textPaneLabel, "cell 1 0");
+
+				//---- editorPaneLabel ----
+				editorPaneLabel.setText("JEditorPane:");
+				editorPaneLabel.setHorizontalTextPosition(SwingConstants.LEADING);
+				panel2.add(editorPaneLabel, "cell 2 0");
+
+				//---- customLabel ----
+				customLabel.setText("Custom:");
+				panel2.add(customLabel, "cell 3 0");
+
+				//======== textAreaScrollPane ========
+				{
+					textAreaScrollPane.setViewportView(textArea);
+				}
+				panel2.add(textAreaScrollPane, "cell 0 1");
+
+				//======== textPaneScrollPane ========
+				{
+					textPaneScrollPane.setViewportView(textPane);
+				}
+				panel2.add(textPaneScrollPane, "cell 1 1");
+
+				//======== editorPaneScrollPane ========
+				{
+					editorPaneScrollPane.setViewportView(editorPane);
+				}
+				panel2.add(editorPaneScrollPane, "cell 2 1");
+
+				//======== customScrollPane ========
+				{
+
+					//---- button1 ----
+					button1.setText("I'm a large button, but do not implement Scrollable interface");
+					button1.setPreferredSize(new Dimension(800, 800));
+					button1.setHorizontalAlignment(SwingConstants.LEADING);
+					button1.setVerticalAlignment(SwingConstants.TOP);
+					customScrollPane.setViewportView(button1);
+				}
+				panel2.add(customScrollPane, "cell 3 1");
+			}
+			splitPane2.setBottomComponent(panel2);
+		}
+		add(splitPane2, "cell 0 0");
+
+		//======== panel3 ========
+		{
+			panel3.setLayout(new MigLayout(
+				"hidemode 3",
+				// columns
+				"[fill]" +
+				"[grow,fill]para" +
+				"[fill]" +
+				"[fill]" +
+				"[fill]" +
+				"[fill]" +
+				"[fill]",
+				// rows
+				"[]"));
+
+			//---- arcLabel ----
+			arcLabel.setText("Arc:");
+			panel3.add(arcLabel, "cell 0 0");
+
+			//---- arcSlider ----
+			arcSlider.setMaximum(40);
+			arcSlider.setValue(20);
+			arcSlider.setSnapToTicks(true);
+			arcSlider.setMajorTickSpacing(10);
+			arcSlider.setMinorTickSpacing(1);
+			arcSlider.setPaintTicks(true);
+			arcSlider.setPaintLabels(true);
+			arcSlider.addChangeListener(e -> arcSliderChanged());
+			panel3.add(arcSlider, "cell 1 0");
+
+			//---- cornersCheckBox ----
+			cornersCheckBox.setText("Corners");
+			cornersCheckBox.addActionListener(e -> cornersChanged());
+			panel3.add(cornersCheckBox, "cell 2 0");
+
+			//---- columnHeaderCheckBox ----
+			columnHeaderCheckBox.setText("Column Header");
+			columnHeaderCheckBox.addActionListener(e -> columnHeaderChanged());
+			panel3.add(columnHeaderCheckBox, "cell 3 0");
+
+			//---- rowHeaderCheckBox ----
+			rowHeaderCheckBox.setText("Row Header");
+			rowHeaderCheckBox.addActionListener(e -> rowHeaderChanged());
+			panel3.add(rowHeaderCheckBox, "cell 4 0");
+
+			//---- horizontalScrollBarCheckBox ----
+			horizontalScrollBarCheckBox.setText("Horizontal ScrollBar");
+			horizontalScrollBarCheckBox.setSelected(true);
+			horizontalScrollBarCheckBox.addActionListener(e -> horizontalScrollBarChanged());
+			panel3.add(horizontalScrollBarCheckBox, "cell 5 0");
+
+			//---- verticalScrollBarCheckBox ----
+			verticalScrollBarCheckBox.setText("Vertical ScrollBar");
+			verticalScrollBarCheckBox.setSelected(true);
+			verticalScrollBarCheckBox.addActionListener(e -> verticalScrollBarChanged());
+			panel3.add(verticalScrollBarCheckBox, "cell 6 0");
+		}
+		add(panel3, "cell 0 1");
+		// JFormDesigner - End of component initialization  //GEN-END:initComponents
+	}
+
+	// JFormDesigner - Variables declaration - DO NOT MODIFY  //GEN-BEGIN:variables
+	private JSplitPane splitPane2;
+	private FlatTestPanel panel1;
+	private JLabel listLabel;
+	private JLabel treeLabel;
+	private JLabel tableLabel;
+	private JCheckBox autoResizeModeCheckBox;
+	private JScrollPane listScrollPane;
+	private JList<String> list;
+	private JScrollPane treeScrollPane;
+	private JTree tree;
+	private JScrollPane tableScrollPane;
+	private JTable table;
+	private FlatTestPanel panel2;
+	private JLabel textAreaLabel;
+	private JLabel textPaneLabel;
+	private JLabel editorPaneLabel;
+	private JLabel customLabel;
+	private JScrollPane textAreaScrollPane;
+	private JTextArea textArea;
+	private JScrollPane textPaneScrollPane;
+	private JTextPane textPane;
+	private JScrollPane editorPaneScrollPane;
+	private JEditorPane editorPane;
+	private JScrollPane customScrollPane;
+	private JButton button1;
+	private JPanel panel3;
+	private JSlider arcSlider;
+	private JCheckBox cornersCheckBox;
+	private JCheckBox columnHeaderCheckBox;
+	private JCheckBox rowHeaderCheckBox;
+	private JCheckBox horizontalScrollBarCheckBox;
+	private JCheckBox verticalScrollBarCheckBox;
+	// JFormDesigner - End of variables declaration  //GEN-END:variables
+
+	//---- class Corner -------------------------------------------------------
+
+	private static class Corner
+		extends JPanel
+	{
+		Corner( Color color ) {
+			super.setBackground( color );
+		}
+
+		@Override
+		public void setBackground( Color bg ) {
+			// do not change background when checkbox "explicit colors" is selected
+		}
+	}
+}

--- a/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatRoundedScrollPaneTest.java
+++ b/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatRoundedScrollPaneTest.java
@@ -24,6 +24,8 @@ import java.util.Arrays;
 import java.util.stream.Collectors;
 import javax.swing.*;
 import javax.swing.border.Border;
+import javax.swing.border.CompoundBorder;
+import javax.swing.border.MatteBorder;
 import javax.swing.table.AbstractTableModel;
 import javax.swing.tree.*;
 import com.formdev.flatlaf.FlatClientProperties;
@@ -212,6 +214,19 @@ public class FlatRoundedScrollPaneTest
 			: "?" );
 	}
 
+	private void viewportBorderChanged() {
+		Border viewportBorder = viewportBorderCheckBox.isSelected()
+			? new CompoundBorder(
+				new MatteBorder( 1, 1, 0, 0, Color.red ),
+				new MatteBorder( 0, 0, 1, 1, Color.blue ) )
+			: null;
+		for( JScrollPane scrollPane : allJScrollPanes ) {
+			scrollPane.setViewportBorder( viewportBorder );
+			scrollPane.revalidate();
+			scrollPane.repaint();
+		}
+	}
+
 	private void initComponents() {
 		// JFormDesigner - Component initialization - DO NOT MODIFY  //GEN-BEGIN:initComponents
 		splitPane2 = new JSplitPane();
@@ -247,6 +262,7 @@ public class FlatRoundedScrollPaneTest
 		cornersCheckBox = new JCheckBox();
 		columnHeaderCheckBox = new JCheckBox();
 		horizontalScrollBarCheckBox = new JCheckBox();
+		viewportBorderCheckBox = new JCheckBox();
 		rowHeaderCheckBox = new JCheckBox();
 		verticalScrollBarCheckBox = new JCheckBox();
 
@@ -437,6 +453,11 @@ public class FlatRoundedScrollPaneTest
 			horizontalScrollBarCheckBox.addActionListener(e -> horizontalScrollBarChanged());
 			panel3.add(horizontalScrollBarCheckBox, "cell 4 0");
 
+			//---- viewportBorderCheckBox ----
+			viewportBorderCheckBox.setText("Viewport border");
+			viewportBorderCheckBox.addActionListener(e -> viewportBorderChanged());
+			panel3.add(viewportBorderCheckBox, "cell 2 1");
+
 			//---- rowHeaderCheckBox ----
 			rowHeaderCheckBox.setText("Row Header");
 			rowHeaderCheckBox.addActionListener(e -> rowHeaderChanged());
@@ -485,6 +506,7 @@ public class FlatRoundedScrollPaneTest
 	private JCheckBox cornersCheckBox;
 	private JCheckBox columnHeaderCheckBox;
 	private JCheckBox horizontalScrollBarCheckBox;
+	private JCheckBox viewportBorderCheckBox;
 	private JCheckBox rowHeaderCheckBox;
 	private JCheckBox verticalScrollBarCheckBox;
 	// JFormDesigner - End of variables declaration  //GEN-END:variables

--- a/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatRoundedScrollPaneTest.jfd
+++ b/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatRoundedScrollPaneTest.jfd
@@ -27,6 +27,18 @@ new FormModel {
 						"value": "cell 0 0,aligny top,growy 0"
 					} )
 					add( new FormComponent( "javax.swing.JLabel" ) {
+						name: "paddingLabel"
+						"text": "Padding:"
+					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+						"value": "cell 0 0,alignx trailing,growx 0"
+					} )
+					add( new FormComponent( "javax.swing.JLabel" ) {
+						name: "paddingField"
+						"text": "0"
+					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+						"value": "cell 0 0,alignx trailing,growx 0"
+					} )
+					add( new FormComponent( "javax.swing.JLabel" ) {
 						name: "treeLabel"
 						"text": "JTree:"
 						"horizontalTextPosition": 10
@@ -156,8 +168,8 @@ new FormModel {
 			} )
 			add( new FormContainer( "javax.swing.JPanel", new FormLayoutManager( class net.miginfocom.swing.MigLayout ) {
 				"$layoutConstraints": "hidemode 3"
-				"$columnConstraints": "[fill][grow,fill]para[fill][fill][fill][fill][fill]"
-				"$rowConstraints": "[]"
+				"$columnConstraints": "[fill][grow,fill]para[][][]"
+				"$rowConstraints": "[][]"
 			} ) {
 				name: "panel3"
 				add( new FormComponent( "javax.swing.JLabel" ) {
@@ -180,7 +192,7 @@ new FormModel {
 					"paintLabels": true
 					addEvent( new FormEvent( "javax.swing.event.ChangeListener", "stateChanged", "arcSliderChanged", false ) )
 				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-					"value": "cell 1 0"
+					"value": "cell 1 0 1 2"
 				} )
 				add( new FormComponent( "javax.swing.JCheckBox" ) {
 					name: "cornersCheckBox"
@@ -197,19 +209,19 @@ new FormModel {
 					"value": "cell 3 0"
 				} )
 				add( new FormComponent( "javax.swing.JCheckBox" ) {
-					name: "rowHeaderCheckBox"
-					"text": "Row Header"
-					addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "rowHeaderChanged", false ) )
-				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-					"value": "cell 4 0"
-				} )
-				add( new FormComponent( "javax.swing.JCheckBox" ) {
 					name: "horizontalScrollBarCheckBox"
 					"text": "Horizontal ScrollBar"
 					"selected": true
 					addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "horizontalScrollBarChanged", false ) )
 				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-					"value": "cell 5 0"
+					"value": "cell 4 0"
+				} )
+				add( new FormComponent( "javax.swing.JCheckBox" ) {
+					name: "rowHeaderCheckBox"
+					"text": "Row Header"
+					addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "rowHeaderChanged", false ) )
+				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+					"value": "cell 3 1"
 				} )
 				add( new FormComponent( "javax.swing.JCheckBox" ) {
 					name: "verticalScrollBarCheckBox"
@@ -217,7 +229,7 @@ new FormModel {
 					"selected": true
 					addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "verticalScrollBarChanged", false ) )
 				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-					"value": "cell 6 0"
+					"value": "cell 4 1"
 				} )
 			}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
 				"value": "cell 0 1"

--- a/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatRoundedScrollPaneTest.jfd
+++ b/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatRoundedScrollPaneTest.jfd
@@ -1,4 +1,4 @@
-JFDML JFormDesigner: "8.1.0.0.283" Java: "19.0.2" encoding: "UTF-8"
+JFDML JFormDesigner: "8.1.1.0.298" Java: "19.0.2" encoding: "UTF-8"
 
 new FormModel {
 	contentType: "form/swing"
@@ -215,6 +215,13 @@ new FormModel {
 					addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "horizontalScrollBarChanged", false ) )
 				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
 					"value": "cell 4 0"
+				} )
+				add( new FormComponent( "javax.swing.JCheckBox" ) {
+					name: "viewportBorderCheckBox"
+					"text": "Viewport border"
+					addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "viewportBorderChanged", false ) )
+				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+					"value": "cell 2 1"
 				} )
 				add( new FormComponent( "javax.swing.JCheckBox" ) {
 					name: "rowHeaderCheckBox"

--- a/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatRoundedScrollPaneTest.jfd
+++ b/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatRoundedScrollPaneTest.jfd
@@ -1,0 +1,230 @@
+JFDML JFormDesigner: "8.1.0.0.283" Java: "19.0.2" encoding: "UTF-8"
+
+new FormModel {
+	contentType: "form/swing"
+	root: new FormRoot {
+		add( new FormContainer( "com.formdev.flatlaf.testing.FlatTestPanel", new FormLayoutManager( class net.miginfocom.swing.MigLayout ) {
+			"$layoutConstraints": "ltr,insets dialog,hidemode 3"
+			"$columnConstraints": "[200,grow,fill]"
+			"$rowConstraints": "[grow,fill][]"
+		} ) {
+			name: "this"
+			add( new FormContainer( "javax.swing.JSplitPane", new FormLayoutManager( class javax.swing.JSplitPane ) ) {
+				name: "splitPane2"
+				"orientation": 0
+				"resizeWeight": 0.5
+				add( new FormContainer( "com.formdev.flatlaf.testing.FlatTestPanel", new FormLayoutManager( class net.miginfocom.swing.MigLayout ) {
+					"$columnConstraints": "[200,grow,fill][200,grow,fill][200,grow,fill][200,grow,fill]"
+					"$rowConstraints": "[]0[200,grow,fill]"
+					"$layoutConstraints": "ltr,insets 3,hidemode 3"
+				} ) {
+					name: "panel1"
+					add( new FormComponent( "javax.swing.JLabel" ) {
+						name: "listLabel"
+						"text": "JList:"
+						"horizontalTextPosition": 10
+					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+						"value": "cell 0 0,aligny top,growy 0"
+					} )
+					add( new FormComponent( "javax.swing.JLabel" ) {
+						name: "treeLabel"
+						"text": "JTree:"
+						"horizontalTextPosition": 10
+					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+						"value": "cell 1 0"
+					} )
+					add( new FormComponent( "javax.swing.JLabel" ) {
+						name: "tableLabel"
+						"text": "JTable:"
+						"horizontalTextPosition": 10
+					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+						"value": "cell 2 0 2 1"
+					} )
+					add( new FormComponent( "javax.swing.JCheckBox" ) {
+						name: "autoResizeModeCheckBox"
+						"text": "Auto-resize mode"
+						"selected": true
+						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "autoResizeModeChanged", false ) )
+					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+						"value": "cell 2 0 2 1,alignx right,growx 0"
+					} )
+					add( new FormContainer( "javax.swing.JScrollPane", new FormLayoutManager( class javax.swing.JScrollPane ) ) {
+						name: "listScrollPane"
+						add( new FormComponent( "javax.swing.JList" ) {
+							name: "list"
+							auxiliary() {
+								"JavaCodeGenerator.typeParameters": "String"
+								"JavaCodeGenerator.variableLocal": false
+							}
+						} )
+					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+						"value": "cell 0 1,growx"
+					} )
+					add( new FormContainer( "javax.swing.JScrollPane", new FormLayoutManager( class javax.swing.JScrollPane ) ) {
+						name: "treeScrollPane"
+						add( new FormComponent( "javax.swing.JTree" ) {
+							name: "tree"
+						} )
+					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+						"value": "cell 1 1"
+					} )
+					add( new FormContainer( "javax.swing.JScrollPane", new FormLayoutManager( class javax.swing.JScrollPane ) ) {
+						name: "tableScrollPane"
+						add( new FormComponent( "javax.swing.JTable" ) {
+							name: "table"
+						} )
+					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+						"value": "cell 2 1 2 1,width 100,height 100"
+					} )
+				}, new FormLayoutConstraints( class java.lang.String ) {
+					"value": "left"
+				} )
+				add( new FormContainer( "com.formdev.flatlaf.testing.FlatTestPanel", new FormLayoutManager( class net.miginfocom.swing.MigLayout ) {
+					"$columnConstraints": "[200,grow,fill][200,grow,fill][200,grow,fill][200,grow,fill]"
+					"$rowConstraints": "[]0[200,grow,fill]"
+					"$layoutConstraints": "ltr,insets 3,hidemode 3"
+				} ) {
+					name: "panel2"
+					add( new FormComponent( "javax.swing.JLabel" ) {
+						name: "textAreaLabel"
+						"text": "JTextArea:"
+						"horizontalTextPosition": 10
+					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+						"value": "cell 0 0"
+					} )
+					add( new FormComponent( "javax.swing.JLabel" ) {
+						name: "textPaneLabel"
+						"text": "JTextPane:"
+						"horizontalTextPosition": 10
+					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+						"value": "cell 1 0"
+					} )
+					add( new FormComponent( "javax.swing.JLabel" ) {
+						name: "editorPaneLabel"
+						"text": "JEditorPane:"
+						"horizontalTextPosition": 10
+					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+						"value": "cell 2 0"
+					} )
+					add( new FormComponent( "javax.swing.JLabel" ) {
+						name: "customLabel"
+						"text": "Custom:"
+					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+						"value": "cell 3 0"
+					} )
+					add( new FormContainer( "javax.swing.JScrollPane", new FormLayoutManager( class javax.swing.JScrollPane ) ) {
+						name: "textAreaScrollPane"
+						add( new FormComponent( "javax.swing.JTextArea" ) {
+							name: "textArea"
+						} )
+					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+						"value": "cell 0 1"
+					} )
+					add( new FormContainer( "javax.swing.JScrollPane", new FormLayoutManager( class javax.swing.JScrollPane ) ) {
+						name: "textPaneScrollPane"
+						add( new FormComponent( "javax.swing.JTextPane" ) {
+							name: "textPane"
+						} )
+					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+						"value": "cell 1 1"
+					} )
+					add( new FormContainer( "javax.swing.JScrollPane", new FormLayoutManager( class javax.swing.JScrollPane ) ) {
+						name: "editorPaneScrollPane"
+						add( new FormComponent( "javax.swing.JEditorPane" ) {
+							name: "editorPane"
+						} )
+					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+						"value": "cell 2 1"
+					} )
+					add( new FormContainer( "javax.swing.JScrollPane", new FormLayoutManager( class javax.swing.JScrollPane ) ) {
+						name: "customScrollPane"
+						add( new FormComponent( "javax.swing.JButton" ) {
+							name: "button1"
+							"text": "I'm a large button, but do not implement Scrollable interface"
+							"preferredSize": new java.awt.Dimension( 800, 800 )
+							"horizontalAlignment": 10
+							"verticalAlignment": 1
+						} )
+					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+						"value": "cell 3 1"
+					} )
+				}, new FormLayoutConstraints( class java.lang.String ) {
+					"value": "right"
+				} )
+			}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+				"value": "cell 0 0"
+			} )
+			add( new FormContainer( "javax.swing.JPanel", new FormLayoutManager( class net.miginfocom.swing.MigLayout ) {
+				"$layoutConstraints": "hidemode 3"
+				"$columnConstraints": "[fill][grow,fill]para[fill][fill][fill][fill][fill]"
+				"$rowConstraints": "[]"
+			} ) {
+				name: "panel3"
+				add( new FormComponent( "javax.swing.JLabel" ) {
+					name: "arcLabel"
+					"text": "Arc:"
+					auxiliary() {
+						"JavaCodeGenerator.variableLocal": true
+					}
+				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+					"value": "cell 0 0"
+				} )
+				add( new FormComponent( "javax.swing.JSlider" ) {
+					name: "arcSlider"
+					"maximum": 40
+					"value": 20
+					"snapToTicks": true
+					"majorTickSpacing": 10
+					"minorTickSpacing": 1
+					"paintTicks": true
+					"paintLabels": true
+					addEvent( new FormEvent( "javax.swing.event.ChangeListener", "stateChanged", "arcSliderChanged", false ) )
+				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+					"value": "cell 1 0"
+				} )
+				add( new FormComponent( "javax.swing.JCheckBox" ) {
+					name: "cornersCheckBox"
+					"text": "Corners"
+					addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "cornersChanged", false ) )
+				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+					"value": "cell 2 0"
+				} )
+				add( new FormComponent( "javax.swing.JCheckBox" ) {
+					name: "columnHeaderCheckBox"
+					"text": "Column Header"
+					addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "columnHeaderChanged", false ) )
+				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+					"value": "cell 3 0"
+				} )
+				add( new FormComponent( "javax.swing.JCheckBox" ) {
+					name: "rowHeaderCheckBox"
+					"text": "Row Header"
+					addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "rowHeaderChanged", false ) )
+				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+					"value": "cell 4 0"
+				} )
+				add( new FormComponent( "javax.swing.JCheckBox" ) {
+					name: "horizontalScrollBarCheckBox"
+					"text": "Horizontal ScrollBar"
+					"selected": true
+					addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "horizontalScrollBarChanged", false ) )
+				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+					"value": "cell 5 0"
+				} )
+				add( new FormComponent( "javax.swing.JCheckBox" ) {
+					name: "verticalScrollBarCheckBox"
+					"text": "Vertical ScrollBar"
+					"selected": true
+					addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "verticalScrollBarChanged", false ) )
+				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+					"value": "cell 6 0"
+				} )
+			}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+				"value": "cell 0 1"
+			} )
+		}, new FormLayoutConstraints( null ) {
+			"location": new java.awt.Point( 0, 0 )
+			"size": new java.awt.Dimension( 875, 715 )
+		} )
+	}
+}

--- a/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatTestFrame.java
+++ b/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatTestFrame.java
@@ -651,6 +651,14 @@ public class FlatTestFrame
 				JViewport columnHeader = ((JScrollPane)c).getColumnHeader();
 				if( columnHeader != null )
 					action.accept( columnHeader.getView(), "columnHeader" );
+			} else if( c instanceof JSplitPane ) {
+				JSplitPane splitPane = (JSplitPane) c;
+				Component left = splitPane.getLeftComponent();
+				Component right = splitPane.getRightComponent();
+				if( left instanceof Container )
+					updateComponentsRecur( (Container) left, action );
+				if( right instanceof Container )
+					updateComponentsRecur( (Container) right, action );
 			} else if( c instanceof JTabbedPane ) {
 				JTabbedPane tabPane = (JTabbedPane)c;
 				int tabCount = tabPane.getTabCount();

--- a/flatlaf-testing/src/main/resources/com/formdev/flatlaf/testing/FlatTestLaf.properties
+++ b/flatlaf-testing/src/main/resources/com/formdev/flatlaf/testing/FlatTestLaf.properties
@@ -331,6 +331,11 @@ ScrollBar.hoverTrackColor = #0f0
 ScrollBar.hoverThumbColor = #f00
 
 
+#---- ScrollPane ----
+
+ScrollPane.arc = 20
+
+
 #---- Separator ----
 
 Separator.foreground = #0b0

--- a/flatlaf-theme-editor/src/main/resources/com/formdev/flatlaf/themeeditor/FlatLafUIKeys.txt
+++ b/flatlaf-theme-editor/src/main/resources/com/formdev/flatlaf/themeeditor/FlatLafUIKeys.txt
@@ -717,6 +717,10 @@ ScrollBar.trackHighlight
 ScrollBar.trackInsets
 ScrollBar.width
 ScrollBarUI
+ScrollPane.List.arc
+ScrollPane.Table.arc
+ScrollPane.TextComponent.arc
+ScrollPane.Tree.arc
 ScrollPane.ancestorInputMap
 ScrollPane.ancestorInputMap.RightToLeft
 ScrollPane.arc

--- a/flatlaf-theme-editor/src/main/resources/com/formdev/flatlaf/themeeditor/FlatLafUIKeys.txt
+++ b/flatlaf-theme-editor/src/main/resources/com/formdev/flatlaf/themeeditor/FlatLafUIKeys.txt
@@ -719,6 +719,7 @@ ScrollBar.width
 ScrollBarUI
 ScrollPane.ancestorInputMap
 ScrollPane.ancestorInputMap.RightToLeft
+ScrollPane.arc
 ScrollPane.background
 ScrollPane.border
 ScrollPane.fillUpperCorner


### PR DESCRIPTION
This is an attempt to bring rounded border to `JScrollPane` and all component that are usually placed into a scrollpane. E.g. `JTextArea`, `JTextPane`, `JEditorPane`, `JList`, `JTree` and `JTable`.

The problem is that there are multiple overlapping components involved:
- the `JScrollPane,` which has the border
- the `JViewport,` which has the view component as child (e.g. a `JList`)
- optional column and row headers
- optional corner components
- vertical and horizontal `JScrollBar`s

They are painted in this order and using rounded border on scrollpane would look like this:

![grafik](https://github.com/JFormDesigner/FlatLaf/assets/5604048/a818435c-8a6c-41ee-a903-0915044bb7a9)

The viewport/list and the scrollbar simply paint over the rounded corners.
And there is no way to fix this for the viewport in the look and feel.
(maybe a custom scrollpane implementation, that paints its border and corners after its children, could work)

So the idea to solve this problem is to add some extra space at left and right sides between the border and the viewport/scrollbars:

![grafik](https://github.com/JFormDesigner/FlatLaf/assets/5604048/6883b551-12d9-4652-a1e8-0d01ed80e2ce)

That's better, but the scrollbar should be at the border:

![grafik](https://github.com/JFormDesigner/FlatLaf/assets/5604048/587434e3-8236-46b0-891f-89eccb7f1aa8)

We can hide the scrollbar track and make the thumb round to improve the look:
~~~properties
ScrollBar.track = @componentBackground
ScrollBar.thumbInsets = 2,2,2,2
ScrollBar.thumbArc = 999
~~~

![grafik](https://github.com/JFormDesigner/FlatLaf/assets/5604048/d6e19eb3-a931-4589-91f2-6a58f3229c76)

If the vertical scrollbar is hidden, it looks like this:

![grafik](https://github.com/JFormDesigner/FlatLaf/assets/5604048/9611f6e2-5b7a-4dff-8ed2-18b452373a9d)

With rounded selection (and smaller border arc than in previous screenshots) this looks really nice:

~~~properties
ScrollPane.arc = 12
List.selectionArc = 8
~~~

![grafik](https://github.com/JFormDesigner/FlatLaf/assets/5604048/5432bb4c-59c2-447e-928c-d6a12583cf2d) ![grafik](https://github.com/JFormDesigner/FlatLaf/assets/5604048/6ddd561f-1ff5-460d-878b-9976915b8b74)

Here are some screenshot that shows the extra space, which was added for rounded border, in green:

![grafik](https://github.com/JFormDesigner/FlatLaf/assets/5604048/028b29d2-080f-4135-82a7-dbf8e9afdf30) ![grafik](https://github.com/JFormDesigner/FlatLaf/assets/5604048/5f0909bc-891d-4dad-82c4-1531f4116a01)

Smaller border arc results in smaller extra space, larger arc gives larger extra space:

![grafik](https://github.com/JFormDesigner/FlatLaf/assets/5604048/9c18fffa-ef9e-4e0f-9275-ec1740674ee8) ![grafik](https://github.com/JFormDesigner/FlatLaf/assets/5604048/0028d0c2-db63-42a2-8390-51bcb27b59ec)

Possible improvements/ideas:

- ~~make viewport wider if vertical scrollbar is visible to remove the gap between viewport and vertical scrollbar (see above screenshot)~~
- adapt vertical scrollbar painting to rounded border to allow full height vertical scrollbar
- ~~allow specifying scrollpane border arc for component types (e.g. use rounded border for multi-line text components, but not for lists, tables and trees)~~

For testing you need to enable rounded border. E.g.:

~~~properties
ScrollPane.arc = 12
~~~
