### PR TITLE
TabbedPane: support rotated/vertical tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ FlatLaf Change Log
 
 #### New features and improvements
 
+- TabbedPane: Support vertical tabs. (PR #758, issue #633)
 - ToolBar: Added styling properties `separatorWidth` and `separatorColor`.
 
 #### Fixed bugs

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/FlatClientProperties.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/FlatClientProperties.java
@@ -933,6 +933,59 @@ public interface FlatClientProperties
 	String TABBED_PANE_TAB_ICON_PLACEMENT = "JTabbedPane.tabIconPlacement";
 
 	/**
+	 * Specifies the rotation of the tabs (title, icon, etc).
+	 * <p>
+	 * <strong>Component</strong> {@link javax.swing.JTabbedPane}<br>
+	 * <strong>Value type</strong> {@link java.lang.Integer} or {@link java.lang.String}<br>
+	 * <strong>Allowed Values</strong>
+	 *     {@link SwingConstants#LEFT},
+	 *     {@link SwingConstants#RIGHT},
+	 *     {@link #TABBED_PANE_TAB_ROTATION_NONE}, (default)
+	 *     {@link #TABBED_PANE_TAB_ROTATION_AUTO},
+	 *     {@link #TABBED_PANE_TAB_ROTATION_LEFT} or
+	 *     {@link #TABBED_PANE_TAB_ROTATION_RIGHT}
+	 *
+	 * @since 3.3
+	 */
+	String TABBED_PANE_TAB_ROTATION = "JTabbedPane.tabRotation";
+
+	/**
+	 * Tabs are not rotated.
+	 *
+	 * @see #TABBED_PANE_TAB_ROTATION
+	 * @since 3.3
+	 */
+	String TABBED_PANE_TAB_ROTATION_NONE = "none";
+
+	/**
+	 * Tabs are rotated depending on tab placement.
+	 * <p>
+	 * For top and bottom tab placement, the tabs are not rotated.<br>
+	 * For left tab placement, the tabs are rotated counter clockwise.<br>
+	 * For right tab placement, the tabs are rotated clockwise.
+	 *
+	 * @see #TABBED_PANE_TAB_ROTATION
+	 * @since 3.3
+	 */
+	String TABBED_PANE_TAB_ROTATION_AUTO = "auto";
+
+	/**
+	 * Tabs are rotated counter clockwise.
+	 *
+	 * @see #TABBED_PANE_TAB_ROTATION
+	 * @since 3.3
+	 */
+	String TABBED_PANE_TAB_ROTATION_LEFT = "left";
+
+	/**
+	 * Tabs are rotated clockwise.
+	 *
+	 * @see #TABBED_PANE_TAB_ROTATION
+	 * @since 3.3
+	 */
+	String TABBED_PANE_TAB_ROTATION_RIGHT = "right";
+
+	/**
 	 * Specifies a component that will be placed at the leading edge of the tabs area.
 	 * <p>
 	 * For top and bottom tab placement, the laid out component size will be

--- a/flatlaf-core/src/main/resources/com/formdev/flatlaf/FlatLaf.properties
+++ b/flatlaf-core/src/main/resources/com/formdev/flatlaf/FlatLaf.properties
@@ -697,6 +697,8 @@ TabbedPane.tabAreaAlignment = leading
 TabbedPane.tabAlignment = center
 # allowed values: preferred, equal or compact
 TabbedPane.tabWidthMode = preferred
+# allowed values: none, auto, left or right
+TabbedPane.tabRotation = none
 
 # allowed values: underlined or card
 TabbedPane.tabType = underlined

--- a/flatlaf-core/src/test/java/com/formdev/flatlaf/ui/TestFlatStyleableInfo.java
+++ b/flatlaf-core/src/test/java/com/formdev/flatlaf/ui/TestFlatStyleableInfo.java
@@ -752,6 +752,7 @@ public class TestFlatStyleableInfo
 			"tabAreaAlignment", String.class,
 			"tabAlignment", String.class,
 			"tabWidthMode", String.class,
+			"tabRotation", String.class,
 
 			"arrowType", String.class,
 			"buttonInsets", Insets.class,

--- a/flatlaf-core/src/test/java/com/formdev/flatlaf/ui/TestFlatStyleableValue.java
+++ b/flatlaf-core/src/test/java/com/formdev/flatlaf/ui/TestFlatStyleableValue.java
@@ -758,6 +758,7 @@ public class TestFlatStyleableValue
 		testString( c, ui, "tabAreaAlignment", "leading" );
 		testString( c, ui, "tabAlignment", "center" );
 		testString( c, ui, "tabWidthMode", "preferred" );
+		testString( c, ui, "tabRotation", "none" );
 
 		testString( c, ui, "arrowType", "chevron" );
 		testInsets( c, ui, "buttonInsets", 1,2,3,4 );

--- a/flatlaf-core/src/test/java/com/formdev/flatlaf/ui/TestFlatStyling.java
+++ b/flatlaf-core/src/test/java/com/formdev/flatlaf/ui/TestFlatStyling.java
@@ -937,6 +937,7 @@ public class TestFlatStyling
 		ui.applyStyle( "tabAreaAlignment: leading" );
 		ui.applyStyle( "tabAlignment: center" );
 		ui.applyStyle( "tabWidthMode: preferred" );
+		ui.applyStyle( "tabRotation: none" );
 
 		ui.applyStyle( "arrowType: chevron" );
 		ui.applyStyle( "buttonInsets: 1,2,3,4" );

--- a/flatlaf-demo/src/main/java/com/formdev/flatlaf/demo/ScrollablePanel.java
+++ b/flatlaf-demo/src/main/java/com/formdev/flatlaf/demo/ScrollablePanel.java
@@ -34,7 +34,7 @@ public class ScrollablePanel
 {
 	@Override
 	public Dimension getPreferredScrollableViewportSize() {
-		return UIScale.scale( new Dimension( 400, 400 ) );
+		return new Dimension( getPreferredSize().width, UIScale.scale( 400 ) );
 	}
 
 	@Override
@@ -49,7 +49,7 @@ public class ScrollablePanel
 
 	@Override
 	public boolean getScrollableTracksViewportWidth() {
-		return false;
+		return true;
 	}
 
 	@Override

--- a/flatlaf-demo/src/main/java/com/formdev/flatlaf/demo/TabsPanel.java
+++ b/flatlaf-demo/src/main/java/com/formdev/flatlaf/demo/TabsPanel.java
@@ -313,6 +313,14 @@ class TabsPanel
 		putTabbedPanesClientProperty( TABBED_PANE_SHOW_TAB_SEPARATORS, showTabSeparators );
 	}
 
+	private void tabRotationChanged() {
+		String tabRotation = rotationAutoButton.isSelected() ? TABBED_PANE_TAB_ROTATION_AUTO
+			: rotationLeftButton.isSelected() ? TABBED_PANE_TAB_ROTATION_LEFT
+			: rotationRightButton.isSelected() ? TABBED_PANE_TAB_ROTATION_RIGHT
+			: null;
+		putTabbedPanesClientProperty( TABBED_PANE_TAB_ROTATION, tabRotation );
+	}
+
 	private void putTabbedPanesClientProperty( String key, Object value ) {
 		updateTabbedPanesRecur( this, tabbedPane -> tabbedPane.putClientProperty( key, value ) );
 	}
@@ -331,6 +339,8 @@ class TabsPanel
 
 	private void initComponents() {
 		// JFormDesigner - Component initialization - DO NOT MODIFY  //GEN-BEGIN:initComponents
+		JScrollPane tabsScrollPane = new JScrollPane();
+		ScrollablePanel panel6 = new ScrollablePanel();
 		JPanel panel1 = new JPanel();
 		JLabel tabPlacementLabel = new JLabel();
 		tabPlacementToolBar = new JToolBar();
@@ -397,344 +407,369 @@ class TabsPanel
 		scrollAsNeededSingleButton = new JToggleButton();
 		scrollAsNeededButton = new JToggleButton();
 		scrollNeverButton = new JToggleButton();
-		scrollButtonsPlacementLabel = new JLabel();
-		scrollButtonsPlacementToolBar = new JToolBar();
-		scrollBothButton = new JToggleButton();
-		scrollTrailingButton = new JToggleButton();
-		showTabSeparatorsCheckBox = new JCheckBox();
 		tabsPopupPolicyLabel = new JLabel();
 		tabsPopupPolicyToolBar = new JToolBar();
 		popupAsNeededButton = new JToggleButton();
 		popupNeverButton = new JToggleButton();
+		showTabSeparatorsCheckBox = new JCheckBox();
+		scrollButtonsPlacementLabel = new JLabel();
+		scrollButtonsPlacementToolBar = new JToolBar();
+		scrollBothButton = new JToggleButton();
+		scrollTrailingButton = new JToggleButton();
 		tabTypeLabel = new JLabel();
 		tabTypeToolBar = new JToolBar();
 		underlinedTabTypeButton = new JToggleButton();
 		cardTabTypeButton = new JToggleButton();
+		tabRotationLabel = new JLabel();
+		tabRotationToolBar = new JToolBar();
+		rotationNoneButton = new JToggleButton();
+		rotationAutoButton = new JToggleButton();
+		rotationLeftButton = new JToggleButton();
+		rotationRightButton = new JToggleButton();
 
 		//======== this ========
 		setLayout(new MigLayout(
-			"insets dialog,hidemode 3",
+			"insets 0,hidemode 3",
 			// columns
-			"[grow,fill]para" +
-			"[fill]para" +
-			"[fill]",
+			"[grow,fill]",
 			// rows
-			"[grow,fill]para" +
-			"[]" +
+			"[grow,fill]0" +
+			"[]0" +
 			"[]"));
 
-		//======== panel1 ========
+		//======== tabsScrollPane ========
 		{
-			panel1.setLayout(new MigLayout(
-				"insets 0,hidemode 3",
-				// columns
-				"[grow,fill]",
-				// rows
-				"[]" +
-				"[fill]para" +
-				"[]0" +
-				"[]" +
-				"[]para" +
-				"[]" +
-				"[]para" +
-				"[]" +
-				"[]"));
+			tabsScrollPane.setBorder(BorderFactory.createEmptyBorder());
 
-			//---- tabPlacementLabel ----
-			tabPlacementLabel.setText("Tab placement");
-			tabPlacementLabel.putClientProperty("FlatLaf.styleClass", "h3");
-			panel1.add(tabPlacementLabel, "cell 0 0");
-
-			//======== tabPlacementToolBar ========
+			//======== panel6 ========
 			{
-				tabPlacementToolBar.setFloatable(false);
-				tabPlacementToolBar.setBorder(BorderFactory.createEmptyBorder());
-
-				//---- topPlacementButton ----
-				topPlacementButton.setText("top");
-				topPlacementButton.setSelected(true);
-				topPlacementButton.putClientProperty("FlatLaf.styleClass", "small");
-				topPlacementButton.addActionListener(e -> tabPlacementChanged());
-				tabPlacementToolBar.add(topPlacementButton);
-
-				//---- bottomPlacementButton ----
-				bottomPlacementButton.setText("bottom");
-				bottomPlacementButton.putClientProperty("FlatLaf.styleClass", "small");
-				bottomPlacementButton.addActionListener(e -> tabPlacementChanged());
-				tabPlacementToolBar.add(bottomPlacementButton);
-
-				//---- leftPlacementButton ----
-				leftPlacementButton.setText("left");
-				leftPlacementButton.putClientProperty("FlatLaf.styleClass", "small");
-				leftPlacementButton.addActionListener(e -> tabPlacementChanged());
-				tabPlacementToolBar.add(leftPlacementButton);
-
-				//---- rightPlacementButton ----
-				rightPlacementButton.setText("right");
-				rightPlacementButton.putClientProperty("FlatLaf.styleClass", "small");
-				rightPlacementButton.addActionListener(e -> tabPlacementChanged());
-				tabPlacementToolBar.add(rightPlacementButton);
-				tabPlacementToolBar.addSeparator();
-
-				//---- scrollButton ----
-				scrollButton.setText("scroll");
-				scrollButton.putClientProperty("FlatLaf.styleClass", "small");
-				scrollButton.addActionListener(e -> scrollChanged());
-				tabPlacementToolBar.add(scrollButton);
-
-				//---- borderButton ----
-				borderButton.setText("border");
-				borderButton.putClientProperty("FlatLaf.styleClass", "small");
-				borderButton.addActionListener(e -> borderChanged());
-				tabPlacementToolBar.add(borderButton);
-			}
-			panel1.add(tabPlacementToolBar, "cell 0 0,alignx right,growx 0");
-			panel1.add(tabPlacementTabbedPane, "cell 0 1,width 300:300,height 100:100");
-
-			//---- tabLayoutLabel ----
-			tabLayoutLabel.setText("Tab layout");
-			tabLayoutLabel.putClientProperty("FlatLaf.styleClass", "h3");
-			panel1.add(tabLayoutLabel, "cell 0 2");
-
-			//======== tabLayoutToolBar ========
-			{
-				tabLayoutToolBar.setFloatable(false);
-				tabLayoutToolBar.setBorder(BorderFactory.createEmptyBorder());
-
-				//---- scrollTabLayoutButton ----
-				scrollTabLayoutButton.setText("scroll");
-				scrollTabLayoutButton.setSelected(true);
-				scrollTabLayoutButton.putClientProperty("FlatLaf.styleClass", "small");
-				scrollTabLayoutButton.addActionListener(e -> tabLayoutChanged());
-				tabLayoutToolBar.add(scrollTabLayoutButton);
-
-				//---- wrapTabLayoutButton ----
-				wrapTabLayoutButton.setText("wrap");
-				wrapTabLayoutButton.putClientProperty("FlatLaf.styleClass", "small");
-				wrapTabLayoutButton.addActionListener(e -> tabLayoutChanged());
-				tabLayoutToolBar.add(wrapTabLayoutButton);
-			}
-			panel1.add(tabLayoutToolBar, "cell 0 2,alignx right,growx 0");
-
-			//---- scrollLayoutNoteLabel ----
-			scrollLayoutNoteLabel.setText("(use mouse wheel to scroll; arrow button shows hidden tabs)");
-			scrollLayoutNoteLabel.setEnabled(false);
-			scrollLayoutNoteLabel.putClientProperty("FlatLaf.styleClass", "small");
-			panel1.add(scrollLayoutNoteLabel, "cell 0 3");
-
-			//---- wrapLayoutNoteLabel ----
-			wrapLayoutNoteLabel.setText("(probably better to use scroll layout?)");
-			wrapLayoutNoteLabel.setEnabled(false);
-			wrapLayoutNoteLabel.putClientProperty("FlatLaf.styleClass", "small");
-			panel1.add(wrapLayoutNoteLabel, "cell 0 3");
-			panel1.add(scrollLayoutTabbedPane, "cell 0 4");
-			panel1.add(wrapLayoutTabbedPane, "cell 0 4,width 100:100,height pref*2px");
-
-			//---- closableTabsLabel ----
-			closableTabsLabel.setText("Closable tabs");
-			closableTabsLabel.putClientProperty("FlatLaf.styleClass", "h3");
-			panel1.add(closableTabsLabel, "cell 0 5");
-
-			//======== closableTabsToolBar ========
-			{
-				closableTabsToolBar.setFloatable(false);
-				closableTabsToolBar.setBorder(BorderFactory.createEmptyBorder());
-
-				//---- squareCloseButton ----
-				squareCloseButton.setText("square");
-				squareCloseButton.setSelected(true);
-				squareCloseButton.putClientProperty("FlatLaf.styleClass", "small");
-				squareCloseButton.addActionListener(e -> closeButtonStyleChanged());
-				closableTabsToolBar.add(squareCloseButton);
-
-				//---- circleCloseButton ----
-				circleCloseButton.setText("circle");
-				circleCloseButton.putClientProperty("FlatLaf.styleClass", "small");
-				circleCloseButton.addActionListener(e -> closeButtonStyleChanged());
-				closableTabsToolBar.add(circleCloseButton);
-
-				//---- redCrossCloseButton ----
-				redCrossCloseButton.setText("red cross");
-				redCrossCloseButton.putClientProperty("FlatLaf.styleClass", "small");
-				redCrossCloseButton.addActionListener(e -> closeButtonStyleChanged());
-				closableTabsToolBar.add(redCrossCloseButton);
-			}
-			panel1.add(closableTabsToolBar, "cell 0 5,alignx right,growx 0");
-			panel1.add(closableTabsTabbedPane, "cell 0 6");
-
-			//---- tabAreaComponentsLabel ----
-			tabAreaComponentsLabel.setText("Custom tab area components");
-			tabAreaComponentsLabel.putClientProperty("FlatLaf.styleClass", "h3");
-			panel1.add(tabAreaComponentsLabel, "cell 0 7");
-
-			//======== tabAreaComponentsToolBar ========
-			{
-				tabAreaComponentsToolBar.setFloatable(false);
-				tabAreaComponentsToolBar.setBorder(BorderFactory.createEmptyBorder());
-
-				//---- leadingComponentButton ----
-				leadingComponentButton.setText("leading");
-				leadingComponentButton.setSelected(true);
-				leadingComponentButton.putClientProperty("FlatLaf.styleClass", "small");
-				leadingComponentButton.addActionListener(e -> customComponentsChanged());
-				tabAreaComponentsToolBar.add(leadingComponentButton);
-
-				//---- trailingComponentButton ----
-				trailingComponentButton.setText("trailing");
-				trailingComponentButton.setSelected(true);
-				trailingComponentButton.putClientProperty("FlatLaf.styleClass", "small");
-				trailingComponentButton.addActionListener(e -> customComponentsChanged());
-				tabAreaComponentsToolBar.add(trailingComponentButton);
-			}
-			panel1.add(tabAreaComponentsToolBar, "cell 0 7,alignx right,growx 0");
-			panel1.add(customComponentsTabbedPane, "cell 0 8");
-		}
-		add(panel1, "cell 0 0");
-
-		//======== panel2 ========
-		{
-			panel2.setLayout(new MigLayout(
-				"insets 0,hidemode 3",
-				// columns
-				"[grow,fill]",
-				// rows
-				"[]0" +
-				"[]" +
-				"[fill]" +
-				"[center]" +
-				"[center]" +
-				"[center]para" +
-				"[center]0" +
-				"[]" +
-				"[center]" +
-				"[center]" +
-				"[center]" +
-				"[]"));
-
-			//---- tabIconPlacementLabel ----
-			tabIconPlacementLabel.setText("Tab icon placement");
-			tabIconPlacementLabel.putClientProperty("FlatLaf.styleClass", "h3");
-			panel2.add(tabIconPlacementLabel, "cell 0 0");
-
-			//---- tabIconPlacementNodeLabel ----
-			tabIconPlacementNodeLabel.setText("(top/bottom/leading/trailing)");
-			tabIconPlacementNodeLabel.setEnabled(false);
-			tabIconPlacementNodeLabel.putClientProperty("FlatLaf.styleClass", "small");
-			panel2.add(tabIconPlacementNodeLabel, "cell 0 1");
-			panel2.add(iconTopTabbedPane, "cell 0 2");
-			panel2.add(iconBottomTabbedPane, "cell 0 3");
-			panel2.add(iconLeadingTabbedPane, "cell 0 4");
-			panel2.add(iconTrailingTabbedPane, "cell 0 5");
-
-			//---- tabAreaAlignmentLabel ----
-			tabAreaAlignmentLabel.setText("Tab area alignment");
-			tabAreaAlignmentLabel.putClientProperty("FlatLaf.styleClass", "h3");
-			panel2.add(tabAreaAlignmentLabel, "cell 0 6");
-
-			//---- tabAreaAlignmentNoteLabel ----
-			tabAreaAlignmentNoteLabel.setText("(leading/center/trailing/fill)");
-			tabAreaAlignmentNoteLabel.setEnabled(false);
-			tabAreaAlignmentNoteLabel.putClientProperty("FlatLaf.styleClass", "small");
-			panel2.add(tabAreaAlignmentNoteLabel, "cell 0 7");
-			panel2.add(alignLeadingTabbedPane, "cell 0 8");
-			panel2.add(alignCenterTabbedPane, "cell 0 9");
-			panel2.add(alignTrailingTabbedPane, "cell 0 10");
-			panel2.add(alignFillTabbedPane, "cell 0 11");
-		}
-		add(panel2, "cell 1 0,growy");
-
-		//======== panel3 ========
-		{
-			panel3.setLayout(new MigLayout(
-				"insets 0,hidemode 3",
-				// columns
-				"[grow,fill]",
-				// rows
-				"[]0" +
-				"[]" +
-				"[]" +
-				"[]" +
-				"[]para" +
-				"[]" +
-				"[]" +
-				"[]para" +
-				"[]0" +
-				"[]"));
-
-			//---- tabWidthModeLabel ----
-			tabWidthModeLabel.setText("Tab width mode");
-			tabWidthModeLabel.putClientProperty("FlatLaf.styleClass", "h3");
-			panel3.add(tabWidthModeLabel, "cell 0 0");
-
-			//---- tabWidthModeNoteLabel ----
-			tabWidthModeNoteLabel.setText("(preferred/equal/compact)");
-			tabWidthModeNoteLabel.setEnabled(false);
-			tabWidthModeNoteLabel.putClientProperty("FlatLaf.styleClass", "small");
-			panel3.add(tabWidthModeNoteLabel, "cell 0 1");
-			panel3.add(widthPreferredTabbedPane, "cell 0 2");
-			panel3.add(widthEqualTabbedPane, "cell 0 3");
-			panel3.add(widthCompactTabbedPane, "cell 0 4");
-
-			//---- minMaxTabWidthLabel ----
-			minMaxTabWidthLabel.setText("Minimum/maximum tab width");
-			minMaxTabWidthLabel.putClientProperty("FlatLaf.styleClass", "h3");
-			panel3.add(minMaxTabWidthLabel, "cell 0 5");
-			panel3.add(minimumTabWidthTabbedPane, "cell 0 6");
-			panel3.add(maximumTabWidthTabbedPane, "cell 0 7");
-
-			//---- tabAlignmentLabel ----
-			tabAlignmentLabel.setText("Tab title alignment");
-			tabAlignmentLabel.putClientProperty("FlatLaf.styleClass", "h3");
-			panel3.add(tabAlignmentLabel, "cell 0 8");
-
-			//======== panel5 ========
-			{
-				panel5.setLayout(new MigLayout(
-					"insets 0,hidemode 3",
+				panel6.setLayout(new MigLayout(
+					"insets dialog,hidemode 3",
 					// columns
 					"[grow,fill]para" +
+					"[fill]para" +
 					"[fill]",
 					// rows
-					"[]" +
-					"[]" +
-					"[]" +
-					"[]"));
+					"[grow,fill]"));
 
-				//---- tabAlignmentNoteLabel ----
-				tabAlignmentNoteLabel.setText("(leading/center/trailing)");
-				tabAlignmentNoteLabel.setEnabled(false);
-				tabAlignmentNoteLabel.putClientProperty("FlatLaf.styleClass", "small");
-				panel5.add(tabAlignmentNoteLabel, "cell 0 0");
-
-				//---- tabAlignmentNoteLabel2 ----
-				tabAlignmentNoteLabel2.setText("(trailing)");
-				tabAlignmentNoteLabel2.setEnabled(false);
-				tabAlignmentNoteLabel2.putClientProperty("FlatLaf.styleClass", "small");
-				panel5.add(tabAlignmentNoteLabel2, "cell 1 0,alignx right,growx 0");
-				panel5.add(tabAlignLeadingTabbedPane, "cell 0 1");
-
-				//======== tabAlignVerticalTabbedPane ========
+				//======== panel1 ========
 				{
-					tabAlignVerticalTabbedPane.setTabPlacement(SwingConstants.LEFT);
+					panel1.setLayout(new MigLayout(
+						"insets 0,hidemode 3",
+						// columns
+						"[grow,fill]",
+						// rows
+						"[]" +
+						"[fill]para" +
+						"[]0" +
+						"[]" +
+						"[]para" +
+						"[]" +
+						"[]para" +
+						"[]" +
+						"[]"));
+
+					//---- tabPlacementLabel ----
+					tabPlacementLabel.setText("Tab placement");
+					tabPlacementLabel.putClientProperty("FlatLaf.styleClass", "h3");
+					panel1.add(tabPlacementLabel, "cell 0 0");
+
+					//======== tabPlacementToolBar ========
+					{
+						tabPlacementToolBar.setFloatable(false);
+						tabPlacementToolBar.setBorder(BorderFactory.createEmptyBorder());
+
+						//---- topPlacementButton ----
+						topPlacementButton.setText("top");
+						topPlacementButton.setSelected(true);
+						topPlacementButton.putClientProperty("FlatLaf.styleClass", "small");
+						topPlacementButton.addActionListener(e -> tabPlacementChanged());
+						tabPlacementToolBar.add(topPlacementButton);
+
+						//---- bottomPlacementButton ----
+						bottomPlacementButton.setText("bottom");
+						bottomPlacementButton.putClientProperty("FlatLaf.styleClass", "small");
+						bottomPlacementButton.addActionListener(e -> tabPlacementChanged());
+						tabPlacementToolBar.add(bottomPlacementButton);
+
+						//---- leftPlacementButton ----
+						leftPlacementButton.setText("left");
+						leftPlacementButton.putClientProperty("FlatLaf.styleClass", "small");
+						leftPlacementButton.addActionListener(e -> tabPlacementChanged());
+						tabPlacementToolBar.add(leftPlacementButton);
+
+						//---- rightPlacementButton ----
+						rightPlacementButton.setText("right");
+						rightPlacementButton.putClientProperty("FlatLaf.styleClass", "small");
+						rightPlacementButton.addActionListener(e -> tabPlacementChanged());
+						tabPlacementToolBar.add(rightPlacementButton);
+						tabPlacementToolBar.addSeparator();
+
+						//---- scrollButton ----
+						scrollButton.setText("scroll");
+						scrollButton.putClientProperty("FlatLaf.styleClass", "small");
+						scrollButton.addActionListener(e -> scrollChanged());
+						tabPlacementToolBar.add(scrollButton);
+
+						//---- borderButton ----
+						borderButton.setText("border");
+						borderButton.putClientProperty("FlatLaf.styleClass", "small");
+						borderButton.addActionListener(e -> borderChanged());
+						tabPlacementToolBar.add(borderButton);
+					}
+					panel1.add(tabPlacementToolBar, "cell 0 0,alignx right,growx 0");
+					panel1.add(tabPlacementTabbedPane, "cell 0 1,width 300:300,height 100:100");
+
+					//---- tabLayoutLabel ----
+					tabLayoutLabel.setText("Tab layout");
+					tabLayoutLabel.putClientProperty("FlatLaf.styleClass", "h3");
+					panel1.add(tabLayoutLabel, "cell 0 2");
+
+					//======== tabLayoutToolBar ========
+					{
+						tabLayoutToolBar.setFloatable(false);
+						tabLayoutToolBar.setBorder(BorderFactory.createEmptyBorder());
+
+						//---- scrollTabLayoutButton ----
+						scrollTabLayoutButton.setText("scroll");
+						scrollTabLayoutButton.setSelected(true);
+						scrollTabLayoutButton.putClientProperty("FlatLaf.styleClass", "small");
+						scrollTabLayoutButton.addActionListener(e -> tabLayoutChanged());
+						tabLayoutToolBar.add(scrollTabLayoutButton);
+
+						//---- wrapTabLayoutButton ----
+						wrapTabLayoutButton.setText("wrap");
+						wrapTabLayoutButton.putClientProperty("FlatLaf.styleClass", "small");
+						wrapTabLayoutButton.addActionListener(e -> tabLayoutChanged());
+						tabLayoutToolBar.add(wrapTabLayoutButton);
+					}
+					panel1.add(tabLayoutToolBar, "cell 0 2,alignx right,growx 0");
+
+					//---- scrollLayoutNoteLabel ----
+					scrollLayoutNoteLabel.setText("(use mouse wheel to scroll; arrow button shows hidden tabs)");
+					scrollLayoutNoteLabel.setEnabled(false);
+					scrollLayoutNoteLabel.putClientProperty("FlatLaf.styleClass", "small");
+					panel1.add(scrollLayoutNoteLabel, "cell 0 3");
+
+					//---- wrapLayoutNoteLabel ----
+					wrapLayoutNoteLabel.setText("(probably better to use scroll layout?)");
+					wrapLayoutNoteLabel.setEnabled(false);
+					wrapLayoutNoteLabel.putClientProperty("FlatLaf.styleClass", "small");
+					panel1.add(wrapLayoutNoteLabel, "cell 0 3");
+					panel1.add(scrollLayoutTabbedPane, "cell 0 4");
+					panel1.add(wrapLayoutTabbedPane, "cell 0 4,width 100:100,height pref*2px");
+
+					//---- closableTabsLabel ----
+					closableTabsLabel.setText("Closable tabs");
+					closableTabsLabel.putClientProperty("FlatLaf.styleClass", "h3");
+					panel1.add(closableTabsLabel, "cell 0 5");
+
+					//======== closableTabsToolBar ========
+					{
+						closableTabsToolBar.setFloatable(false);
+						closableTabsToolBar.setBorder(BorderFactory.createEmptyBorder());
+
+						//---- squareCloseButton ----
+						squareCloseButton.setText("square");
+						squareCloseButton.setSelected(true);
+						squareCloseButton.putClientProperty("FlatLaf.styleClass", "small");
+						squareCloseButton.addActionListener(e -> closeButtonStyleChanged());
+						closableTabsToolBar.add(squareCloseButton);
+
+						//---- circleCloseButton ----
+						circleCloseButton.setText("circle");
+						circleCloseButton.putClientProperty("FlatLaf.styleClass", "small");
+						circleCloseButton.addActionListener(e -> closeButtonStyleChanged());
+						closableTabsToolBar.add(circleCloseButton);
+
+						//---- redCrossCloseButton ----
+						redCrossCloseButton.setText("red cross");
+						redCrossCloseButton.putClientProperty("FlatLaf.styleClass", "small");
+						redCrossCloseButton.addActionListener(e -> closeButtonStyleChanged());
+						closableTabsToolBar.add(redCrossCloseButton);
+					}
+					panel1.add(closableTabsToolBar, "cell 0 5,alignx right,growx 0");
+					panel1.add(closableTabsTabbedPane, "cell 0 6");
+
+					//---- tabAreaComponentsLabel ----
+					tabAreaComponentsLabel.setText("Custom tab area components");
+					tabAreaComponentsLabel.putClientProperty("FlatLaf.styleClass", "h3");
+					panel1.add(tabAreaComponentsLabel, "cell 0 7");
+
+					//======== tabAreaComponentsToolBar ========
+					{
+						tabAreaComponentsToolBar.setFloatable(false);
+						tabAreaComponentsToolBar.setBorder(BorderFactory.createEmptyBorder());
+
+						//---- leadingComponentButton ----
+						leadingComponentButton.setText("leading");
+						leadingComponentButton.setSelected(true);
+						leadingComponentButton.putClientProperty("FlatLaf.styleClass", "small");
+						leadingComponentButton.addActionListener(e -> customComponentsChanged());
+						tabAreaComponentsToolBar.add(leadingComponentButton);
+
+						//---- trailingComponentButton ----
+						trailingComponentButton.setText("trailing");
+						trailingComponentButton.setSelected(true);
+						trailingComponentButton.putClientProperty("FlatLaf.styleClass", "small");
+						trailingComponentButton.addActionListener(e -> customComponentsChanged());
+						tabAreaComponentsToolBar.add(trailingComponentButton);
+					}
+					panel1.add(tabAreaComponentsToolBar, "cell 0 7,alignx right,growx 0");
+					panel1.add(customComponentsTabbedPane, "cell 0 8");
 				}
-				panel5.add(tabAlignVerticalTabbedPane, "cell 1 1 1 3,growy");
-				panel5.add(tabAlignCenterTabbedPane, "cell 0 2");
-				panel5.add(tabAlignTrailingTabbedPane, "cell 0 3");
+				panel6.add(panel1, "cell 0 0");
+
+				//======== panel2 ========
+				{
+					panel2.setLayout(new MigLayout(
+						"insets 0,hidemode 3",
+						// columns
+						"[grow,fill]",
+						// rows
+						"[]0" +
+						"[]" +
+						"[fill]" +
+						"[center]" +
+						"[center]" +
+						"[center]para" +
+						"[center]0" +
+						"[]" +
+						"[center]" +
+						"[center]" +
+						"[center]" +
+						"[]"));
+
+					//---- tabIconPlacementLabel ----
+					tabIconPlacementLabel.setText("Tab icon placement");
+					tabIconPlacementLabel.putClientProperty("FlatLaf.styleClass", "h3");
+					panel2.add(tabIconPlacementLabel, "cell 0 0");
+
+					//---- tabIconPlacementNodeLabel ----
+					tabIconPlacementNodeLabel.setText("(top/bottom/leading/trailing)");
+					tabIconPlacementNodeLabel.setEnabled(false);
+					tabIconPlacementNodeLabel.putClientProperty("FlatLaf.styleClass", "small");
+					panel2.add(tabIconPlacementNodeLabel, "cell 0 1");
+					panel2.add(iconTopTabbedPane, "cell 0 2");
+					panel2.add(iconBottomTabbedPane, "cell 0 3");
+					panel2.add(iconLeadingTabbedPane, "cell 0 4");
+					panel2.add(iconTrailingTabbedPane, "cell 0 5");
+
+					//---- tabAreaAlignmentLabel ----
+					tabAreaAlignmentLabel.setText("Tab area alignment");
+					tabAreaAlignmentLabel.putClientProperty("FlatLaf.styleClass", "h3");
+					panel2.add(tabAreaAlignmentLabel, "cell 0 6");
+
+					//---- tabAreaAlignmentNoteLabel ----
+					tabAreaAlignmentNoteLabel.setText("(leading/center/trailing/fill)");
+					tabAreaAlignmentNoteLabel.setEnabled(false);
+					tabAreaAlignmentNoteLabel.putClientProperty("FlatLaf.styleClass", "small");
+					panel2.add(tabAreaAlignmentNoteLabel, "cell 0 7");
+					panel2.add(alignLeadingTabbedPane, "cell 0 8");
+					panel2.add(alignCenterTabbedPane, "cell 0 9");
+					panel2.add(alignTrailingTabbedPane, "cell 0 10");
+					panel2.add(alignFillTabbedPane, "cell 0 11");
+				}
+				panel6.add(panel2, "cell 1 0,growy");
+
+				//======== panel3 ========
+				{
+					panel3.setLayout(new MigLayout(
+						"insets 0,hidemode 3",
+						// columns
+						"[grow,fill]",
+						// rows
+						"[]0" +
+						"[]" +
+						"[]" +
+						"[]" +
+						"[]para" +
+						"[]" +
+						"[]" +
+						"[]para" +
+						"[]0" +
+						"[]"));
+
+					//---- tabWidthModeLabel ----
+					tabWidthModeLabel.setText("Tab width mode");
+					tabWidthModeLabel.putClientProperty("FlatLaf.styleClass", "h3");
+					panel3.add(tabWidthModeLabel, "cell 0 0");
+
+					//---- tabWidthModeNoteLabel ----
+					tabWidthModeNoteLabel.setText("(preferred/equal/compact)");
+					tabWidthModeNoteLabel.setEnabled(false);
+					tabWidthModeNoteLabel.putClientProperty("FlatLaf.styleClass", "small");
+					panel3.add(tabWidthModeNoteLabel, "cell 0 1");
+					panel3.add(widthPreferredTabbedPane, "cell 0 2");
+					panel3.add(widthEqualTabbedPane, "cell 0 3");
+					panel3.add(widthCompactTabbedPane, "cell 0 4");
+
+					//---- minMaxTabWidthLabel ----
+					minMaxTabWidthLabel.setText("Minimum/maximum tab width");
+					minMaxTabWidthLabel.putClientProperty("FlatLaf.styleClass", "h3");
+					panel3.add(minMaxTabWidthLabel, "cell 0 5");
+					panel3.add(minimumTabWidthTabbedPane, "cell 0 6");
+					panel3.add(maximumTabWidthTabbedPane, "cell 0 7");
+
+					//---- tabAlignmentLabel ----
+					tabAlignmentLabel.setText("Tab title alignment");
+					tabAlignmentLabel.putClientProperty("FlatLaf.styleClass", "h3");
+					panel3.add(tabAlignmentLabel, "cell 0 8");
+
+					//======== panel5 ========
+					{
+						panel5.setLayout(new MigLayout(
+							"insets 0,hidemode 3",
+							// columns
+							"[grow,fill]para" +
+							"[fill]",
+							// rows
+							"[]" +
+							"[]" +
+							"[]" +
+							"[]" +
+							"[]"));
+
+						//---- tabAlignmentNoteLabel ----
+						tabAlignmentNoteLabel.setText("(leading/center/trailing)");
+						tabAlignmentNoteLabel.setEnabled(false);
+						tabAlignmentNoteLabel.putClientProperty("FlatLaf.styleClass", "small");
+						panel5.add(tabAlignmentNoteLabel, "cell 0 0");
+
+						//---- tabAlignmentNoteLabel2 ----
+						tabAlignmentNoteLabel2.setText("(trailing)");
+						tabAlignmentNoteLabel2.setEnabled(false);
+						tabAlignmentNoteLabel2.putClientProperty("FlatLaf.styleClass", "small");
+						panel5.add(tabAlignmentNoteLabel2, "cell 1 0,alignx right,growx 0");
+						panel5.add(tabAlignLeadingTabbedPane, "cell 0 1");
+
+						//======== tabAlignVerticalTabbedPane ========
+						{
+							tabAlignVerticalTabbedPane.setTabPlacement(SwingConstants.LEFT);
+						}
+						panel5.add(tabAlignVerticalTabbedPane, "cell 1 1 1 4,growy");
+						panel5.add(tabAlignCenterTabbedPane, "cell 0 2");
+						panel5.add(tabAlignTrailingTabbedPane, "cell 0 3");
+					}
+					panel3.add(panel5, "cell 0 9");
+				}
+				panel6.add(panel3, "cell 2 0");
 			}
-			panel3.add(panel5, "cell 0 9");
+			tabsScrollPane.setViewportView(panel6);
 		}
-		add(panel3, "cell 2 0");
-		add(separator2, "cell 0 1 3 1");
+		add(tabsScrollPane, "cell 0 0");
+		add(separator2, "cell 0 1");
 
 		//======== panel4 ========
 		{
 			panel4.setLayout(new MigLayout(
-				"insets 0,hidemode 3",
+				"insets panel,hidemode 3",
 				// columns
 				"[]" +
 				"[fill]para" +
 				"[fill]" +
 				"[fill]para" +
+				"[fill]" +
 				"[fill]",
 				// rows
 				"[]" +
@@ -770,38 +805,9 @@ class TabsPanel
 			}
 			panel4.add(scrollButtonsPolicyToolBar, "cell 1 0");
 
-			//---- scrollButtonsPlacementLabel ----
-			scrollButtonsPlacementLabel.setText("Scroll buttons placement:");
-			panel4.add(scrollButtonsPlacementLabel, "cell 2 0");
-
-			//======== scrollButtonsPlacementToolBar ========
-			{
-				scrollButtonsPlacementToolBar.setFloatable(false);
-				scrollButtonsPlacementToolBar.setBorder(BorderFactory.createEmptyBorder());
-
-				//---- scrollBothButton ----
-				scrollBothButton.setText("both");
-				scrollBothButton.setSelected(true);
-				scrollBothButton.putClientProperty("FlatLaf.styleClass", "small");
-				scrollBothButton.addActionListener(e -> scrollButtonsPlacementChanged());
-				scrollButtonsPlacementToolBar.add(scrollBothButton);
-
-				//---- scrollTrailingButton ----
-				scrollTrailingButton.setText("trailing");
-				scrollTrailingButton.putClientProperty("FlatLaf.styleClass", "small");
-				scrollTrailingButton.addActionListener(e -> scrollButtonsPlacementChanged());
-				scrollButtonsPlacementToolBar.add(scrollTrailingButton);
-			}
-			panel4.add(scrollButtonsPlacementToolBar, "cell 3 0");
-
-			//---- showTabSeparatorsCheckBox ----
-			showTabSeparatorsCheckBox.setText("Show tab separators");
-			showTabSeparatorsCheckBox.addActionListener(e -> showTabSeparatorsChanged());
-			panel4.add(showTabSeparatorsCheckBox, "cell 4 0");
-
 			//---- tabsPopupPolicyLabel ----
 			tabsPopupPolicyLabel.setText("Tabs popup policy:");
-			panel4.add(tabsPopupPolicyLabel, "cell 0 1");
+			panel4.add(tabsPopupPolicyLabel, "cell 2 0");
 
 			//======== tabsPopupPolicyToolBar ========
 			{
@@ -821,7 +827,36 @@ class TabsPanel
 				popupNeverButton.addActionListener(e -> tabsPopupPolicyChanged());
 				tabsPopupPolicyToolBar.add(popupNeverButton);
 			}
-			panel4.add(tabsPopupPolicyToolBar, "cell 1 1");
+			panel4.add(tabsPopupPolicyToolBar, "cell 3 0");
+
+			//---- showTabSeparatorsCheckBox ----
+			showTabSeparatorsCheckBox.setText("Show tab separators");
+			showTabSeparatorsCheckBox.addActionListener(e -> showTabSeparatorsChanged());
+			panel4.add(showTabSeparatorsCheckBox, "cell 4 0 2 1,alignx left,growx 0");
+
+			//---- scrollButtonsPlacementLabel ----
+			scrollButtonsPlacementLabel.setText("Scroll buttons placement:");
+			panel4.add(scrollButtonsPlacementLabel, "cell 0 1");
+
+			//======== scrollButtonsPlacementToolBar ========
+			{
+				scrollButtonsPlacementToolBar.setFloatable(false);
+				scrollButtonsPlacementToolBar.setBorder(BorderFactory.createEmptyBorder());
+
+				//---- scrollBothButton ----
+				scrollBothButton.setText("both");
+				scrollBothButton.setSelected(true);
+				scrollBothButton.putClientProperty("FlatLaf.styleClass", "small");
+				scrollBothButton.addActionListener(e -> scrollButtonsPlacementChanged());
+				scrollButtonsPlacementToolBar.add(scrollBothButton);
+
+				//---- scrollTrailingButton ----
+				scrollTrailingButton.setText("trailing");
+				scrollTrailingButton.putClientProperty("FlatLaf.styleClass", "small");
+				scrollTrailingButton.addActionListener(e -> scrollButtonsPlacementChanged());
+				scrollButtonsPlacementToolBar.add(scrollTrailingButton);
+			}
+			panel4.add(scrollButtonsPlacementToolBar, "cell 1 1");
 
 			//---- tabTypeLabel ----
 			tabTypeLabel.setText("Tab type:");
@@ -845,8 +880,44 @@ class TabsPanel
 				tabTypeToolBar.add(cardTabTypeButton);
 			}
 			panel4.add(tabTypeToolBar, "cell 3 1");
+
+			//---- tabRotationLabel ----
+			tabRotationLabel.setText("Tab rotation:");
+			panel4.add(tabRotationLabel, "cell 4 1");
+
+			//======== tabRotationToolBar ========
+			{
+				tabRotationToolBar.setFloatable(false);
+				tabRotationToolBar.setBorder(BorderFactory.createEmptyBorder());
+
+				//---- rotationNoneButton ----
+				rotationNoneButton.setText("none");
+				rotationNoneButton.setSelected(true);
+				rotationNoneButton.putClientProperty("FlatLaf.styleClass", "small");
+				rotationNoneButton.addActionListener(e -> tabRotationChanged());
+				tabRotationToolBar.add(rotationNoneButton);
+
+				//---- rotationAutoButton ----
+				rotationAutoButton.setText("auto");
+				rotationAutoButton.putClientProperty("FlatLaf.styleClass", "small");
+				rotationAutoButton.addActionListener(e -> tabRotationChanged());
+				tabRotationToolBar.add(rotationAutoButton);
+
+				//---- rotationLeftButton ----
+				rotationLeftButton.setText("left");
+				rotationLeftButton.putClientProperty("FlatLaf.styleClass", "small");
+				rotationLeftButton.addActionListener(e -> tabRotationChanged());
+				tabRotationToolBar.add(rotationLeftButton);
+
+				//---- rotationRightButton ----
+				rotationRightButton.setText("right");
+				rotationRightButton.putClientProperty("FlatLaf.styleClass", "small");
+				rotationRightButton.addActionListener(e -> tabRotationChanged());
+				tabRotationToolBar.add(rotationRightButton);
+			}
+			panel4.add(tabRotationToolBar, "cell 5 1");
 		}
-		add(panel4, "cell 0 2 3 1");
+		add(panel4, "cell 0 2");
 
 		//---- tabPlacementButtonGroup ----
 		ButtonGroup tabPlacementButtonGroup = new ButtonGroup();
@@ -872,20 +943,27 @@ class TabsPanel
 		scrollButtonsPolicyButtonGroup.add(scrollAsNeededButton);
 		scrollButtonsPolicyButtonGroup.add(scrollNeverButton);
 
-		//---- scrollButtonsPlacementButtonGroup ----
-		ButtonGroup scrollButtonsPlacementButtonGroup = new ButtonGroup();
-		scrollButtonsPlacementButtonGroup.add(scrollBothButton);
-		scrollButtonsPlacementButtonGroup.add(scrollTrailingButton);
-
 		//---- tabsPopupPolicyButtonGroup ----
 		ButtonGroup tabsPopupPolicyButtonGroup = new ButtonGroup();
 		tabsPopupPolicyButtonGroup.add(popupAsNeededButton);
 		tabsPopupPolicyButtonGroup.add(popupNeverButton);
 
+		//---- scrollButtonsPlacementButtonGroup ----
+		ButtonGroup scrollButtonsPlacementButtonGroup = new ButtonGroup();
+		scrollButtonsPlacementButtonGroup.add(scrollBothButton);
+		scrollButtonsPlacementButtonGroup.add(scrollTrailingButton);
+
 		//---- tabTypeButtonGroup ----
 		ButtonGroup tabTypeButtonGroup = new ButtonGroup();
 		tabTypeButtonGroup.add(underlinedTabTypeButton);
 		tabTypeButtonGroup.add(cardTabTypeButton);
+
+		//---- tabRotationButtonGroup ----
+		ButtonGroup tabRotationButtonGroup = new ButtonGroup();
+		tabRotationButtonGroup.add(rotationNoneButton);
+		tabRotationButtonGroup.add(rotationAutoButton);
+		tabRotationButtonGroup.add(rotationLeftButton);
+		tabRotationButtonGroup.add(rotationRightButton);
 		// JFormDesigner - End of component initialization  //GEN-END:initComponents
 
 		if( FlatLafDemo.screenshotsMode ) {
@@ -961,18 +1039,24 @@ class TabsPanel
 	private JToggleButton scrollAsNeededSingleButton;
 	private JToggleButton scrollAsNeededButton;
 	private JToggleButton scrollNeverButton;
-	private JLabel scrollButtonsPlacementLabel;
-	private JToolBar scrollButtonsPlacementToolBar;
-	private JToggleButton scrollBothButton;
-	private JToggleButton scrollTrailingButton;
-	private JCheckBox showTabSeparatorsCheckBox;
 	private JLabel tabsPopupPolicyLabel;
 	private JToolBar tabsPopupPolicyToolBar;
 	private JToggleButton popupAsNeededButton;
 	private JToggleButton popupNeverButton;
+	private JCheckBox showTabSeparatorsCheckBox;
+	private JLabel scrollButtonsPlacementLabel;
+	private JToolBar scrollButtonsPlacementToolBar;
+	private JToggleButton scrollBothButton;
+	private JToggleButton scrollTrailingButton;
 	private JLabel tabTypeLabel;
 	private JToolBar tabTypeToolBar;
 	private JToggleButton underlinedTabTypeButton;
 	private JToggleButton cardTabTypeButton;
+	private JLabel tabRotationLabel;
+	private JToolBar tabRotationToolBar;
+	private JToggleButton rotationNoneButton;
+	private JToggleButton rotationAutoButton;
+	private JToggleButton rotationLeftButton;
+	private JToggleButton rotationRightButton;
 	// JFormDesigner - End of variables declaration  //GEN-END:variables
 }

--- a/flatlaf-demo/src/main/java/com/formdev/flatlaf/demo/TabsPanel.jfd
+++ b/flatlaf-demo/src/main/java/com/formdev/flatlaf/demo/TabsPanel.jfd
@@ -1,462 +1,481 @@
-JFDML JFormDesigner: "7.0.5.0.404" Java: "17" encoding: "UTF-8"
+JFDML JFormDesigner: "8.2.0.0.331" Java: "21" encoding: "UTF-8"
 
 new FormModel {
 	contentType: "form/swing"
 	root: new FormRoot {
 		add( new FormContainer( "javax.swing.JPanel", new FormLayoutManager( class net.miginfocom.swing.MigLayout ) {
-			"$layoutConstraints": "insets dialog,hidemode 3"
-			"$columnConstraints": "[grow,fill]para[fill]para[fill]"
-			"$rowConstraints": "[grow,fill]para[][]"
+			"$layoutConstraints": "insets 0,hidemode 3"
+			"$columnConstraints": "[grow,fill]"
+			"$rowConstraints": "[grow,fill]0[]0[]"
 		} ) {
 			name: "this"
-			add( new FormContainer( "javax.swing.JPanel", new FormLayoutManager( class net.miginfocom.swing.MigLayout ) {
-				"$layoutConstraints": "insets 0,hidemode 3"
-				"$columnConstraints": "[grow,fill]"
-				"$rowConstraints": "[][fill]para[]0[][]para[][]para[][]"
-			} ) {
-				name: "panel1"
+			add( new FormContainer( "javax.swing.JScrollPane", new FormLayoutManager( class javax.swing.JScrollPane ) ) {
+				name: "tabsScrollPane"
+				"border": new javax.swing.border.EmptyBorder( 0, 0, 0, 0 )
 				auxiliary() {
 					"JavaCodeGenerator.variableLocal": true
 				}
-				add( new FormComponent( "javax.swing.JLabel" ) {
-					name: "tabPlacementLabel"
-					"text": "Tab placement"
-					"$client.FlatLaf.styleClass": "h3"
+				add( new FormContainer( "com.formdev.flatlaf.demo.ScrollablePanel", new FormLayoutManager( class net.miginfocom.swing.MigLayout ) {
+					"$columnConstraints": "[grow,fill]para[fill]para[fill]"
+					"$rowConstraints": "[grow,fill]"
+					"$layoutConstraints": "insets dialog,hidemode 3"
+				} ) {
+					name: "panel6"
 					auxiliary() {
 						"JavaCodeGenerator.variableLocal": true
 					}
-				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-					"value": "cell 0 0"
-				} )
-				add( new FormContainer( "javax.swing.JToolBar", new FormLayoutManager( class javax.swing.JToolBar ) ) {
-					name: "tabPlacementToolBar"
-					"floatable": false
-					"border": new javax.swing.border.EmptyBorder( 0, 0, 0, 0 )
-					add( new FormComponent( "javax.swing.JToggleButton" ) {
-						name: "topPlacementButton"
-						"text": "top"
-						"selected": true
-						"$buttonGroup": new FormReference( "tabPlacementButtonGroup" )
-						"$client.FlatLaf.styleClass": "small"
-						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "tabPlacementChanged", false ) )
+					add( new FormContainer( "javax.swing.JPanel", new FormLayoutManager( class net.miginfocom.swing.MigLayout ) {
+						"$layoutConstraints": "insets 0,hidemode 3"
+						"$columnConstraints": "[grow,fill]"
+						"$rowConstraints": "[][fill]para[]0[][]para[][]para[][]"
+					} ) {
+						name: "panel1"
+						auxiliary() {
+							"JavaCodeGenerator.variableLocal": true
+						}
+						add( new FormComponent( "javax.swing.JLabel" ) {
+							name: "tabPlacementLabel"
+							"text": "Tab placement"
+							"$client.FlatLaf.styleClass": "h3"
+							auxiliary() {
+								"JavaCodeGenerator.variableLocal": true
+							}
+						}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+							"value": "cell 0 0"
+						} )
+						add( new FormContainer( "javax.swing.JToolBar", new FormLayoutManager( class javax.swing.JToolBar ) ) {
+							name: "tabPlacementToolBar"
+							"floatable": false
+							"border": new javax.swing.border.EmptyBorder( 0, 0, 0, 0 )
+							add( new FormComponent( "javax.swing.JToggleButton" ) {
+								name: "topPlacementButton"
+								"text": "top"
+								"selected": true
+								"$buttonGroup": new FormReference( "tabPlacementButtonGroup" )
+								"$client.FlatLaf.styleClass": "small"
+								addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "tabPlacementChanged", false ) )
+							} )
+							add( new FormComponent( "javax.swing.JToggleButton" ) {
+								name: "bottomPlacementButton"
+								"text": "bottom"
+								"$buttonGroup": new FormReference( "tabPlacementButtonGroup" )
+								"$client.FlatLaf.styleClass": "small"
+								addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "tabPlacementChanged", false ) )
+							} )
+							add( new FormComponent( "javax.swing.JToggleButton" ) {
+								name: "leftPlacementButton"
+								"text": "left"
+								"$buttonGroup": new FormReference( "tabPlacementButtonGroup" )
+								"$client.FlatLaf.styleClass": "small"
+								addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "tabPlacementChanged", false ) )
+							} )
+							add( new FormComponent( "javax.swing.JToggleButton" ) {
+								name: "rightPlacementButton"
+								"text": "right"
+								"$buttonGroup": new FormReference( "tabPlacementButtonGroup" )
+								"$client.FlatLaf.styleClass": "small"
+								addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "tabPlacementChanged", false ) )
+							} )
+							add( new FormComponent( "javax.swing.JToolBar$Separator" ) {
+								name: "separator1"
+							} )
+							add( new FormComponent( "javax.swing.JToggleButton" ) {
+								name: "scrollButton"
+								"text": "scroll"
+								"$client.FlatLaf.styleClass": "small"
+								addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "scrollChanged", false ) )
+							} )
+							add( new FormComponent( "javax.swing.JToggleButton" ) {
+								name: "borderButton"
+								"text": "border"
+								"$client.FlatLaf.styleClass": "small"
+								addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "borderChanged", false ) )
+							} )
+						}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+							"value": "cell 0 0,alignx right,growx 0"
+						} )
+						add( new FormContainer( "javax.swing.JTabbedPane", new FormLayoutManager( class javax.swing.JTabbedPane ) ) {
+							name: "tabPlacementTabbedPane"
+						}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+							"value": "cell 0 1,width 300:300,height 100:100"
+						} )
+						add( new FormComponent( "javax.swing.JLabel" ) {
+							name: "tabLayoutLabel"
+							"text": "Tab layout"
+							"$client.FlatLaf.styleClass": "h3"
+							auxiliary() {
+								"JavaCodeGenerator.variableLocal": true
+							}
+						}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+							"value": "cell 0 2"
+						} )
+						add( new FormContainer( "javax.swing.JToolBar", new FormLayoutManager( class javax.swing.JToolBar ) ) {
+							name: "tabLayoutToolBar"
+							"floatable": false
+							"border": &EmptyBorder0 new javax.swing.border.EmptyBorder( 0, 0, 0, 0 )
+							add( new FormComponent( "javax.swing.JToggleButton" ) {
+								name: "scrollTabLayoutButton"
+								"text": "scroll"
+								"$buttonGroup": new FormReference( "tabLayoutButtonGroup" )
+								"selected": true
+								"$client.FlatLaf.styleClass": "small"
+								addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "tabLayoutChanged", false ) )
+							} )
+							add( new FormComponent( "javax.swing.JToggleButton" ) {
+								name: "wrapTabLayoutButton"
+								"text": "wrap"
+								"$buttonGroup": new FormReference( "tabLayoutButtonGroup" )
+								"$client.FlatLaf.styleClass": "small"
+								addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "tabLayoutChanged", false ) )
+							} )
+						}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+							"value": "cell 0 2,alignx right,growx 0"
+						} )
+						add( new FormComponent( "javax.swing.JLabel" ) {
+							name: "scrollLayoutNoteLabel"
+							"text": "(use mouse wheel to scroll; arrow button shows hidden tabs)"
+							"enabled": false
+							"$client.FlatLaf.styleClass": "small"
+						}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+							"value": "cell 0 3"
+						} )
+						add( new FormComponent( "javax.swing.JLabel" ) {
+							name: "wrapLayoutNoteLabel"
+							"text": "(probably better to use scroll layout?)"
+							"enabled": false
+							"$client.FlatLaf.styleClass": "small"
+						}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+							"value": "cell 0 3"
+						} )
+						add( new FormContainer( "javax.swing.JTabbedPane", new FormLayoutManager( class javax.swing.JTabbedPane ) ) {
+							name: "scrollLayoutTabbedPane"
+						}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+							"value": "cell 0 4"
+						} )
+						add( new FormContainer( "javax.swing.JTabbedPane", new FormLayoutManager( class javax.swing.JTabbedPane ) ) {
+							name: "wrapLayoutTabbedPane"
+						}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+							"value": "cell 0 4,width 100:100,height pref*2px"
+						} )
+						add( new FormComponent( "javax.swing.JLabel" ) {
+							name: "closableTabsLabel"
+							"text": "Closable tabs"
+							"$client.FlatLaf.styleClass": "h3"
+							auxiliary() {
+								"JavaCodeGenerator.variableLocal": true
+							}
+						}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+							"value": "cell 0 5"
+						} )
+						add( new FormContainer( "javax.swing.JToolBar", new FormLayoutManager( class javax.swing.JToolBar ) ) {
+							name: "closableTabsToolBar"
+							"floatable": false
+							"border": new javax.swing.border.EmptyBorder( 0, 0, 0, 0 )
+							add( new FormComponent( "javax.swing.JToggleButton" ) {
+								name: "squareCloseButton"
+								"text": "square"
+								"$buttonGroup": new FormReference( "closableTabsButtonGroup" )
+								"selected": true
+								"$client.FlatLaf.styleClass": "small"
+								addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "closeButtonStyleChanged", false ) )
+							} )
+							add( new FormComponent( "javax.swing.JToggleButton" ) {
+								name: "circleCloseButton"
+								"text": "circle"
+								"$buttonGroup": new FormReference( "closableTabsButtonGroup" )
+								"$client.FlatLaf.styleClass": "small"
+								addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "closeButtonStyleChanged", false ) )
+							} )
+							add( new FormComponent( "javax.swing.JToggleButton" ) {
+								name: "redCrossCloseButton"
+								"text": "red cross"
+								"$buttonGroup": new FormReference( "closableTabsButtonGroup" )
+								"$client.FlatLaf.styleClass": "small"
+								addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "closeButtonStyleChanged", false ) )
+							} )
+						}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+							"value": "cell 0 5,alignx right,growx 0"
+						} )
+						add( new FormContainer( "javax.swing.JTabbedPane", new FormLayoutManager( class javax.swing.JTabbedPane ) ) {
+							name: "closableTabsTabbedPane"
+						}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+							"value": "cell 0 6"
+						} )
+						add( new FormComponent( "javax.swing.JLabel" ) {
+							name: "tabAreaComponentsLabel"
+							"text": "Custom tab area components"
+							"$client.FlatLaf.styleClass": "h3"
+							auxiliary() {
+								"JavaCodeGenerator.variableLocal": true
+							}
+						}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+							"value": "cell 0 7"
+						} )
+						add( new FormContainer( "javax.swing.JToolBar", new FormLayoutManager( class javax.swing.JToolBar ) ) {
+							name: "tabAreaComponentsToolBar"
+							"floatable": false
+							"border": new javax.swing.border.EmptyBorder( 0, 0, 0, 0 )
+							add( new FormComponent( "javax.swing.JToggleButton" ) {
+								name: "leadingComponentButton"
+								"text": "leading"
+								"selected": true
+								"$client.FlatLaf.styleClass": "small"
+								addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "customComponentsChanged", false ) )
+							} )
+							add( new FormComponent( "javax.swing.JToggleButton" ) {
+								name: "trailingComponentButton"
+								"text": "trailing"
+								"selected": true
+								"$client.FlatLaf.styleClass": "small"
+								addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "customComponentsChanged", false ) )
+							} )
+						}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+							"value": "cell 0 7,alignx right,growx 0"
+						} )
+						add( new FormContainer( "javax.swing.JTabbedPane", new FormLayoutManager( class javax.swing.JTabbedPane ) ) {
+							name: "customComponentsTabbedPane"
+						}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+							"value": "cell 0 8"
+						} )
+					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+						"value": "cell 0 0"
 					} )
-					add( new FormComponent( "javax.swing.JToggleButton" ) {
-						name: "bottomPlacementButton"
-						"text": "bottom"
-						"$buttonGroup": new FormReference( "tabPlacementButtonGroup" )
-						"$client.FlatLaf.styleClass": "small"
-						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "tabPlacementChanged", false ) )
+					add( new FormContainer( "javax.swing.JPanel", new FormLayoutManager( class net.miginfocom.swing.MigLayout ) {
+						"$layoutConstraints": "insets 0,hidemode 3"
+						"$columnConstraints": "[grow,fill]"
+						"$rowConstraints": "[]0[][fill][center][center][center]para[center]0[][center][center][center][]"
+					} ) {
+						name: "panel2"
+						auxiliary() {
+							"JavaCodeGenerator.variableLocal": true
+						}
+						add( new FormComponent( "javax.swing.JLabel" ) {
+							name: "tabIconPlacementLabel"
+							"text": "Tab icon placement"
+							"$client.FlatLaf.styleClass": "h3"
+							auxiliary() {
+								"JavaCodeGenerator.variableLocal": true
+							}
+						}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+							"value": "cell 0 0"
+						} )
+						add( new FormComponent( "javax.swing.JLabel" ) {
+							name: "tabIconPlacementNodeLabel"
+							"text": "(top/bottom/leading/trailing)"
+							"enabled": false
+							"$client.FlatLaf.styleClass": "small"
+							auxiliary() {
+								"JavaCodeGenerator.variableLocal": true
+							}
+						}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+							"value": "cell 0 1"
+						} )
+						add( new FormContainer( "javax.swing.JTabbedPane", new FormLayoutManager( class javax.swing.JTabbedPane ) ) {
+							name: "iconTopTabbedPane"
+						}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+							"value": "cell 0 2"
+						} )
+						add( new FormContainer( "javax.swing.JTabbedPane", new FormLayoutManager( class javax.swing.JTabbedPane ) ) {
+							name: "iconBottomTabbedPane"
+						}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+							"value": "cell 0 3"
+						} )
+						add( new FormContainer( "javax.swing.JTabbedPane", new FormLayoutManager( class javax.swing.JTabbedPane ) ) {
+							name: "iconLeadingTabbedPane"
+						}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+							"value": "cell 0 4"
+						} )
+						add( new FormContainer( "javax.swing.JTabbedPane", new FormLayoutManager( class javax.swing.JTabbedPane ) ) {
+							name: "iconTrailingTabbedPane"
+						}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+							"value": "cell 0 5"
+						} )
+						add( new FormComponent( "javax.swing.JLabel" ) {
+							name: "tabAreaAlignmentLabel"
+							"text": "Tab area alignment"
+							"$client.FlatLaf.styleClass": "h3"
+							auxiliary() {
+								"JavaCodeGenerator.variableLocal": true
+							}
+						}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+							"value": "cell 0 6"
+						} )
+						add( new FormComponent( "javax.swing.JLabel" ) {
+							name: "tabAreaAlignmentNoteLabel"
+							"text": "(leading/center/trailing/fill)"
+							"enabled": false
+							"$client.FlatLaf.styleClass": "small"
+							auxiliary() {
+								"JavaCodeGenerator.variableLocal": true
+							}
+						}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+							"value": "cell 0 7"
+						} )
+						add( new FormContainer( "javax.swing.JTabbedPane", new FormLayoutManager( class javax.swing.JTabbedPane ) ) {
+							name: "alignLeadingTabbedPane"
+						}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+							"value": "cell 0 8"
+						} )
+						add( new FormContainer( "javax.swing.JTabbedPane", new FormLayoutManager( class javax.swing.JTabbedPane ) ) {
+							name: "alignCenterTabbedPane"
+						}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+							"value": "cell 0 9"
+						} )
+						add( new FormContainer( "javax.swing.JTabbedPane", new FormLayoutManager( class javax.swing.JTabbedPane ) ) {
+							name: "alignTrailingTabbedPane"
+						}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+							"value": "cell 0 10"
+						} )
+						add( new FormContainer( "javax.swing.JTabbedPane", new FormLayoutManager( class javax.swing.JTabbedPane ) ) {
+							name: "alignFillTabbedPane"
+						}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+							"value": "cell 0 11"
+						} )
+					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+						"value": "cell 1 0,growy"
 					} )
-					add( new FormComponent( "javax.swing.JToggleButton" ) {
-						name: "leftPlacementButton"
-						"text": "left"
-						"$buttonGroup": new FormReference( "tabPlacementButtonGroup" )
-						"$client.FlatLaf.styleClass": "small"
-						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "tabPlacementChanged", false ) )
+					add( new FormContainer( "javax.swing.JPanel", new FormLayoutManager( class net.miginfocom.swing.MigLayout ) {
+						"$layoutConstraints": "insets 0,hidemode 3"
+						"$columnConstraints": "[grow,fill]"
+						"$rowConstraints": "[]0[][][][]para[][][]para[]0[]"
+					} ) {
+						name: "panel3"
+						auxiliary() {
+							"JavaCodeGenerator.variableLocal": true
+						}
+						add( new FormComponent( "javax.swing.JLabel" ) {
+							name: "tabWidthModeLabel"
+							"text": "Tab width mode"
+							"$client.FlatLaf.styleClass": "h3"
+							auxiliary() {
+								"JavaCodeGenerator.variableLocal": true
+							}
+						}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+							"value": "cell 0 0"
+						} )
+						add( new FormComponent( "javax.swing.JLabel" ) {
+							name: "tabWidthModeNoteLabel"
+							"text": "(preferred/equal/compact)"
+							"enabled": false
+							"$client.FlatLaf.styleClass": "small"
+							auxiliary() {
+								"JavaCodeGenerator.variableLocal": true
+							}
+						}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+							"value": "cell 0 1"
+						} )
+						add( new FormContainer( "javax.swing.JTabbedPane", new FormLayoutManager( class javax.swing.JTabbedPane ) ) {
+							name: "widthPreferredTabbedPane"
+						}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+							"value": "cell 0 2"
+						} )
+						add( new FormContainer( "javax.swing.JTabbedPane", new FormLayoutManager( class javax.swing.JTabbedPane ) ) {
+							name: "widthEqualTabbedPane"
+						}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+							"value": "cell 0 3"
+						} )
+						add( new FormContainer( "javax.swing.JTabbedPane", new FormLayoutManager( class javax.swing.JTabbedPane ) ) {
+							name: "widthCompactTabbedPane"
+						}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+							"value": "cell 0 4"
+						} )
+						add( new FormComponent( "javax.swing.JLabel" ) {
+							name: "minMaxTabWidthLabel"
+							"text": "Minimum/maximum tab width"
+							"$client.FlatLaf.styleClass": "h3"
+							auxiliary() {
+								"JavaCodeGenerator.variableLocal": true
+							}
+						}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+							"value": "cell 0 5"
+						} )
+						add( new FormContainer( "javax.swing.JTabbedPane", new FormLayoutManager( class javax.swing.JTabbedPane ) ) {
+							name: "minimumTabWidthTabbedPane"
+						}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+							"value": "cell 0 6"
+						} )
+						add( new FormContainer( "javax.swing.JTabbedPane", new FormLayoutManager( class javax.swing.JTabbedPane ) ) {
+							name: "maximumTabWidthTabbedPane"
+						}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+							"value": "cell 0 7"
+						} )
+						add( new FormComponent( "javax.swing.JLabel" ) {
+							name: "tabAlignmentLabel"
+							"text": "Tab title alignment"
+							"$client.FlatLaf.styleClass": "h3"
+							auxiliary() {
+								"JavaCodeGenerator.variableLocal": true
+							}
+						}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+							"value": "cell 0 8"
+						} )
+						add( new FormContainer( "javax.swing.JPanel", new FormLayoutManager( class net.miginfocom.swing.MigLayout ) {
+							"$columnConstraints": "[grow,fill]para[fill]"
+							"$rowConstraints": "[][][][][]"
+							"$layoutConstraints": "insets 0,hidemode 3"
+						} ) {
+							name: "panel5"
+							add( new FormComponent( "javax.swing.JLabel" ) {
+								name: "tabAlignmentNoteLabel"
+								"text": "(leading/center/trailing)"
+								"enabled": false
+								"$client.FlatLaf.styleClass": "small"
+								auxiliary() {
+									"JavaCodeGenerator.variableLocal": true
+								}
+							}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+								"value": "cell 0 0"
+							} )
+							add( new FormComponent( "javax.swing.JLabel" ) {
+								name: "tabAlignmentNoteLabel2"
+								"text": "(trailing)"
+								"enabled": false
+								"$client.FlatLaf.styleClass": "small"
+								auxiliary() {
+									"JavaCodeGenerator.variableLocal": true
+								}
+							}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+								"value": "cell 1 0,alignx right,growx 0"
+							} )
+							add( new FormContainer( "javax.swing.JTabbedPane", new FormLayoutManager( class javax.swing.JTabbedPane ) ) {
+								name: "tabAlignLeadingTabbedPane"
+							}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+								"value": "cell 0 1"
+							} )
+							add( new FormContainer( "javax.swing.JTabbedPane", new FormLayoutManager( class javax.swing.JTabbedPane ) ) {
+								name: "tabAlignVerticalTabbedPane"
+								"tabPlacement": 2
+							}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+								"value": "cell 1 1 1 4,growy"
+							} )
+							add( new FormContainer( "javax.swing.JTabbedPane", new FormLayoutManager( class javax.swing.JTabbedPane ) ) {
+								name: "tabAlignCenterTabbedPane"
+							}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+								"value": "cell 0 2"
+							} )
+							add( new FormContainer( "javax.swing.JTabbedPane", new FormLayoutManager( class javax.swing.JTabbedPane ) ) {
+								name: "tabAlignTrailingTabbedPane"
+							}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+								"value": "cell 0 3"
+							} )
+						}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+							"value": "cell 0 9"
+						} )
+					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+						"value": "cell 2 0"
 					} )
-					add( new FormComponent( "javax.swing.JToggleButton" ) {
-						name: "rightPlacementButton"
-						"text": "right"
-						"$buttonGroup": new FormReference( "tabPlacementButtonGroup" )
-						"$client.FlatLaf.styleClass": "small"
-						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "tabPlacementChanged", false ) )
-					} )
-					add( new FormComponent( "javax.swing.JToolBar$Separator" ) {
-						name: "separator1"
-					} )
-					add( new FormComponent( "javax.swing.JToggleButton" ) {
-						name: "scrollButton"
-						"text": "scroll"
-						"$client.FlatLaf.styleClass": "small"
-						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "scrollChanged", false ) )
-					} )
-					add( new FormComponent( "javax.swing.JToggleButton" ) {
-						name: "borderButton"
-						"text": "border"
-						"$client.FlatLaf.styleClass": "small"
-						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "borderChanged", false ) )
-					} )
-				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-					"value": "cell 0 0,alignx right,growx 0"
-				} )
-				add( new FormContainer( "javax.swing.JTabbedPane", new FormLayoutManager( class javax.swing.JTabbedPane ) ) {
-					name: "tabPlacementTabbedPane"
-				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-					"value": "cell 0 1,width 300:300,height 100:100"
-				} )
-				add( new FormComponent( "javax.swing.JLabel" ) {
-					name: "tabLayoutLabel"
-					"text": "Tab layout"
-					"$client.FlatLaf.styleClass": "h3"
-					auxiliary() {
-						"JavaCodeGenerator.variableLocal": true
-					}
-				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-					"value": "cell 0 2"
-				} )
-				add( new FormContainer( "javax.swing.JToolBar", new FormLayoutManager( class javax.swing.JToolBar ) ) {
-					name: "tabLayoutToolBar"
-					"floatable": false
-					"border": &EmptyBorder0 new javax.swing.border.EmptyBorder( 0, 0, 0, 0 )
-					add( new FormComponent( "javax.swing.JToggleButton" ) {
-						name: "scrollTabLayoutButton"
-						"text": "scroll"
-						"$buttonGroup": new FormReference( "tabLayoutButtonGroup" )
-						"selected": true
-						"$client.FlatLaf.styleClass": "small"
-						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "tabLayoutChanged", false ) )
-					} )
-					add( new FormComponent( "javax.swing.JToggleButton" ) {
-						name: "wrapTabLayoutButton"
-						"text": "wrap"
-						"$buttonGroup": new FormReference( "tabLayoutButtonGroup" )
-						"$client.FlatLaf.styleClass": "small"
-						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "tabLayoutChanged", false ) )
-					} )
-				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-					"value": "cell 0 2,alignx right,growx 0"
-				} )
-				add( new FormComponent( "javax.swing.JLabel" ) {
-					name: "scrollLayoutNoteLabel"
-					"text": "(use mouse wheel to scroll; arrow button shows hidden tabs)"
-					"enabled": false
-					"$client.FlatLaf.styleClass": "small"
-				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-					"value": "cell 0 3"
-				} )
-				add( new FormComponent( "javax.swing.JLabel" ) {
-					name: "wrapLayoutNoteLabel"
-					"text": "(probably better to use scroll layout?)"
-					"enabled": false
-					"$client.FlatLaf.styleClass": "small"
-				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-					"value": "cell 0 3"
-				} )
-				add( new FormContainer( "javax.swing.JTabbedPane", new FormLayoutManager( class javax.swing.JTabbedPane ) ) {
-					name: "scrollLayoutTabbedPane"
-				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-					"value": "cell 0 4"
-				} )
-				add( new FormContainer( "javax.swing.JTabbedPane", new FormLayoutManager( class javax.swing.JTabbedPane ) ) {
-					name: "wrapLayoutTabbedPane"
-				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-					"value": "cell 0 4,width 100:100,height pref*2px"
-				} )
-				add( new FormComponent( "javax.swing.JLabel" ) {
-					name: "closableTabsLabel"
-					"text": "Closable tabs"
-					"$client.FlatLaf.styleClass": "h3"
-					auxiliary() {
-						"JavaCodeGenerator.variableLocal": true
-					}
-				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-					"value": "cell 0 5"
-				} )
-				add( new FormContainer( "javax.swing.JToolBar", new FormLayoutManager( class javax.swing.JToolBar ) ) {
-					name: "closableTabsToolBar"
-					"floatable": false
-					"border": new javax.swing.border.EmptyBorder( 0, 0, 0, 0 )
-					add( new FormComponent( "javax.swing.JToggleButton" ) {
-						name: "squareCloseButton"
-						"text": "square"
-						"$buttonGroup": new FormReference( "closableTabsButtonGroup" )
-						"selected": true
-						"$client.FlatLaf.styleClass": "small"
-						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "closeButtonStyleChanged", false ) )
-					} )
-					add( new FormComponent( "javax.swing.JToggleButton" ) {
-						name: "circleCloseButton"
-						"text": "circle"
-						"$buttonGroup": new FormReference( "closableTabsButtonGroup" )
-						"$client.FlatLaf.styleClass": "small"
-						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "closeButtonStyleChanged", false ) )
-					} )
-					add( new FormComponent( "javax.swing.JToggleButton" ) {
-						name: "redCrossCloseButton"
-						"text": "red cross"
-						"$buttonGroup": new FormReference( "closableTabsButtonGroup" )
-						"$client.FlatLaf.styleClass": "small"
-						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "closeButtonStyleChanged", false ) )
-					} )
-				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-					"value": "cell 0 5,alignx right,growx 0"
-				} )
-				add( new FormContainer( "javax.swing.JTabbedPane", new FormLayoutManager( class javax.swing.JTabbedPane ) ) {
-					name: "closableTabsTabbedPane"
-				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-					"value": "cell 0 6"
-				} )
-				add( new FormComponent( "javax.swing.JLabel" ) {
-					name: "tabAreaComponentsLabel"
-					"text": "Custom tab area components"
-					"$client.FlatLaf.styleClass": "h3"
-					auxiliary() {
-						"JavaCodeGenerator.variableLocal": true
-					}
-				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-					"value": "cell 0 7"
-				} )
-				add( new FormContainer( "javax.swing.JToolBar", new FormLayoutManager( class javax.swing.JToolBar ) ) {
-					name: "tabAreaComponentsToolBar"
-					"floatable": false
-					"border": new javax.swing.border.EmptyBorder( 0, 0, 0, 0 )
-					add( new FormComponent( "javax.swing.JToggleButton" ) {
-						name: "leadingComponentButton"
-						"text": "leading"
-						"selected": true
-						"$client.FlatLaf.styleClass": "small"
-						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "customComponentsChanged", false ) )
-					} )
-					add( new FormComponent( "javax.swing.JToggleButton" ) {
-						name: "trailingComponentButton"
-						"text": "trailing"
-						"selected": true
-						"$client.FlatLaf.styleClass": "small"
-						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "customComponentsChanged", false ) )
-					} )
-				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-					"value": "cell 0 7,alignx right,growx 0"
-				} )
-				add( new FormContainer( "javax.swing.JTabbedPane", new FormLayoutManager( class javax.swing.JTabbedPane ) ) {
-					name: "customComponentsTabbedPane"
-				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-					"value": "cell 0 8"
 				} )
 			}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
 				"value": "cell 0 0"
 			} )
-			add( new FormContainer( "javax.swing.JPanel", new FormLayoutManager( class net.miginfocom.swing.MigLayout ) {
-				"$layoutConstraints": "insets 0,hidemode 3"
-				"$columnConstraints": "[grow,fill]"
-				"$rowConstraints": "[]0[][fill][center][center][center]para[center]0[][center][center][center][]"
-			} ) {
-				name: "panel2"
-				auxiliary() {
-					"JavaCodeGenerator.variableLocal": true
-				}
-				add( new FormComponent( "javax.swing.JLabel" ) {
-					name: "tabIconPlacementLabel"
-					"text": "Tab icon placement"
-					"$client.FlatLaf.styleClass": "h3"
-					auxiliary() {
-						"JavaCodeGenerator.variableLocal": true
-					}
-				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-					"value": "cell 0 0"
-				} )
-				add( new FormComponent( "javax.swing.JLabel" ) {
-					name: "tabIconPlacementNodeLabel"
-					"text": "(top/bottom/leading/trailing)"
-					"enabled": false
-					"$client.FlatLaf.styleClass": "small"
-					auxiliary() {
-						"JavaCodeGenerator.variableLocal": true
-					}
-				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-					"value": "cell 0 1"
-				} )
-				add( new FormContainer( "javax.swing.JTabbedPane", new FormLayoutManager( class javax.swing.JTabbedPane ) ) {
-					name: "iconTopTabbedPane"
-				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-					"value": "cell 0 2"
-				} )
-				add( new FormContainer( "javax.swing.JTabbedPane", new FormLayoutManager( class javax.swing.JTabbedPane ) ) {
-					name: "iconBottomTabbedPane"
-				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-					"value": "cell 0 3"
-				} )
-				add( new FormContainer( "javax.swing.JTabbedPane", new FormLayoutManager( class javax.swing.JTabbedPane ) ) {
-					name: "iconLeadingTabbedPane"
-				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-					"value": "cell 0 4"
-				} )
-				add( new FormContainer( "javax.swing.JTabbedPane", new FormLayoutManager( class javax.swing.JTabbedPane ) ) {
-					name: "iconTrailingTabbedPane"
-				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-					"value": "cell 0 5"
-				} )
-				add( new FormComponent( "javax.swing.JLabel" ) {
-					name: "tabAreaAlignmentLabel"
-					"text": "Tab area alignment"
-					"$client.FlatLaf.styleClass": "h3"
-					auxiliary() {
-						"JavaCodeGenerator.variableLocal": true
-					}
-				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-					"value": "cell 0 6"
-				} )
-				add( new FormComponent( "javax.swing.JLabel" ) {
-					name: "tabAreaAlignmentNoteLabel"
-					"text": "(leading/center/trailing/fill)"
-					"enabled": false
-					"$client.FlatLaf.styleClass": "small"
-					auxiliary() {
-						"JavaCodeGenerator.variableLocal": true
-					}
-				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-					"value": "cell 0 7"
-				} )
-				add( new FormContainer( "javax.swing.JTabbedPane", new FormLayoutManager( class javax.swing.JTabbedPane ) ) {
-					name: "alignLeadingTabbedPane"
-				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-					"value": "cell 0 8"
-				} )
-				add( new FormContainer( "javax.swing.JTabbedPane", new FormLayoutManager( class javax.swing.JTabbedPane ) ) {
-					name: "alignCenterTabbedPane"
-				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-					"value": "cell 0 9"
-				} )
-				add( new FormContainer( "javax.swing.JTabbedPane", new FormLayoutManager( class javax.swing.JTabbedPane ) ) {
-					name: "alignTrailingTabbedPane"
-				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-					"value": "cell 0 10"
-				} )
-				add( new FormContainer( "javax.swing.JTabbedPane", new FormLayoutManager( class javax.swing.JTabbedPane ) ) {
-					name: "alignFillTabbedPane"
-				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-					"value": "cell 0 11"
-				} )
-			}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-				"value": "cell 1 0,growy"
-			} )
-			add( new FormContainer( "javax.swing.JPanel", new FormLayoutManager( class net.miginfocom.swing.MigLayout ) {
-				"$layoutConstraints": "insets 0,hidemode 3"
-				"$columnConstraints": "[grow,fill]"
-				"$rowConstraints": "[]0[][][][]para[][][]para[]0[]"
-			} ) {
-				name: "panel3"
-				auxiliary() {
-					"JavaCodeGenerator.variableLocal": true
-				}
-				add( new FormComponent( "javax.swing.JLabel" ) {
-					name: "tabWidthModeLabel"
-					"text": "Tab width mode"
-					"$client.FlatLaf.styleClass": "h3"
-					auxiliary() {
-						"JavaCodeGenerator.variableLocal": true
-					}
-				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-					"value": "cell 0 0"
-				} )
-				add( new FormComponent( "javax.swing.JLabel" ) {
-					name: "tabWidthModeNoteLabel"
-					"text": "(preferred/equal/compact)"
-					"enabled": false
-					"$client.FlatLaf.styleClass": "small"
-					auxiliary() {
-						"JavaCodeGenerator.variableLocal": true
-					}
-				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-					"value": "cell 0 1"
-				} )
-				add( new FormContainer( "javax.swing.JTabbedPane", new FormLayoutManager( class javax.swing.JTabbedPane ) ) {
-					name: "widthPreferredTabbedPane"
-				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-					"value": "cell 0 2"
-				} )
-				add( new FormContainer( "javax.swing.JTabbedPane", new FormLayoutManager( class javax.swing.JTabbedPane ) ) {
-					name: "widthEqualTabbedPane"
-				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-					"value": "cell 0 3"
-				} )
-				add( new FormContainer( "javax.swing.JTabbedPane", new FormLayoutManager( class javax.swing.JTabbedPane ) ) {
-					name: "widthCompactTabbedPane"
-				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-					"value": "cell 0 4"
-				} )
-				add( new FormComponent( "javax.swing.JLabel" ) {
-					name: "minMaxTabWidthLabel"
-					"text": "Minimum/maximum tab width"
-					"$client.FlatLaf.styleClass": "h3"
-					auxiliary() {
-						"JavaCodeGenerator.variableLocal": true
-					}
-				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-					"value": "cell 0 5"
-				} )
-				add( new FormContainer( "javax.swing.JTabbedPane", new FormLayoutManager( class javax.swing.JTabbedPane ) ) {
-					name: "minimumTabWidthTabbedPane"
-				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-					"value": "cell 0 6"
-				} )
-				add( new FormContainer( "javax.swing.JTabbedPane", new FormLayoutManager( class javax.swing.JTabbedPane ) ) {
-					name: "maximumTabWidthTabbedPane"
-				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-					"value": "cell 0 7"
-				} )
-				add( new FormComponent( "javax.swing.JLabel" ) {
-					name: "tabAlignmentLabel"
-					"text": "Tab title alignment"
-					"$client.FlatLaf.styleClass": "h3"
-					auxiliary() {
-						"JavaCodeGenerator.variableLocal": true
-					}
-				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-					"value": "cell 0 8"
-				} )
-				add( new FormContainer( "javax.swing.JPanel", new FormLayoutManager( class net.miginfocom.swing.MigLayout ) {
-					"$columnConstraints": "[grow,fill]para[fill]"
-					"$rowConstraints": "[][][][]"
-					"$layoutConstraints": "insets 0,hidemode 3"
-				} ) {
-					name: "panel5"
-					add( new FormComponent( "javax.swing.JLabel" ) {
-						name: "tabAlignmentNoteLabel"
-						"text": "(leading/center/trailing)"
-						"enabled": false
-						"$client.FlatLaf.styleClass": "small"
-						auxiliary() {
-							"JavaCodeGenerator.variableLocal": true
-						}
-					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-						"value": "cell 0 0"
-					} )
-					add( new FormComponent( "javax.swing.JLabel" ) {
-						name: "tabAlignmentNoteLabel2"
-						"text": "(trailing)"
-						"enabled": false
-						"$client.FlatLaf.styleClass": "small"
-						auxiliary() {
-							"JavaCodeGenerator.variableLocal": true
-						}
-					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-						"value": "cell 1 0,alignx right,growx 0"
-					} )
-					add( new FormContainer( "javax.swing.JTabbedPane", new FormLayoutManager( class javax.swing.JTabbedPane ) ) {
-						name: "tabAlignLeadingTabbedPane"
-					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-						"value": "cell 0 1"
-					} )
-					add( new FormContainer( "javax.swing.JTabbedPane", new FormLayoutManager( class javax.swing.JTabbedPane ) ) {
-						name: "tabAlignVerticalTabbedPane"
-						"tabPlacement": 2
-					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-						"value": "cell 1 1 1 3,growy"
-					} )
-					add( new FormContainer( "javax.swing.JTabbedPane", new FormLayoutManager( class javax.swing.JTabbedPane ) ) {
-						name: "tabAlignCenterTabbedPane"
-					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-						"value": "cell 0 2"
-					} )
-					add( new FormContainer( "javax.swing.JTabbedPane", new FormLayoutManager( class javax.swing.JTabbedPane ) ) {
-						name: "tabAlignTrailingTabbedPane"
-					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-						"value": "cell 0 3"
-					} )
-				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-					"value": "cell 0 9"
-				} )
-			}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-				"value": "cell 2 0"
-			} )
 			add( new FormComponent( "javax.swing.JSeparator" ) {
 				name: "separator2"
 			}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-				"value": "cell 0 1 3 1"
+				"value": "cell 0 1"
 			} )
 			add( new FormContainer( "javax.swing.JPanel", new FormLayoutManager( class net.miginfocom.swing.MigLayout ) {
-				"$layoutConstraints": "insets 0,hidemode 3"
-				"$columnConstraints": "[][fill]para[fill][fill]para[fill]"
+				"$layoutConstraints": "insets panel,hidemode 3"
+				"$columnConstraints": "[][fill]para[fill][fill]para[fill][fill]"
 				"$rowConstraints": "[][center]"
 			} ) {
 				name: "panel4"
@@ -499,48 +518,10 @@ new FormModel {
 					"value": "cell 1 0"
 				} )
 				add( new FormComponent( "javax.swing.JLabel" ) {
-					name: "scrollButtonsPlacementLabel"
-					"text": "Scroll buttons placement:"
-				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-					"value": "cell 2 0"
-				} )
-				add( new FormContainer( "javax.swing.JToolBar", new FormLayoutManager( class javax.swing.JToolBar ) ) {
-					name: "scrollButtonsPlacementToolBar"
-					"floatable": false
-					"border": #EmptyBorder0
-					add( new FormComponent( "javax.swing.JToggleButton" ) {
-						name: "scrollBothButton"
-						"text": "both"
-						"selected": true
-						"$buttonGroup": new FormReference( "scrollButtonsPlacementButtonGroup" )
-						"$client.FlatLaf.styleClass": "small"
-						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "scrollButtonsPlacementChanged", false ) )
-					} )
-					add( new FormComponent( "javax.swing.JToggleButton" ) {
-						name: "scrollTrailingButton"
-						"text": "trailing"
-						"$buttonGroup": new FormReference( "scrollButtonsPlacementButtonGroup" )
-						"$client.FlatLaf.styleClass": "small"
-						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "scrollButtonsPlacementChanged", false ) )
-					} )
-				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-					"value": "cell 3 0"
-				} )
-				add( new FormComponent( "javax.swing.JCheckBox" ) {
-					name: "showTabSeparatorsCheckBox"
-					"text": "Show tab separators"
-					auxiliary() {
-						"JavaCodeGenerator.variableLocal": false
-					}
-					addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "showTabSeparatorsChanged", false ) )
-				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-					"value": "cell 4 0"
-				} )
-				add( new FormComponent( "javax.swing.JLabel" ) {
 					name: "tabsPopupPolicyLabel"
 					"text": "Tabs popup policy:"
 				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-					"value": "cell 0 1"
+					"value": "cell 2 0"
 				} )
 				add( new FormContainer( "javax.swing.JToolBar", new FormLayoutManager( class javax.swing.JToolBar ) ) {
 					name: "tabsPopupPolicyToolBar"
@@ -560,6 +541,44 @@ new FormModel {
 						"$buttonGroup": new FormReference( "tabsPopupPolicyButtonGroup" )
 						"$client.FlatLaf.styleClass": "small"
 						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "tabsPopupPolicyChanged", false ) )
+					} )
+				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+					"value": "cell 3 0"
+				} )
+				add( new FormComponent( "javax.swing.JCheckBox" ) {
+					name: "showTabSeparatorsCheckBox"
+					"text": "Show tab separators"
+					auxiliary() {
+						"JavaCodeGenerator.variableLocal": false
+					}
+					addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "showTabSeparatorsChanged", false ) )
+				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+					"value": "cell 4 0 2 1,alignx left,growx 0"
+				} )
+				add( new FormComponent( "javax.swing.JLabel" ) {
+					name: "scrollButtonsPlacementLabel"
+					"text": "Scroll buttons placement:"
+				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+					"value": "cell 0 1"
+				} )
+				add( new FormContainer( "javax.swing.JToolBar", new FormLayoutManager( class javax.swing.JToolBar ) ) {
+					name: "scrollButtonsPlacementToolBar"
+					"floatable": false
+					"border": #EmptyBorder0
+					add( new FormComponent( "javax.swing.JToggleButton" ) {
+						name: "scrollBothButton"
+						"text": "both"
+						"selected": true
+						"$buttonGroup": new FormReference( "scrollButtonsPlacementButtonGroup" )
+						"$client.FlatLaf.styleClass": "small"
+						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "scrollButtonsPlacementChanged", false ) )
+					} )
+					add( new FormComponent( "javax.swing.JToggleButton" ) {
+						name: "scrollTrailingButton"
+						"text": "trailing"
+						"$buttonGroup": new FormReference( "scrollButtonsPlacementButtonGroup" )
+						"$client.FlatLaf.styleClass": "small"
+						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "scrollButtonsPlacementChanged", false ) )
 					} )
 				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
 					"value": "cell 1 1"
@@ -591,47 +610,94 @@ new FormModel {
 				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
 					"value": "cell 3 1"
 				} )
+				add( new FormComponent( "javax.swing.JLabel" ) {
+					name: "tabRotationLabel"
+					"text": "Tab rotation:"
+				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+					"value": "cell 4 1"
+				} )
+				add( new FormContainer( "javax.swing.JToolBar", new FormLayoutManager( class javax.swing.JToolBar ) ) {
+					name: "tabRotationToolBar"
+					"floatable": false
+					"border": #EmptyBorder0
+					add( new FormComponent( "javax.swing.JToggleButton" ) {
+						name: "rotationNoneButton"
+						"text": "none"
+						"selected": true
+						"$client.FlatLaf.styleClass": "small"
+						"$buttonGroup": new FormReference( "tabRotationButtonGroup" )
+						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "tabRotationChanged", false ) )
+					} )
+					add( new FormComponent( "javax.swing.JToggleButton" ) {
+						name: "rotationAutoButton"
+						"text": "auto"
+						"$client.FlatLaf.styleClass": "small"
+						"$buttonGroup": new FormReference( "tabRotationButtonGroup" )
+						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "tabRotationChanged", false ) )
+					} )
+					add( new FormComponent( "javax.swing.JToggleButton" ) {
+						name: "rotationLeftButton"
+						"text": "left"
+						"$client.FlatLaf.styleClass": "small"
+						"$buttonGroup": new FormReference( "tabRotationButtonGroup" )
+						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "tabRotationChanged", false ) )
+					} )
+					add( new FormComponent( "javax.swing.JToggleButton" ) {
+						name: "rotationRightButton"
+						"text": "right"
+						"$client.FlatLaf.styleClass": "small"
+						"$buttonGroup": new FormReference( "tabRotationButtonGroup" )
+						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "tabRotationChanged", false ) )
+					} )
+				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+					"value": "cell 5 1"
+				} )
 			}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-				"value": "cell 0 2 3 1"
+				"value": "cell 0 2"
 			} )
 		}, new FormLayoutConstraints( null ) {
 			"location": new java.awt.Point( 0, 0 )
-			"size": new java.awt.Dimension( 1145, 895 )
+			"size": new java.awt.Dimension( 1145, 1045 )
 		} )
 		add( new FormNonVisual( "javax.swing.ButtonGroup" ) {
 			name: "tabPlacementButtonGroup"
 		}, new FormLayoutConstraints( null ) {
-			"location": new java.awt.Point( 5, 915 )
+			"location": new java.awt.Point( 5, 1080 )
 		} )
 		add( new FormNonVisual( "javax.swing.ButtonGroup" ) {
 			name: "closableTabsButtonGroup"
 		}, new FormLayoutConstraints( null ) {
-			"location": new java.awt.Point( 5, 970 )
+			"location": new java.awt.Point( 5, 1135 )
 		} )
 		add( new FormNonVisual( "javax.swing.ButtonGroup" ) {
 			name: "tabLayoutButtonGroup"
 		}, new FormLayoutConstraints( null ) {
-			"location": new java.awt.Point( 5, 1020 )
+			"location": new java.awt.Point( 5, 1185 )
 		} )
 		add( new FormNonVisual( "javax.swing.ButtonGroup" ) {
 			name: "tabsPopupPolicyButtonGroup"
 		}, new FormLayoutConstraints( null ) {
-			"location": new java.awt.Point( 200, 915 )
+			"location": new java.awt.Point( 200, 1080 )
 		} )
 		add( new FormNonVisual( "javax.swing.ButtonGroup" ) {
 			name: "scrollButtonsPolicyButtonGroup"
 		}, new FormLayoutConstraints( null ) {
-			"location": new java.awt.Point( 200, 965 )
+			"location": new java.awt.Point( 200, 1130 )
 		} )
 		add( new FormNonVisual( "javax.swing.ButtonGroup" ) {
 			name: "scrollButtonsPlacementButtonGroup"
 		}, new FormLayoutConstraints( null ) {
-			"location": new java.awt.Point( 200, 1020 )
+			"location": new java.awt.Point( 200, 1185 )
 		} )
 		add( new FormNonVisual( "javax.swing.ButtonGroup" ) {
 			name: "tabTypeButtonGroup"
 		}, new FormLayoutConstraints( null ) {
-			"location": new java.awt.Point( 0, 1072 )
+			"location": new java.awt.Point( 0, 1235 )
+		} )
+		add( new FormNonVisual( "javax.swing.ButtonGroup" ) {
+			name: "tabRotationButtonGroup"
+		}, new FormLayoutConstraints( null ) {
+			"location": new java.awt.Point( 200, 1235 )
 		} )
 	}
 }

--- a/flatlaf-extras/src/main/java/com/formdev/flatlaf/extras/components/FlatTabbedPane.java
+++ b/flatlaf-extras/src/main/java/com/formdev/flatlaf/extras/components/FlatTabbedPane.java
@@ -502,6 +502,29 @@ public class FlatTabbedPane
 	}
 
 
+	// NOTE: enum names must be equal to allowed strings
+	/** @since 3.3 */ public enum TabRotation { none, auto, left, right }
+
+	/**
+	 * Returns how the tabs should be rotated.
+	 *
+	 * @since 3.3
+	 */
+	public TabRotation getTabRotation() {
+		return getClientPropertyEnumString( TABBED_PANE_TAB_ROTATION, TabRotation.class,
+			"TabbedPane.tabRotation", TabRotation.none );
+	}
+
+	/**
+	 * Specifies how the tabs should be rotated.
+	 *
+	 * @since 3.3
+	 */
+	public void setTabRotation( TabRotation tabRotation ) {
+		putClientPropertyEnumString( TABBED_PANE_TAB_ROTATION, tabRotation );
+	}
+
+
 	/**
 	 * Returns the tab icon placement (relative to tab title).
 	 */

--- a/flatlaf-testing/dumps/uidefaults/FlatDarkLaf_1.8.0.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatDarkLaf_1.8.0.txt
@@ -1081,6 +1081,7 @@ TabbedPane.tabAreaAlignment    leading
 TabbedPane.tabAreaInsets       0,0,0,0    javax.swing.plaf.InsetsUIResource [UI]
 TabbedPane.tabHeight           32
 TabbedPane.tabInsets           4,12,4,12    javax.swing.plaf.InsetsUIResource [UI]
+TabbedPane.tabRotation         none
 TabbedPane.tabRunOverlay       0
 TabbedPane.tabSelectionArc     0
 TabbedPane.tabSelectionHeight  3

--- a/flatlaf-testing/dumps/uidefaults/FlatLightLaf_1.8.0.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatLightLaf_1.8.0.txt
@@ -1086,6 +1086,7 @@ TabbedPane.tabAreaAlignment    leading
 TabbedPane.tabAreaInsets       0,0,0,0    javax.swing.plaf.InsetsUIResource [UI]
 TabbedPane.tabHeight           32
 TabbedPane.tabInsets           4,12,4,12    javax.swing.plaf.InsetsUIResource [UI]
+TabbedPane.tabRotation         none
 TabbedPane.tabRunOverlay       0
 TabbedPane.tabSelectionArc     0
 TabbedPane.tabSelectionHeight  3

--- a/flatlaf-testing/dumps/uidefaults/FlatMacDarkLaf_1.8.0.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatMacDarkLaf_1.8.0.txt
@@ -1091,6 +1091,7 @@ TabbedPane.tabAreaAlignment    leading
 TabbedPane.tabAreaInsets       0,0,0,0    javax.swing.plaf.InsetsUIResource [UI]
 TabbedPane.tabHeight           32
 TabbedPane.tabInsets           4,12,4,12    javax.swing.plaf.InsetsUIResource [UI]
+TabbedPane.tabRotation         none
 TabbedPane.tabRunOverlay       0
 TabbedPane.tabSelectionArc     999
 TabbedPane.tabSelectionHeight  3

--- a/flatlaf-testing/dumps/uidefaults/FlatMacLightLaf_1.8.0.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatMacLightLaf_1.8.0.txt
@@ -1095,6 +1095,7 @@ TabbedPane.tabAreaAlignment    leading
 TabbedPane.tabAreaInsets       0,0,0,0    javax.swing.plaf.InsetsUIResource [UI]
 TabbedPane.tabHeight           32
 TabbedPane.tabInsets           4,12,4,12    javax.swing.plaf.InsetsUIResource [UI]
+TabbedPane.tabRotation         none
 TabbedPane.tabRunOverlay       0
 TabbedPane.tabSelectionArc     999
 TabbedPane.tabSelectionHeight  3

--- a/flatlaf-testing/dumps/uidefaults/FlatTestLaf_1.8.0.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatTestLaf_1.8.0.txt
@@ -1116,6 +1116,7 @@ TabbedPane.tabAreaAlignment    leading
 TabbedPane.tabAreaInsets       0,0,0,0    javax.swing.plaf.InsetsUIResource [UI]
 TabbedPane.tabHeight           32
 TabbedPane.tabInsets           4,12,4,12    javax.swing.plaf.InsetsUIResource [UI]
+TabbedPane.tabRotation         none
 TabbedPane.tabRunOverlay       0
 TabbedPane.tabSelectionArc     0
 TabbedPane.tabSelectionHeight  3

--- a/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatContainerTest.java
+++ b/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatContainerTest.java
@@ -32,6 +32,7 @@ import com.formdev.flatlaf.extras.components.FlatTabbedPane.*;
 import com.formdev.flatlaf.extras.components.FlatTriStateCheckBox;
 import com.formdev.flatlaf.icons.FlatInternalFrameCloseIcon;
 import com.formdev.flatlaf.util.ScaledImageIcon;
+import com.jgoodies.forms.factories.CC;
 import com.jgoodies.forms.layout.*;
 import net.miginfocom.swing.*;
 
@@ -62,6 +63,7 @@ public class FlatContainerTest
 		tabAreaAlignmentField.init( TabAreaAlignment.class, true );
 		tabAlignmentField.init( TabAlignment.class, true );
 		tabWidthModeField.init( TabWidthMode.class, true );
+		tabRotationField.init( TabRotation.class, true );
 
 		tabCountChanged();
 
@@ -72,6 +74,18 @@ public class FlatContainerTest
 
 		tabScrollCheckBox.setSelected( true );
 		tabScrollChanged();
+	}
+
+	private void showOnlyOne() {
+		boolean showOnlyOne = showOnlyOneCheckBox.isSelected();
+
+		tabbedPane2.setVisible( !showOnlyOne );
+		tabbedPane3.setVisible( !showOnlyOne );
+		tabbedPane4.setVisible( !showOnlyOne );
+
+		int span = showOnlyOne ? 3 : 1;
+		FormLayout formLayout = (FormLayout) tabbedPane1.getParent().getLayout();
+		formLayout.setConstraints( tabbedPane1, CC.xywh( 1, 7, span, span ) );
 	}
 
 	private void tabScrollChanged() {
@@ -314,6 +328,12 @@ public class FlatContainerTest
 			tabbedPane.setTabWidthMode( value );
 	}
 
+	private void tabRotationChanged() {
+		TabRotation value = tabRotationField.getSelectedValue();
+		for( FlatTabbedPane tabbedPane : allTabbedPanes )
+			tabbedPane.setTabRotation( value );
+	}
+
 	private void tabTypeChanged() {
 		TabType value = tabTypeComboBox.getSelectedValue();
 		for( FlatTabbedPane tabbedPane : allTabbedPanes )
@@ -509,6 +529,7 @@ public class FlatContainerTest
 		JPanel panel13 = new JPanel();
 		JLabel label4 = new JLabel();
 		JLabel tabbedPaneLabel = new JLabel();
+		showOnlyOneCheckBox = new JCheckBox();
 		tabbedPane1 = new FlatTabbedPane();
 		tabbedPane3 = new FlatTabbedPane();
 		tabbedPane2 = new FlatTabbedPane();
@@ -520,19 +541,19 @@ public class FlatContainerTest
 		customTabsCheckBox = new JCheckBox();
 		htmlTabsCheckBox = new JCheckBox();
 		multiLineTabsCheckBox = new JCheckBox();
+		JLabel tabPlacementLabel = new JLabel();
+		tabPlacementField = new FlatTestEnumSelector<>();
+		tabBackForegroundCheckBox = new JCheckBox();
 		JLabel tabsPopupPolicyLabel = new JLabel();
 		tabsPopupPolicyField = new FlatTestEnumSelector<>();
-		tabBackForegroundCheckBox = new JCheckBox();
-		JLabel scrollButtonsPolicyLabel = new JLabel();
-		scrollButtonsPolicyField = new FlatTestEnumSelector<>();
 		tabIconsCheckBox = new JCheckBox();
 		tabIconSizeSpinner = new JSpinner();
 		iconPlacementField = new FlatTestEnumSelector<>();
+		JLabel scrollButtonsPolicyLabel = new JLabel();
+		scrollButtonsPolicyField = new FlatTestEnumSelector<>();
+		tabsClosableCheckBox = new JCheckBox();
 		JLabel scrollButtonsPlacementLabel = new JLabel();
 		scrollButtonsPlacementField = new FlatTestEnumSelector<>();
-		tabsClosableCheckBox = new JCheckBox();
-		JLabel tabPlacementLabel = new JLabel();
-		tabPlacementField = new FlatTestEnumSelector<>();
 		secondTabClosableCheckBox = new FlatTriStateCheckBox();
 		JLabel tabAreaAlignmentLabel = new JLabel();
 		tabAreaAlignmentField = new FlatTestEnumSelector<>();
@@ -540,6 +561,8 @@ public class FlatContainerTest
 		tabWidthModeField = new FlatTestEnumSelector<>();
 		JLabel tabAlignmentLabel = new JLabel();
 		tabAlignmentField = new FlatTestEnumSelector<>();
+		JLabel tabRotationLabel = new JLabel();
+		tabRotationField = new FlatTestEnumSelector<>();
 		JLabel tabTypeLabel = new JLabel();
 		tabTypeComboBox = new FlatTestEnumSelector<>();
 		leadingComponentCheckBox = new JCheckBox();
@@ -636,6 +659,12 @@ public class FlatContainerTest
 			//---- tabbedPaneLabel ----
 			tabbedPaneLabel.setText("JTabbedPane:");
 			panel9.add(tabbedPaneLabel, cc.xy(1, 5));
+
+			//---- showOnlyOneCheckBox ----
+			showOnlyOneCheckBox.setText("show only one tabbed pane");
+			showOnlyOneCheckBox.setMnemonic('W');
+			showOnlyOneCheckBox.addActionListener(e -> showOnlyOne());
+			panel9.add(showOnlyOneCheckBox, cc.xy(3, 5, CellConstraints.RIGHT, CellConstraints.DEFAULT));
 			panel9.add(tabbedPane1, cc.xy(1, 7));
 
 			//======== tabbedPane3 ========
@@ -713,26 +742,26 @@ public class FlatContainerTest
 				multiLineTabsCheckBox.addActionListener(e -> htmlTabsChanged());
 				tabbedPaneControlPanel.add(multiLineTabsCheckBox, "cell 2 0 2 1");
 
-				//---- tabsPopupPolicyLabel ----
-				tabsPopupPolicyLabel.setText("Tabs popup policy:");
-				tabbedPaneControlPanel.add(tabsPopupPolicyLabel, "cell 0 1");
+				//---- tabPlacementLabel ----
+				tabPlacementLabel.setText("Tab placement:");
+				tabbedPaneControlPanel.add(tabPlacementLabel, "cell 0 1");
 
-				//---- tabsPopupPolicyField ----
-				tabsPopupPolicyField.addActionListener(e -> tabsPopupPolicyChanged());
-				tabbedPaneControlPanel.add(tabsPopupPolicyField, "cell 1 1");
+				//---- tabPlacementField ----
+				tabPlacementField.addActionListener(e -> tabPlacementChanged());
+				tabbedPaneControlPanel.add(tabPlacementField, "cell 1 1");
 
 				//---- tabBackForegroundCheckBox ----
 				tabBackForegroundCheckBox.setText("Tab back/foreground");
 				tabBackForegroundCheckBox.addActionListener(e -> tabBackForegroundChanged());
 				tabbedPaneControlPanel.add(tabBackForegroundCheckBox, "cell 2 1 2 1");
 
-				//---- scrollButtonsPolicyLabel ----
-				scrollButtonsPolicyLabel.setText("Scroll buttons policy:");
-				tabbedPaneControlPanel.add(scrollButtonsPolicyLabel, "cell 0 2");
+				//---- tabsPopupPolicyLabel ----
+				tabsPopupPolicyLabel.setText("Tabs popup policy:");
+				tabbedPaneControlPanel.add(tabsPopupPolicyLabel, "cell 0 2");
 
-				//---- scrollButtonsPolicyField ----
-				scrollButtonsPolicyField.addActionListener(e -> scrollButtonsPolicyChanged());
-				tabbedPaneControlPanel.add(scrollButtonsPolicyField, "cell 1 2");
+				//---- tabsPopupPolicyField ----
+				tabsPopupPolicyField.addActionListener(e -> tabsPopupPolicyChanged());
+				tabbedPaneControlPanel.add(tabsPopupPolicyField, "cell 1 2");
 
 				//---- tabIconsCheckBox ----
 				tabIconsCheckBox.setText("Tab icons");
@@ -750,26 +779,26 @@ public class FlatContainerTest
 				iconPlacementField.addActionListener(e -> iconPlacementChanged());
 				tabbedPaneControlPanel.add(iconPlacementField, "cell 2 2 2 1");
 
-				//---- scrollButtonsPlacementLabel ----
-				scrollButtonsPlacementLabel.setText("Scroll buttons placement:");
-				tabbedPaneControlPanel.add(scrollButtonsPlacementLabel, "cell 0 3");
+				//---- scrollButtonsPolicyLabel ----
+				scrollButtonsPolicyLabel.setText("Scroll buttons policy:");
+				tabbedPaneControlPanel.add(scrollButtonsPolicyLabel, "cell 0 3");
 
-				//---- scrollButtonsPlacementField ----
-				scrollButtonsPlacementField.addActionListener(e -> scrollButtonsPlacementChanged());
-				tabbedPaneControlPanel.add(scrollButtonsPlacementField, "cell 1 3");
+				//---- scrollButtonsPolicyField ----
+				scrollButtonsPolicyField.addActionListener(e -> scrollButtonsPolicyChanged());
+				tabbedPaneControlPanel.add(scrollButtonsPolicyField, "cell 1 3");
 
 				//---- tabsClosableCheckBox ----
 				tabsClosableCheckBox.setText("Tabs closable");
 				tabsClosableCheckBox.addActionListener(e -> tabsClosableChanged());
 				tabbedPaneControlPanel.add(tabsClosableCheckBox, "cell 2 3 2 1");
 
-				//---- tabPlacementLabel ----
-				tabPlacementLabel.setText("Tab placement:");
-				tabbedPaneControlPanel.add(tabPlacementLabel, "cell 0 4");
+				//---- scrollButtonsPlacementLabel ----
+				scrollButtonsPlacementLabel.setText("Scroll buttons placement:");
+				tabbedPaneControlPanel.add(scrollButtonsPlacementLabel, "cell 0 4");
 
-				//---- tabPlacementField ----
-				tabPlacementField.addActionListener(e -> tabPlacementChanged());
-				tabbedPaneControlPanel.add(tabPlacementField, "cell 1 4");
+				//---- scrollButtonsPlacementField ----
+				scrollButtonsPlacementField.addActionListener(e -> scrollButtonsPlacementChanged());
+				tabbedPaneControlPanel.add(scrollButtonsPlacementField, "cell 1 4");
 
 				//---- secondTabClosableCheckBox ----
 				secondTabClosableCheckBox.setText("Second Tab closable");
@@ -799,6 +828,14 @@ public class FlatContainerTest
 				//---- tabAlignmentField ----
 				tabAlignmentField.addActionListener(e -> tabAlignmentChanged());
 				tabbedPaneControlPanel.add(tabAlignmentField, "cell 1 6");
+
+				//---- tabRotationLabel ----
+				tabRotationLabel.setText("Tab rotation:");
+				tabbedPaneControlPanel.add(tabRotationLabel, "cell 2 6");
+
+				//---- tabRotationField ----
+				tabRotationField.addActionListener(e -> tabRotationChanged());
+				tabbedPaneControlPanel.add(tabRotationField, "cell 3 6");
 
 				//---- tabTypeLabel ----
 				tabTypeLabel.setText("Tab type:");
@@ -892,6 +929,7 @@ public class FlatContainerTest
 	}
 
 	// JFormDesigner - Variables declaration - DO NOT MODIFY  //GEN-BEGIN:variables
+	private JCheckBox showOnlyOneCheckBox;
 	private FlatTabbedPane tabbedPane1;
 	private FlatTabbedPane tabbedPane3;
 	private FlatTabbedPane tabbedPane2;
@@ -901,19 +939,20 @@ public class FlatContainerTest
 	private JCheckBox customTabsCheckBox;
 	private JCheckBox htmlTabsCheckBox;
 	private JCheckBox multiLineTabsCheckBox;
-	private FlatTestEnumSelector<TabsPopupPolicy> tabsPopupPolicyField;
+	private FlatTestEnumSelector<TabPlacement> tabPlacementField;
 	private JCheckBox tabBackForegroundCheckBox;
-	private FlatTestEnumSelector<ScrollButtonsPolicy> scrollButtonsPolicyField;
+	private FlatTestEnumSelector<TabsPopupPolicy> tabsPopupPolicyField;
 	private JCheckBox tabIconsCheckBox;
 	private JSpinner tabIconSizeSpinner;
 	private FlatTestEnumSelector<TabIconPlacement> iconPlacementField;
-	private FlatTestEnumSelector<ScrollButtonsPlacement> scrollButtonsPlacementField;
+	private FlatTestEnumSelector<ScrollButtonsPolicy> scrollButtonsPolicyField;
 	private JCheckBox tabsClosableCheckBox;
-	private FlatTestEnumSelector<TabPlacement> tabPlacementField;
+	private FlatTestEnumSelector<ScrollButtonsPlacement> scrollButtonsPlacementField;
 	private FlatTriStateCheckBox secondTabClosableCheckBox;
 	private FlatTestEnumSelector<TabAreaAlignment> tabAreaAlignmentField;
 	private FlatTestEnumSelector<TabWidthMode> tabWidthModeField;
 	private FlatTestEnumSelector<TabAlignment> tabAlignmentField;
+	private FlatTestEnumSelector<TabRotation> tabRotationField;
 	private FlatTestEnumSelector<TabType> tabTypeComboBox;
 	private JCheckBox leadingComponentCheckBox;
 	private JCheckBox customBorderCheckBox;

--- a/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatContainerTest.jfd
+++ b/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatContainerTest.jfd
@@ -91,13 +91,25 @@ new FormModel {
 					"gridX": 1
 					"gridY": 5
 				} )
+				add( new FormComponent( "javax.swing.JCheckBox" ) {
+					name: "showOnlyOneCheckBox"
+					"text": "show only one tabbed pane"
+					"mnemonic": 87
+					auxiliary() {
+						"JavaCodeGenerator.variableLocal": false
+					}
+					addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "showOnlyOne", false ) )
+				}, new FormLayoutConstraints( class com.jgoodies.forms.layout.CellConstraints ) {
+					"gridX": 3
+					"gridY": 5
+					"hAlign": sfield com.jgoodies.forms.layout.CellConstraints RIGHT
+				} )
 				add( new FormContainer( "com.formdev.flatlaf.extras.components.FlatTabbedPane", new FormLayoutManager( class javax.swing.JTabbedPane ) ) {
 					name: "tabbedPane1"
 					auxiliary() {
 						"JavaCodeGenerator.variableLocal": false
 					}
 				}, new FormLayoutConstraints( class com.jgoodies.forms.layout.CellConstraints ) {
-					"gridX": 1
 					"gridY": 7
 				} )
 				add( new FormContainer( "com.formdev.flatlaf.extras.components.FlatTabbedPane", new FormLayoutManager( class javax.swing.JTabbedPane ) ) {
@@ -198,18 +210,18 @@ new FormModel {
 						"value": "cell 2 0 2 1"
 					} )
 					add( new FormComponent( "javax.swing.JLabel" ) {
-						name: "tabsPopupPolicyLabel"
-						"text": "Tabs popup policy:"
+						name: "tabPlacementLabel"
+						"text": "Tab placement:"
 					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
 						"value": "cell 0 1"
 					} )
 					add( new FormComponent( "com.formdev.flatlaf.testing.FlatTestEnumSelector" ) {
-						name: "tabsPopupPolicyField"
+						name: "tabPlacementField"
 						auxiliary() {
 							"JavaCodeGenerator.variableLocal": false
-							"JavaCodeGenerator.typeParameters": "TabsPopupPolicy"
+							"JavaCodeGenerator.typeParameters": "TabPlacement"
 						}
-						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "tabsPopupPolicyChanged", false ) )
+						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "tabPlacementChanged", false ) )
 					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
 						"value": "cell 1 1"
 					} )
@@ -224,18 +236,18 @@ new FormModel {
 						"value": "cell 2 1 2 1"
 					} )
 					add( new FormComponent( "javax.swing.JLabel" ) {
-						name: "scrollButtonsPolicyLabel"
-						"text": "Scroll buttons policy:"
+						name: "tabsPopupPolicyLabel"
+						"text": "Tabs popup policy:"
 					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
 						"value": "cell 0 2"
 					} )
 					add( new FormComponent( "com.formdev.flatlaf.testing.FlatTestEnumSelector" ) {
-						name: "scrollButtonsPolicyField"
+						name: "tabsPopupPolicyField"
 						auxiliary() {
 							"JavaCodeGenerator.variableLocal": false
-							"JavaCodeGenerator.typeParameters": "ScrollButtonsPolicy"
+							"JavaCodeGenerator.typeParameters": "TabsPopupPolicy"
 						}
-						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "scrollButtonsPolicyChanged", false ) )
+						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "tabsPopupPolicyChanged", false ) )
 					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
 						"value": "cell 1 2"
 					} )
@@ -280,18 +292,18 @@ new FormModel {
 						"value": "cell 2 2 2 1"
 					} )
 					add( new FormComponent( "javax.swing.JLabel" ) {
-						name: "scrollButtonsPlacementLabel"
-						"text": "Scroll buttons placement:"
+						name: "scrollButtonsPolicyLabel"
+						"text": "Scroll buttons policy:"
 					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
 						"value": "cell 0 3"
 					} )
 					add( new FormComponent( "com.formdev.flatlaf.testing.FlatTestEnumSelector" ) {
-						name: "scrollButtonsPlacementField"
+						name: "scrollButtonsPolicyField"
 						auxiliary() {
 							"JavaCodeGenerator.variableLocal": false
-							"JavaCodeGenerator.typeParameters": "ScrollButtonsPlacement"
+							"JavaCodeGenerator.typeParameters": "ScrollButtonsPolicy"
 						}
-						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "scrollButtonsPlacementChanged", false ) )
+						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "scrollButtonsPolicyChanged", false ) )
 					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
 						"value": "cell 1 3"
 					} )
@@ -306,18 +318,18 @@ new FormModel {
 						"value": "cell 2 3 2 1"
 					} )
 					add( new FormComponent( "javax.swing.JLabel" ) {
-						name: "tabPlacementLabel"
-						"text": "Tab placement:"
+						name: "scrollButtonsPlacementLabel"
+						"text": "Scroll buttons placement:"
 					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
 						"value": "cell 0 4"
 					} )
 					add( new FormComponent( "com.formdev.flatlaf.testing.FlatTestEnumSelector" ) {
-						name: "tabPlacementField"
+						name: "scrollButtonsPlacementField"
 						auxiliary() {
 							"JavaCodeGenerator.variableLocal": false
-							"JavaCodeGenerator.typeParameters": "TabPlacement"
+							"JavaCodeGenerator.typeParameters": "ScrollButtonsPlacement"
 						}
-						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "tabPlacementChanged", false ) )
+						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "scrollButtonsPlacementChanged", false ) )
 					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
 						"value": "cell 1 4"
 					} )
@@ -378,6 +390,22 @@ new FormModel {
 						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "tabAlignmentChanged", false ) )
 					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
 						"value": "cell 1 6"
+					} )
+					add( new FormComponent( "javax.swing.JLabel" ) {
+						name: "tabRotationLabel"
+						"text": "Tab rotation:"
+					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+						"value": "cell 2 6"
+					} )
+					add( new FormComponent( "com.formdev.flatlaf.testing.FlatTestEnumSelector" ) {
+						name: "tabRotationField"
+						auxiliary() {
+							"JavaCodeGenerator.typeParameters": "TabRotation"
+							"JavaCodeGenerator.variableLocal": false
+						}
+						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "tabRotationChanged", false ) )
+					}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+						"value": "cell 3 6"
 					} )
 					add( new FormComponent( "javax.swing.JLabel" ) {
 						name: "tabTypeLabel"

--- a/flatlaf-theme-editor/src/main/resources/com/formdev/flatlaf/themeeditor/FlatLafUIKeys.txt
+++ b/flatlaf-theme-editor/src/main/resources/com/formdev/flatlaf/themeeditor/FlatLafUIKeys.txt
@@ -881,6 +881,7 @@ TabbedPane.tabAreaAlignment
 TabbedPane.tabAreaInsets
 TabbedPane.tabHeight
 TabbedPane.tabInsets
+TabbedPane.tabRotation
 TabbedPane.tabRunOverlay
 TabbedPane.tabSelectionArc
 TabbedPane.tabSelectionHeight


### PR DESCRIPTION
This PR brings rotated/vertical tabs to TabbedPane.

![image](https://github.com/JFormDesigner/FlatLaf/assets/5604048/22dde084-f176-4f39-8fc3-f20eb1d29750) ![image](https://github.com/JFormDesigner/FlatLaf/assets/5604048/5c30fa77-fffa-47a0-8b8f-42fd9df8fc70)

![image](https://github.com/JFormDesigner/FlatLaf/assets/5604048/18d6f963-f8ee-4b3c-ae63-11c9554f565a)

There is a new UI property that controls rotation for **all** tabbed panes in application:

~~~properties
# allowed values: none, auto, left or right
TabbedPane.tabRotation = none
~~~

- `none` does not rotate (the default)
- `auto` rotates left if tab placement is left, rotates right if tab placement is right, does not rotate if tab placement is top or bottom
- `left` always rotates to the left for all tab placements
- `right` always rotates to the right for all tab placements

To rotate a **single** tabbed pane, use client property `JTabbedPane.tabRotation`:

~~~java
tabbedPane.putClientProperty( "JTabbedPane.tabRotation", "left" );
~~~