### PR TITLE
Fixing NPE when showing a popup without an invoker on Windows 10

### DIFF
--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatPopupFactory.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatPopupFactory.java
@@ -397,6 +397,10 @@ public class FlatPopupFactory
 	}
 
 	private static boolean overlapsHeavyWeightComponent( Component owner, Component contents, int x, int y ) {
+		if( owner == null ) {
+			return false;
+		}
+
 		Window window = SwingUtilities.getWindowAncestor( owner );
 		if( window == null )
 			return false;


### PR DESCRIPTION
Fixes #753