### PR TITLE
Window decorations: "full window content" mode

### DIFF
--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/FlatClientProperties.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/FlatClientProperties.java
@@ -257,18 +257,39 @@ public interface FlatClientProperties
 	String COMPONENT_FOCUS_OWNER = "JComponent.focusOwner";
 
 	/**
-	 * Specifies whether a component in an embedded menu bar should behave as caption
+	 * Specifies whether a component shown in a window title bar area should behave as caption
 	 * (left-click allows moving window, right-click shows window system menu).
-	 * The component does not receive mouse pressed/released/clicked/dragged events,
+	 * The caption component does not receive mouse pressed/released/clicked/dragged events,
 	 * but it gets mouse entered/exited/moved events.
 	 * <p>
+	 * Since 3.4, this client property also supports using a function that can check
+	 * whether a given location in the component should behave as caption.
+	 * Useful for components that do not use mouse input on whole component bounds.
+	 *
+	 * <pre>{@code
+	 * myComponent.putClientProperty( "JComponent.titleBarCaption",
+	 *     (Function<Point, Boolean>) pt -> {
+	 *         // parameter pt contains mouse location (in myComponent coordinates)
+	 *         // return true if the component is not interested in mouse input at the given location
+	 *         // return false if the component wants process mouse input at the given location
+	 *         // return null if the component children should be checked
+	 *         return ...; // check here
+	 *     } );
+	 * }</pre>
+	 * <b>Warning</b>:
+	 * <ul>
+	 *   <li>This function is invoked often when mouse is moved over window title bar area
+	 *       and should therefore return quickly.
+	 *   <li>This function is invoked on 'AWT-Windows' thread (not 'AWT-EventQueue' thread)
+	 *       while processing Windows messages.
+	 *       It <b>must not</b> change any component property or layout because this could cause a dead lock.
+	 * </ul>
+	 * <p>
 	 * <strong>Component</strong> {@link javax.swing.JComponent}<br>
-	 * <strong>Value type</strong> {@link java.lang.Boolean}
+	 * <strong>Value type</strong> {@link java.lang.Boolean} or {@link java.util.function.Function}&lt;Point, Boolean&gt;
 	 *
 	 * @since 2.5
-	 * @deprecated No longer used since FlatLaf 3.4. Retained for API compatibility.
 	 */
-	@Deprecated
 	String COMPONENT_TITLE_BAR_CAPTION = "JComponent.titleBarCaption";
 
 

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/FlatClientProperties.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/FlatClientProperties.java
@@ -266,7 +266,9 @@ public interface FlatClientProperties
 	 * <strong>Value type</strong> {@link java.lang.Boolean}
 	 *
 	 * @since 2.5
+	 * @deprecated No longer used since FlatLaf 3.4. Retained for API compatibility.
 	 */
+	@Deprecated
 	String COMPONENT_TITLE_BAR_CAPTION = "JComponent.titleBarCaption";
 
 
@@ -274,7 +276,7 @@ public interface FlatClientProperties
 
 	/**
 	 * Marks the panel as placeholder for the iconfify/maximize/close buttons
-	 * in fullWindowContent mode.
+	 * in fullWindowContent mode. See {@link #FULL_WINDOW_CONTENT}.
 	 * <p>
 	 * If fullWindowContent mode is enabled, the preferred size of the panel is equal
 	 * to the size of the iconfify/maximize/close buttons. Otherwise is is {@code 0,0}.
@@ -461,6 +463,32 @@ public interface FlatClientProperties
 	 * <strong>Value type</strong> {@link java.lang.Boolean}
 	 */
 	String MENU_BAR_EMBEDDED = "JRootPane.menuBarEmbedded";
+
+	/**
+	 * Specifies whether the content pane (and the glass pane) should be extended
+	 * into the window title bar area
+	 * (requires enabled window decorations). Default is {@code false}.
+	 * <p>
+	 * On macOS, use client property {@code apple.awt.fullWindowContent}
+	 * (see <a href="https://www.formdev.com/flatlaf/macos/#full_window_content">macOS Full window content</a>).
+	 * <p>
+	 * Setting this enables/disables full window content
+	 * for the {@code JFrame} or {@code JDialog} that contains the root pane.
+	 * <p>
+	 * If {@code true}, the content pane (and the glass pane) is extended into
+	 * the title bar area. The window icon and title are hidden.
+	 * Only the iconfify/maximize/close buttons stay visible in the upper right corner
+	 * (and overlap the content pane).
+	 * <p>
+	 * The user can left-click-and-drag on the title bar area to move the window,
+	 * except when clicking on a component that processes mouse events (e.g. buttons or menus).
+	 * <p>
+	 * <strong>Component</strong> {@link javax.swing.JRootPane}<br>
+	 * <strong>Value type</strong> {@link java.lang.Boolean}
+	 *
+	 * @since 3.4
+	 */
+	String FULL_WINDOW_CONTENT = "FlatLaf.fullWindowContent";
 
 	/**
 	 * Contains the current bounds of the iconfify/maximize/close buttons

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatNativeWindowBorder.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatNativeWindowBorder.java
@@ -219,13 +219,13 @@ public class FlatNativeWindowBorder
 	}
 
 	static void setTitleBarHeightAndHitTestSpots( Window window, int titleBarHeight,
-		Predicate<Point> hitTestCallback, Rectangle appIconBounds, Rectangle minimizeButtonBounds,
+		Predicate<Point> captionHitTestCallback, Rectangle appIconBounds, Rectangle minimizeButtonBounds,
 		Rectangle maximizeButtonBounds, Rectangle closeButtonBounds )
 	{
 		if( !isSupported() )
 			return;
 
-		nativeProvider.updateTitleBarInfo( window, titleBarHeight, hitTestCallback,
+		nativeProvider.updateTitleBarInfo( window, titleBarHeight, captionHitTestCallback,
 			appIconBounds, minimizeButtonBounds, maximizeButtonBounds, closeButtonBounds );
 	}
 
@@ -271,7 +271,7 @@ public class FlatNativeWindowBorder
 	{
 		boolean hasCustomDecoration( Window window );
 		void setHasCustomDecoration( Window window, boolean hasCustomDecoration );
-		void updateTitleBarInfo( Window window, int titleBarHeight, Predicate<Point> hitTestCallback,
+		void updateTitleBarInfo( Window window, int titleBarHeight, Predicate<Point> captionHitTestCallback,
 			Rectangle appIconBounds, Rectangle minimizeButtonBounds, Rectangle maximizeButtonBounds,
 			Rectangle closeButtonBounds );
 

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatNativeWindowBorder.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatNativeWindowBorder.java
@@ -21,11 +21,12 @@ import java.awt.Component;
 import java.awt.Container;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
+import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.Toolkit;
 import java.awt.Window;
 import java.beans.PropertyChangeListener;
-import java.util.List;
+import java.util.function.Predicate;
 import javax.swing.JDialog;
 import javax.swing.JFrame;
 import javax.swing.JRootPane;
@@ -218,13 +219,13 @@ public class FlatNativeWindowBorder
 	}
 
 	static void setTitleBarHeightAndHitTestSpots( Window window, int titleBarHeight,
-		List<Rectangle> hitTestSpots, Rectangle appIconBounds, Rectangle minimizeButtonBounds,
+		Predicate<Point> hitTestCallback, Rectangle appIconBounds, Rectangle minimizeButtonBounds,
 		Rectangle maximizeButtonBounds, Rectangle closeButtonBounds )
 	{
 		if( !isSupported() )
 			return;
 
-		nativeProvider.updateTitleBarInfo( window, titleBarHeight, hitTestSpots,
+		nativeProvider.updateTitleBarInfo( window, titleBarHeight, hitTestCallback,
 			appIconBounds, minimizeButtonBounds, maximizeButtonBounds, closeButtonBounds );
 	}
 
@@ -270,7 +271,7 @@ public class FlatNativeWindowBorder
 	{
 		boolean hasCustomDecoration( Window window );
 		void setHasCustomDecoration( Window window, boolean hasCustomDecoration );
-		void updateTitleBarInfo( Window window, int titleBarHeight, List<Rectangle> hitTestSpots,
+		void updateTitleBarInfo( Window window, int titleBarHeight, Predicate<Point> hitTestCallback,
 			Rectangle appIconBounds, Rectangle minimizeButtonBounds, Rectangle maximizeButtonBounds,
 			Rectangle closeButtonBounds );
 

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatSplitPaneUI.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatSplitPaneUI.java
@@ -84,7 +84,7 @@ import com.formdev.flatlaf.util.UIScale;
  */
 public class FlatSplitPaneUI
 	extends BasicSplitPaneUI
-	implements StyleableUI
+	implements StyleableUI, FlatTitlePane.TitleBarCaptionHitTest
 {
 	@Styleable protected String arrowType;
 	/** @since 3.3 */ @Styleable protected Color draggingColor;
@@ -225,6 +225,15 @@ public class FlatSplitPaneUI
 		// paint divider style (e.g. grip)
 		if( divider instanceof FlatSplitPaneDivider )
 			((FlatSplitPaneDivider)divider).paintStyle( g, x, y, width, height );
+	}
+
+	//---- interface FlatTitlePane.TitleBarCaptionHitTest ----
+
+	/** @since 3.4 */
+	@Override
+	public Boolean isTitleBarCaptionAt( int x, int y ) {
+		// necessary because BasicSplitPaneDivider adds some mouse listeners for dragging divider
+		return null; // check children
 	}
 
 	//---- class FlatSplitPaneDivider -----------------------------------------

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatTabbedPaneUI.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatTabbedPaneUI.java
@@ -182,7 +182,7 @@ import com.formdev.flatlaf.util.UIScale;
  */
 public class FlatTabbedPaneUI
 	extends BasicTabbedPaneUI
-	implements StyleableUI
+	implements StyleableUI, FlatTitlePane.TitleBarCaptionHitTest
 {
 	// tab type
 	/** @since 2 */ protected static final int TAB_TYPE_UNDERLINED = 0;
@@ -2298,6 +2298,17 @@ debug*/
 	private int rectsTotalHeight() {
 		int last = rects.length - 1;
 		return (rects[last].y + rects[last].height) - rects[0].y;
+	}
+
+	//---- interface FlatTitlePane.TitleBarCaptionHitTest ----
+
+	/** @since 3.4 */
+	@Override
+	public Boolean isTitleBarCaptionAt( int x, int y ) {
+		if( tabForCoordinate( tabPane, x, y ) >= 0 )
+			return false;
+
+		return null; // check children
 	}
 
 	//---- class TabCloseButton -----------------------------------------------

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatTitlePane.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatTitlePane.java
@@ -36,6 +36,7 @@ import java.awt.Rectangle;
 import java.awt.Toolkit;
 import java.awt.Window;
 import java.awt.event.ActionListener;
+import java.awt.event.ComponentAdapter;
 import java.awt.event.ComponentEvent;
 import java.awt.event.ComponentListener;
 import java.awt.event.MouseEvent;
@@ -46,7 +47,6 @@ import java.awt.event.WindowEvent;
 import java.awt.geom.AffineTransform;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import javax.accessibility.AccessibleContext;
@@ -57,7 +57,6 @@ import javax.swing.Icon;
 import javax.swing.JButton;
 import javax.swing.JComponent;
 import javax.swing.JDialog;
-import javax.swing.JInternalFrame;
 import javax.swing.JLabel;
 import javax.swing.JMenuBar;
 import javax.swing.JPanel;
@@ -98,7 +97,6 @@ import com.formdev.flatlaf.util.UIScale;
  * @uiDefault TitlePane.showIconBesideTitle					boolean
  * @uiDefault TitlePane.menuBarTitleGap						int
  * @uiDefault TitlePane.menuBarTitleMinimumGap				int
- * @uiDefault TitlePane.menuBarResizeHeight					int
  * @uiDefault TitlePane.closeIcon							Icon
  * @uiDefault TitlePane.iconifyIcon							Icon
  * @uiDefault TitlePane.maximizeIcon						Icon
@@ -109,7 +107,7 @@ import com.formdev.flatlaf.util.UIScale;
 public class FlatTitlePane
 	extends JComponent
 {
-	private static final String KEY_DEBUG_SHOW_RECTANGLES = "FlatLaf.debug.titlebar.showRectangles";
+	static final String KEY_DEBUG_SHOW_RECTANGLES = "FlatLaf.debug.titlebar.showRectangles";
 
 	/** @since 2.5 */ protected final Font titleFont;
 	protected final Color activeBackground;
@@ -131,7 +129,6 @@ public class FlatTitlePane
 	/** @since 2.4 */ protected final boolean showIconBesideTitle;
 	protected final int menuBarTitleGap;
 	/** @since 2.4 */ protected final int menuBarTitleMinimumGap;
-	/** @since 2.4 */ protected final int menuBarResizeHeight;
 
 	protected final JRootPane rootPane;
 	protected final String windowStyle;
@@ -149,6 +146,23 @@ public class FlatTitlePane
 	protected Window window;
 
 	private final Handler handler;
+
+	/**
+	 * This panel handles mouse events if FlatLaf window decorations are used
+	 * without native window border. E.g. on Linux.
+	 * <p>
+	 * This panel usually has same bounds as the title pane,
+	 * except if fullWindowContent mode is enabled.
+	 * <p>
+	 * This panel is not a child of the title pane.
+	 * Instead it is added by FlatRootPaneUI to the layered pane at a layer
+	 * under the title pane and under the frame content.
+	 * The separation is necessary for fullWindowContent mode, where the title pane
+	 * is layered over the frame content (for title pane buttons), but the mousePanel
+	 * needs to be layered under the frame content so that components on content pane
+	 * can receive mouse events when located in title area.
+	 */
+	final JPanel mouseLayer;
 
 	public FlatTitlePane( JRootPane rootPane ) {
 		this.rootPane = rootPane;
@@ -178,7 +192,6 @@ public class FlatTitlePane
 		showIconBesideTitle = FlatUIUtils.getSubUIBoolean( "TitlePane.showIconBesideTitle", windowStyle, false );
 		menuBarTitleGap = FlatUIUtils.getSubUIInt( "TitlePane.menuBarTitleGap", windowStyle, 40 );
 		menuBarTitleMinimumGap = FlatUIUtils.getSubUIInt( "TitlePane.menuBarTitleMinimumGap", windowStyle, 12 );
-		menuBarResizeHeight = FlatUIUtils.getSubUIInt( "TitlePane.menuBarResizeHeight", windowStyle, 4 );
 
 
 		handler = createHandler();
@@ -187,11 +200,10 @@ public class FlatTitlePane
 		addSubComponents();
 		activeChanged( true );
 
-		addMouseListener( handler );
-		addMouseMotionListener( handler );
-
-		// necessary for closing window with double-click on icon
-		iconLabel.addMouseListener( handler );
+		mouseLayer = new JPanel();
+		mouseLayer.setOpaque( false );
+		mouseLayer.addMouseListener( handler );
+		mouseLayer.addMouseMotionListener( handler );
 
 		applyComponentOrientation( rootPane.getComponentOrientation() );
 	}
@@ -234,6 +246,11 @@ public class FlatTitlePane
 		setLayout( new BorderLayout() {
 			@Override
 			public void layoutContainer( Container target ) {
+				if( isFullWindowContent() ) {
+					super.layoutContainer( target );
+					return;
+				}
+
 				// compute available bounds
 				Insets insets = target.getInsets();
 				int x = insets.left;
@@ -247,7 +264,7 @@ public class FlatTitlePane
 				int titleWidth = w - leftWidth - buttonsWidth;
 				int minTitleWidth = UIScale.scale( titleMinimumWidth );
 
-				// increase minimum width if icon is show besides the title
+				// increase minimum width if icon is shown besides the title
 				Icon icon = titleLabel.getIcon();
 				if( icon != null ) {
 					Insets iconInsets = iconLabel.getInsets();
@@ -295,6 +312,9 @@ public class FlatTitlePane
 							horizontalGlue.getWidth(), titleLabel.getHeight() );
 					}
 				}
+
+				// clear hit-test cache
+				lastHitTestTime = 0;
 			}
 		} );
 
@@ -337,6 +357,10 @@ public class FlatTitlePane
 			buttonPanel.add( maximizeButton );
 			buttonPanel.add( restoreButton );
 		}
+		buttonPanel.addComponentListener( new ComponentAdapter() {
+			@Override public void componentResized( ComponentEvent e ) { updateFullWindowContentButtonsBoundsProperty(); }
+			@Override public void componentMoved( ComponentEvent e ) { updateFullWindowContentButtonsBoundsProperty(); }
+		} );
 		buttonPanel.add( closeButton );
 	}
 
@@ -417,7 +441,9 @@ public class FlatTitlePane
 
 	/** @since 3 */
 	protected void updateVisibility() {
-		titleLabel.setVisible( clientPropertyBoolean( rootPane, TITLE_BAR_SHOW_TITLE, true ) );
+		boolean isFullWindowContent = isFullWindowContent();
+		leftPanel.setVisible( !isFullWindowContent );
+		titleLabel.setVisible( clientPropertyBoolean( rootPane, TITLE_BAR_SHOW_TITLE, true ) && !isFullWindowContent );
 		closeButton.setVisible( clientPropertyBoolean( rootPane, TITLE_BAR_SHOW_CLOSE, true ) );
 
 		if( window instanceof Frame ) {
@@ -443,7 +469,7 @@ public class FlatTitlePane
 
 		// get window images
 		List<Image> images = null;
-		if( clientPropertyBoolean( rootPane, TITLE_BAR_SHOW_ICON, defaultShowIcon ) ) {
+		if( clientPropertyBoolean( rootPane, TITLE_BAR_SHOW_ICON, defaultShowIcon ) && !isFullWindowContent() ) {
 			images = window.getIconImages();
 			if( images.isEmpty() ) {
 				// search in owners
@@ -466,6 +492,13 @@ public class FlatTitlePane
 		leftPanel.setBorder( hasIcon && !showIconBesideTitle ? null : FlatUIUtils.nonUIResource( new FlatEmptyBorder( 0, noIconLeftGap, 0, 0 ) ) );
 
 		updateNativeTitleBarHeightAndHitTestSpotsLater();
+	}
+
+	void updateFullWindowContentButtonsBoundsProperty() {
+		Rectangle bounds = isFullWindowContent()
+			? new Rectangle( SwingUtilities.convertPoint( buttonPanel, 0, 0, rootPane ), buttonPanel.getSize() )
+			: null;
+		rootPane.putClientProperty( FlatClientProperties.FULL_WINDOW_CONTENT_BUTTONS_BOUNDS, bounds );
 	}
 
 	@Override
@@ -522,6 +555,11 @@ public class FlatTitlePane
 		window.removeComponentListener( handler );
 	}
 
+	/** @since 3.4 */
+	protected boolean isFullWindowContent() {
+		return FlatRootPaneUI.isFullWindowContent( rootPane );
+	}
+
 	/**
 	 * Returns whether this title pane currently has a visible and embedded menubar.
 	 */
@@ -533,6 +571,9 @@ public class FlatTitlePane
 	 * Returns whether the menubar should be embedded into the title pane.
 	 */
 	protected boolean isMenuBarEmbedded() {
+		if( isFullWindowContent() )
+			return false;
+
 		// not storing value of "TitlePane.menuBarEmbedded" in class to allow changing at runtime
 		return FlatUIUtils.getBoolean( rootPane,
 			FlatSystemProperties.MENUBAR_EMBEDDED,
@@ -620,21 +661,45 @@ public class FlatTitlePane
 			return;
 
 		if( debugTitleBarHeight > 0 ) {
+			// title bar height is measured from window top edge
+			int y = SwingUtilities.convertPoint( window, 0, debugTitleBarHeight, this ).y;
 			g.setColor( Color.green );
-			g.drawLine( 0, debugTitleBarHeight, getWidth(), debugTitleBarHeight );
+			g.drawLine( 0, y, getWidth(), y );
 		}
-		if( debugHitTestSpots != null ) {
-			for( Rectangle r : debugHitTestSpots )
-				paintRect( g, Color.red, r );
-		}
-		paintRect( g, Color.cyan, debugCloseButtonBounds );
-		paintRect( g, Color.blue, debugAppIconBounds );
-		paintRect( g, Color.blue, debugMinimizeButtonBounds );
-		paintRect( g, Color.magenta, debugMaximizeButtonBounds );
-		paintRect( g, Color.cyan, debugCloseButtonBounds );
+
+		g.setColor( Color.red );
+		debugPaintComponentWithMouseListener( g, Color.red, rootPane.getLayeredPane(), 0, 0 );
+
+		debugPaintRect( g, Color.blue, debugAppIconBounds );
+		debugPaintRect( g, Color.blue, debugMinimizeButtonBounds );
+		debugPaintRect( g, Color.magenta, debugMaximizeButtonBounds );
+		debugPaintRect( g, Color.cyan, debugCloseButtonBounds );
 	}
 
-	private void paintRect( Graphics g, Color color, Rectangle r ) {
+	private void debugPaintComponentWithMouseListener( Graphics g, Color color, Component c, int x, int y ) {
+		if( !c.isDisplayable() || !c.isVisible() || c == mouseLayer ||
+			c == iconifyButton || c == maximizeButton || c == restoreButton || c == closeButton )
+		  return;
+
+		if( c.getMouseListeners().length > 0 ||
+			c.getMouseMotionListeners().length > 0 ||
+			c.getMouseWheelListeners().length > 0 )
+		{
+			g.drawRect( x, y, c.getWidth(), c.getHeight() );
+			return;
+		}
+
+		if( c instanceof Container ) {
+			Rectangle titlePaneBoundsOnWindow = SwingUtilities.convertRectangle( this, new Rectangle( getSize() ), window );
+			for( Component child : ((Container)c).getComponents() ) {
+				Rectangle compBoundsOnWindow = SwingUtilities.convertRectangle( c, new Rectangle( c.getSize() ), window );
+				if( compBoundsOnWindow.intersects( titlePaneBoundsOnWindow ) )
+					debugPaintComponentWithMouseListener( g, color, child, x + child.getX(), y + child.getY() );
+			}
+		}
+	}
+
+	private void debugPaintRect( Graphics g, Color color, Rectangle r ) {
 		if( r == null )
 			return;
 
@@ -645,6 +710,9 @@ public class FlatTitlePane
 
 	@Override
 	protected void paintComponent( Graphics g ) {
+		if( isFullWindowContent() )
+			return;
+
 		// not storing value of "TitlePane.unifiedBackground" in class to allow changing at runtime
 		g.setColor( (UIManager.getBoolean( "TitlePane.unifiedBackground" ) &&
 				clientPropertyColor( rootPane, TITLE_BAR_BACKGROUND, null ) == null)
@@ -866,11 +934,14 @@ public class FlatTitlePane
 			return;
 
 		int titleBarHeight = getHeight();
+		// title bar height must be measured from window top edge
+		// (when window is maximized, window y location is e.g. -11 and window top inset is 11)
+		for( Component c = this; c != window && c != null; c = c.getParent() )
+			titleBarHeight += c.getY();
 		// slightly reduce height so that component receives mouseExit events
 		if( titleBarHeight > 0 )
 			titleBarHeight--;
 
-		List<Rectangle> hitTestSpots = new ArrayList<>();
 		Rectangle appIconBounds = null;
 
 		if( !showIconBesideTitle && iconLabel.isVisible() ) {
@@ -928,71 +999,17 @@ public class FlatTitlePane
 			}
 		}
 
-		Rectangle r = getNativeHitTestSpot( buttonPanel );
-		if( r != null )
-			hitTestSpots.add( r );
-
-		JMenuBar menuBar = rootPane.getJMenuBar();
-		if( hasVisibleEmbeddedMenuBar( menuBar ) ) {
-			r = getNativeHitTestSpot( menuBar );
-			if( r != null ) {
-				// if frame is resizable and not maximized, make menu bar hit test spot smaller at top
-				// to have a small area above the menu bar to resize the window
-				if( window instanceof Frame && ((Frame)window).isResizable() && !isWindowMaximized() ) {
-					// limit to 8, because Windows does not use a larger height
-					int resizeHeight = UIScale.scale( Math.min( menuBarResizeHeight, 8 ) );
-					r.y += resizeHeight;
-					r.height -= resizeHeight;
-				}
-
-				int count = menuBar.getComponentCount();
-				for( int i = count - 1; i >= 0; i-- ) {
-					Component c = menuBar.getComponent( i );
-					if( c instanceof Box.Filler ||
-						(c instanceof JComponent && clientPropertyBoolean( (JComponent) c, COMPONENT_TITLE_BAR_CAPTION, false ) ) )
-					{
-						// If menu bar is embedded and contains a horizontal glue or caption component,
-						// then split the hit test spot so that
-						// the glue/caption component area can be used to move the window.
-
-						Point glueLocation = SwingUtilities.convertPoint( c, 0, 0, window );
-						int x2 = glueLocation.x + c.getWidth();
-						Rectangle r2;
-						if( getComponentOrientation().isLeftToRight() ) {
-							r2 = new Rectangle( x2, r.y, (r.x + r.width) - x2, r.height );
-
-							r.width = glueLocation.x - r.x;
-						} else {
-							r2 = new Rectangle( r.x, r.y, glueLocation.x - r.x, r.height );
-
-							r.width = (r.x + r.width) - x2;
-							r.x = x2;
-						}
-						if( r2.width > 0 )
-							hitTestSpots.add( r2 );
-					}
-				}
-
-				hitTestSpots.add( r );
-			}
-		}
-
-		// allow internal frames in layered pane to be moved/resized when placed over title bar
-		for( Component c : rootPane.getLayeredPane().getComponents() ) {
-			r = (c instanceof JInternalFrame) ? getNativeHitTestSpot( (JInternalFrame) c ) : null;
-			if( r != null )
-				hitTestSpots.add( r );
-		}
-
 		Rectangle minimizeButtonBounds = boundsInWindow( iconifyButton );
 		Rectangle maximizeButtonBounds = boundsInWindow( maximizeButton.isVisible() ? maximizeButton : restoreButton );
 		Rectangle closeButtonBounds = boundsInWindow( closeButton );
 
+		// clear hit-test cache
+		lastHitTestTime = 0;
+
 		FlatNativeWindowBorder.setTitleBarHeightAndHitTestSpots( window, titleBarHeight,
-			hitTestSpots, appIconBounds, minimizeButtonBounds, maximizeButtonBounds, closeButtonBounds );
+			this::hitTest, appIconBounds, minimizeButtonBounds, maximizeButtonBounds, closeButtonBounds );
 
 		debugTitleBarHeight = titleBarHeight;
-		debugHitTestSpots = hitTestSpots;
 		debugAppIconBounds = appIconBounds;
 		debugMinimizeButtonBounds = minimizeButtonBounds;
 		debugMaximizeButtonBounds = maximizeButtonBounds;
@@ -1017,8 +1034,66 @@ public class FlatTitlePane
 		return r;
 	}
 
+	/**
+	 * Returns wheter there is a component at the given location, that processes
+	 * mouse events. E.g. buttons, menus, etc.
+	 * <p>
+	 * Note:
+	 * <ul>
+	 *   <li>This method is invoked often when mouse is moved over title bar
+	 *       and should therefore return quickly.
+	 *   <li>This method is invoked on 'AWT-Windows' thread (not 'AWT-EventQueue' thread)
+	 *       while processing Windows messages.
+	 * </ul>
+	 */
+	private boolean hitTest( Point pt ) {
+		// Windows invokes this method every ~200ms, even if the mouse has not moved
+		long time = System.currentTimeMillis();
+		if( pt.x == lastHitTestX && pt.y == lastHitTestY && time < lastHitTestTime + 300 ) {
+			lastHitTestTime = time;
+			return lastHitTestResult;
+		}
+
+		// convert pt from window coordinates to layeredPane coordinates
+		Component layeredPane = rootPane.getLayeredPane();
+		int x = pt.x;
+		int y = pt.y;
+		for( Component c = layeredPane; c != window && c != null; c = c.getParent() ) {
+			x -= c.getX();
+			y -= c.getY();
+		}
+
+		lastHitTestX = pt.x;
+		lastHitTestY = pt.y;
+		lastHitTestTime = time;
+		lastHitTestResult = isComponentWithMouseListenerAt( layeredPane, x, y );
+		return lastHitTestResult;
+	}
+
+	private boolean isComponentWithMouseListenerAt( Component c, int x, int y ) {
+		if( !c.isDisplayable() || !c.isVisible() || !c.contains( x, y ) || c == mouseLayer )
+			return false;
+
+		if( c.getMouseListeners().length > 0 ||
+			c.getMouseMotionListeners().length > 0 ||
+			c.getMouseWheelListeners().length > 0 )
+		  return true;
+
+		if( c instanceof Container ) {
+			for( Component child : ((Container)c).getComponents() ) {
+				if( isComponentWithMouseListenerAt( child, x - child.getX(), y - child.getY() ) )
+					return true;
+			}
+		}
+		return false;
+	}
+
+	private int lastHitTestX;
+	private int lastHitTestY;
+	private long lastHitTestTime;
+	private boolean lastHitTestResult;
+
 	private int debugTitleBarHeight;
-	private List<Rectangle> debugHitTestSpots;
 	private Rectangle debugAppIconBounds;
 	private Rectangle debugMinimizeButtonBounds;
 	private Rectangle debugMaximizeButtonBounds;
@@ -1116,7 +1191,7 @@ public class FlatTitlePane
 				}
 			}
 
-			// compute icon width and gap (if icon is show besides the title)
+			// compute icon width and gap (if icon is shown besides the title)
 			int iconTextGap = 0;
 			int iconWidthAndGap = 0;
 			if( icon != null ) {
@@ -1125,7 +1200,7 @@ public class FlatTitlePane
 				iconWidthAndGap = icon.getIconWidth() + iconTextGap;
 			}
 
-			// layout title and icon (if show besides the title)
+			// layout title and icon (if shown besides the title)
 			String clippedText = SwingUtilities.layoutCompoundLabel( label, fontMetrics, text, icon,
 				label.getVerticalAlignment(), label.getHorizontalAlignment(),
 				label.getVerticalTextPosition(), label.getHorizontalTextPosition(),
@@ -1275,7 +1350,7 @@ debug*/
 			}
 
 			if( e.getClickCount() == 2 && SwingUtilities.isLeftMouseButton( e ) ) {
-				if( e.getSource() == iconLabel ) {
+				if( SwingUtilities.getDeepestComponentAt( FlatTitlePane.this, e.getX(), e.getY() ) == iconLabel ) {
 					// double-click on icon closes window
 					close();
 				} else if( !hasNativeCustomDecoration() ) {
@@ -1302,7 +1377,7 @@ debug*/
 			if( !SwingUtilities.isLeftMouseButton( e ) )
 				return;
 
-			dragOffset = SwingUtilities.convertPoint( FlatTitlePane.this, e.getPoint(), window );
+			dragOffset = SwingUtilities.convertPoint( mouseLayer, e.getPoint(), window );
 			linuxNativeMove = false;
 
 			// on Linux, move or maximize/restore window

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatToolBarUI.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatToolBarUI.java
@@ -82,7 +82,7 @@ import com.formdev.flatlaf.util.UIScale;
  */
 public class FlatToolBarUI
 	extends BasicToolBarUI
-	implements StyleableUI
+	implements StyleableUI, FlatTitlePane.TitleBarCaptionHitTest
 {
 	/** @since 1.4 */ @Styleable protected boolean focusableButtons;
 	/** @since 2 */ @Styleable protected boolean arrowKeysOnlyNavigation;
@@ -451,6 +451,15 @@ public class FlatToolBarUI
 		return (model instanceof DefaultButtonModel)
 			? ((DefaultButtonModel)model).getGroup()
 			: null;
+	}
+
+	//---- interface FlatTitlePane.TitleBarCaptionHitTest ----
+
+	/** @since 3.4 */
+	@Override
+	public Boolean isTitleBarCaptionAt( int x, int y ) {
+		// necessary because BasicToolBarUI adds some mouse listeners for dragging when toolbar is floatable
+		return null; // check children
 	}
 
 	//---- class FlatToolBarFocusTraversalPolicy ------------------------------

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatWindowsNativeWindowBorder.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatWindowsNativeWindowBorder.java
@@ -159,7 +159,7 @@ class FlatWindowsNativeWindowBorder
 	}
 
 	@Override
-	public void updateTitleBarInfo( Window window, int titleBarHeight, Predicate<Point> hitTestCallback,
+	public void updateTitleBarInfo( Window window, int titleBarHeight, Predicate<Point> captionHitTestCallback,
 		Rectangle appIconBounds, Rectangle minimizeButtonBounds, Rectangle maximizeButtonBounds,
 		Rectangle closeButtonBounds )
 	{
@@ -168,7 +168,7 @@ class FlatWindowsNativeWindowBorder
 			return;
 
 		wndProc.titleBarHeight = titleBarHeight;
-		wndProc.hitTestCallback = hitTestCallback;
+		wndProc.captionHitTestCallback = captionHitTestCallback;
 		wndProc.appIconBounds = cloneRectange( appIconBounds );
 		wndProc.minimizeButtonBounds = cloneRectange( minimizeButtonBounds );
 		wndProc.maximizeButtonBounds = cloneRectange( maximizeButtonBounds );
@@ -289,7 +289,7 @@ class FlatWindowsNativeWindowBorder
 
 		// Swing coordinates/values may be scaled on a HiDPI screen
 		private int titleBarHeight; // measured from window top edge, which may be out-of-screen if maximized
-		private Predicate<Point> hitTestCallback;
+		private Predicate<Point> captionHitTestCallback;
 		private Rectangle appIconBounds;
 		private Rectangle minimizeButtonBounds;
 		private Rectangle maximizeButtonBounds;
@@ -376,7 +376,7 @@ class FlatWindowsNativeWindowBorder
 				// that processes mouse events (e.g. buttons, menus, etc)
 				//   - Windows ignores mouse events in this area
 				try {
-					if( hitTestCallback != null && hitTestCallback.test( pt ) )
+					if( captionHitTestCallback != null && !captionHitTestCallback.test( pt ) )
 						return HTCLIENT;
 				} catch( Throwable ex ) {
 					// ignore

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatWindowsNativeWindowBorder.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatWindowsNativeWindowBorder.java
@@ -29,8 +29,8 @@ import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.util.Collections;
 import java.util.IdentityHashMap;
-import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 import javax.swing.JDialog;
 import javax.swing.JFrame;
 import javax.swing.Timer;
@@ -159,7 +159,7 @@ class FlatWindowsNativeWindowBorder
 	}
 
 	@Override
-	public void updateTitleBarInfo( Window window, int titleBarHeight, List<Rectangle> hitTestSpots,
+	public void updateTitleBarInfo( Window window, int titleBarHeight, Predicate<Point> hitTestCallback,
 		Rectangle appIconBounds, Rectangle minimizeButtonBounds, Rectangle maximizeButtonBounds,
 		Rectangle closeButtonBounds )
 	{
@@ -168,7 +168,7 @@ class FlatWindowsNativeWindowBorder
 			return;
 
 		wndProc.titleBarHeight = titleBarHeight;
-		wndProc.hitTestSpots = hitTestSpots.toArray( new Rectangle[hitTestSpots.size()] );
+		wndProc.hitTestCallback = hitTestCallback;
 		wndProc.appIconBounds = cloneRectange( appIconBounds );
 		wndProc.minimizeButtonBounds = cloneRectange( minimizeButtonBounds );
 		wndProc.maximizeButtonBounds = cloneRectange( maximizeButtonBounds );
@@ -288,8 +288,8 @@ class FlatWindowsNativeWindowBorder
 		private final long hwnd;
 
 		// Swing coordinates/values may be scaled on a HiDPI screen
-		private int titleBarHeight;
-		private Rectangle[] hitTestSpots;
+		private int titleBarHeight; // measured from window top edge, which may be out-of-screen if maximized
+		private Predicate<Point> hitTestCallback;
 		private Rectangle appIconBounds;
 		private Rectangle minimizeButtonBounds;
 		private Rectangle maximizeButtonBounds;
@@ -340,50 +340,61 @@ class FlatWindowsNativeWindowBorder
 		private int onNcHitTest( int x, int y, boolean isOnResizeBorder ) {
 			// scale-down mouse x/y because Swing coordinates/values may be scaled on a HiDPI screen
 			Point pt = scaleDown( x, y );
-			int sx = pt.x;
-			int sy = pt.y;
 
 			// return HTSYSMENU if mouse is over application icon
 			//   - left-click on HTSYSMENU area shows system menu
 			//   - double-left-click sends WM_CLOSE
-			if( contains( appIconBounds, sx, sy ) )
+			if( contains( appIconBounds, pt ) )
 				return HTSYSMENU;
 
 			// return HTMINBUTTON if mouse is over minimize button
 			//   - hovering mouse over HTMINBUTTON area shows tooltip on Windows 10/11
-			if( contains( minimizeButtonBounds, sx, sy ) )
+			if( contains( minimizeButtonBounds, pt ) )
 				return HTMINBUTTON;
 
 			// return HTMAXBUTTON if mouse is over maximize/restore button
 			//   - hovering mouse over HTMAXBUTTON area shows tooltip on Windows 10
 			//   - hovering mouse over HTMAXBUTTON area shows snap layouts menu on Windows 11
 			//     https://docs.microsoft.com/en-us/windows/apps/desktop/modernize/apply-snap-layout-menu
-			if( contains( maximizeButtonBounds, sx, sy ) )
+			if( contains( maximizeButtonBounds, pt ) )
 				return HTMAXBUTTON;
 
 			// return HTCLOSE if mouse is over close button
 			//   - hovering mouse over HTCLOSE area shows tooltip on Windows 10/11
-			if( contains( closeButtonBounds, sx, sy ) )
+			if( contains( closeButtonBounds, pt ) )
 				return HTCLOSE;
 
-			boolean isOnTitleBar = (sy < titleBarHeight);
+			// return HTTOP if mouse is over top resize border
+			//   - hovering mouse shows vertical resize cursor
+			//   - left-click and drag vertically resizes window
+			if( isOnResizeBorder )
+				return HTTOP;
 
+			boolean isOnTitleBar = (pt.y < titleBarHeight);
 			if( isOnTitleBar ) {
-				// use a second reference to the array to avoid that it can be changed
-				// in another thread while processing the array
-				Rectangle[] hitTestSpots2 = hitTestSpots;
-				for( Rectangle spot : hitTestSpots2 ) {
-					if( spot.contains( sx, sy ) )
+				// return HTCLIENT if mouse is over any Swing component in title bar
+				// that processes mouse events (e.g. buttons, menus, etc)
+				//   - Windows ignores mouse events in this area
+				try {
+					if( hitTestCallback != null && hitTestCallback.test( pt ) )
 						return HTCLIENT;
+				} catch( Throwable ex ) {
+					// ignore
 				}
-				return isOnResizeBorder ? HTTOP : HTCAPTION;
+
+				// return HTCAPTION if mouse is over title bar
+				//   - right-click shows system menu
+				//   - double-left-click maximizes/restores window size
+				return HTCAPTION;
 			}
 
-			return isOnResizeBorder ? HTTOP : HTCLIENT;
+			// return HTCLIENT
+			//   - Windows ignores mouse events in this area
+			return HTCLIENT;
 		}
 
-		private boolean contains( Rectangle rect, int x, int y ) {
-			return (rect != null && rect.contains( x, y ) );
+		private boolean contains( Rectangle rect, Point pt ) {
+			return (rect != null && rect.contains( pt ) );
 		}
 
 		/**

--- a/flatlaf-core/src/main/resources/com/formdev/flatlaf/FlatLaf.properties
+++ b/flatlaf-core/src/main/resources/com/formdev/flatlaf/FlatLaf.properties
@@ -829,7 +829,6 @@ TitlePane.centerTitleIfMenuBarEmbedded = true
 TitlePane.showIconBesideTitle = false
 TitlePane.menuBarTitleGap = 40
 TitlePane.menuBarTitleMinimumGap = 12
-TitlePane.menuBarResizeHeight = 4
 TitlePane.closeIcon = com.formdev.flatlaf.icons.FlatWindowCloseIcon
 TitlePane.iconifyIcon = com.formdev.flatlaf.icons.FlatWindowIconifyIcon
 TitlePane.maximizeIcon = com.formdev.flatlaf.icons.FlatWindowMaximizeIcon

--- a/flatlaf-demo/src/main/java/com/formdev/flatlaf/demo/DemoFrame.jfd
+++ b/flatlaf-demo/src/main/java/com/formdev/flatlaf/demo/DemoFrame.jfd
@@ -74,7 +74,7 @@ new FormModel {
 					"value": "Center"
 				} )
 			}, new FormLayoutConstraints( class java.lang.String ) {
-				"value": "North"
+				"value": "First"
 			} )
 			add( new FormContainer( "javax.swing.JPanel", new FormLayoutManager( class net.miginfocom.swing.MigLayout ) {
 				"$layoutConstraints": "insets dialog,hidemode 3"
@@ -115,7 +115,7 @@ new FormModel {
 						"title": "Option Pane"
 					} )
 					add( new FormComponent( "com.formdev.flatlaf.demo.extras.ExtrasPanel" ) {
-						name: "extrasPanel1"
+						name: "extrasPanel"
 					}, new FormLayoutConstraints( null ) {
 						"title": "Extras"
 					} )
@@ -131,19 +131,32 @@ new FormModel {
 					"JavaCodeGenerator.variableLocal": false
 				}
 			}, new FormLayoutConstraints( class java.lang.String ) {
-				"value": "South"
+				"value": "Last"
 			} )
-			add( new FormComponent( "com.formdev.flatlaf.demo.intellijthemes.IJThemesPanel" ) {
-				name: "themesPanel"
-				auxiliary() {
-					"JavaCodeGenerator.variableLocal": false
-					"JavaCodeGenerator.variableModifiers": 0
-				}
+			add( new FormContainer( "javax.swing.JPanel", new FormLayoutManager( class java.awt.BorderLayout ) ) {
+				name: "themesPanelPanel"
+				add( new FormContainer( "javax.swing.JPanel", new FormLayoutManager( class java.awt.FlowLayout ) ) {
+					name: "winFullWindowContentButtonsPlaceholder"
+				}, new FormLayoutConstraints( class java.lang.String ) {
+					"value": "North"
+				} )
+				add( new FormComponent( "com.formdev.flatlaf.demo.intellijthemes.IJThemesPanel" ) {
+					name: "themesPanel"
+					auxiliary() {
+						"JavaCodeGenerator.variableLocal": false
+						"JavaCodeGenerator.variableModifiers": 0
+					}
+				}, new FormLayoutConstraints( class java.lang.String ) {
+					"value": "Center"
+				} )
 			}, new FormLayoutConstraints( class java.lang.String ) {
-				"value": "East"
+				"value": "After"
 			} )
 			menuBar: new FormContainer( "javax.swing.JMenuBar", new FormLayoutManager( class javax.swing.JMenuBar ) ) {
-				name: "menuBar1"
+				name: "menuBar"
+				auxiliary() {
+					"JavaCodeGenerator.variableLocal": false
+				}
 				add( new FormContainer( "javax.swing.JMenu", new FormLayoutManager( class javax.swing.JMenu ) ) {
 					name: "fileMenu"
 					"text": "File"

--- a/flatlaf-demo/src/main/resources/com/formdev/flatlaf/demo/icons/collapse.svg
+++ b/flatlaf-demo/src/main/resources/com/formdev/flatlaf/demo/icons/collapse.svg
@@ -1,0 +1,4 @@
+<!-- Copyright 2000-2023 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license. -->
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M1.5 14.5L6 10M14.5 1.5L9.99998 6.00001M2.5 9.50001H6.5L6.5 13.5M13.5 6.5L9.5 6.50003V2.5" stroke="#6E6E6E" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/flatlaf-demo/src/main/resources/com/formdev/flatlaf/demo/icons/expand.svg
+++ b/flatlaf-demo/src/main/resources/com/formdev/flatlaf/demo/icons/expand.svg
@@ -1,0 +1,4 @@
+<!-- Copyright 2000-2023 JetBrains s.r.o. and contributors. Use of this source code is governed by the Apache 2.0 license. -->
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M6.5 9.5L2 14M9.50003 6.50004L14 2.00001M5.5 14.5H1.5V10.5M10.5 1.5L14.5 1.50002V5.5" stroke="#6E6E6E" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/flatlaf-jide-oss/src/main/java/com/formdev/flatlaf/jideoss/ui/FlatJideTabbedPaneUI.java
+++ b/flatlaf-jide-oss/src/main/java/com/formdev/flatlaf/jideoss/ui/FlatJideTabbedPaneUI.java
@@ -16,6 +16,7 @@
 
 package com.formdev.flatlaf.jideoss.ui;
 
+import static com.formdev.flatlaf.FlatClientProperties.COMPONENT_TITLE_BAR_CAPTION;
 import static com.formdev.flatlaf.FlatClientProperties.TABBED_PANE_HAS_FULL_BORDER;
 import static com.formdev.flatlaf.FlatClientProperties.TABBED_PANE_SHOW_TAB_SEPARATORS;
 import static com.formdev.flatlaf.FlatClientProperties.clientPropertyBoolean;
@@ -30,6 +31,7 @@ import java.awt.Graphics;
 import java.awt.Graphics2D;
 import java.awt.Insets;
 import java.awt.LayoutManager;
+import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.Shape;
 import java.awt.event.MouseListener;
@@ -37,6 +39,7 @@ import java.awt.event.MouseMotionListener;
 import java.awt.geom.Path2D;
 import java.awt.geom.Rectangle2D;
 import java.beans.PropertyChangeListener;
+import java.util.function.Function;
 import javax.swing.Icon;
 import javax.swing.JButton;
 import javax.swing.JComponent;
@@ -98,6 +101,25 @@ public class FlatJideTabbedPaneUI
 		LookAndFeelFactory.installJideExtension();
 
 		return new FlatJideTabbedPaneUI();
+	}
+
+	@Override
+	public void installUI( JComponent c ) {
+		super.installUI( c );
+
+		c.putClientProperty( COMPONENT_TITLE_BAR_CAPTION,
+			(Function<Point, Boolean>) pt -> {
+				if( tabForCoordinate( _tabPane, pt.x, pt.y ) >= 0 )
+					return false;
+
+				return null; // check children
+			} );
+	}
+
+	@Override
+	public void uninstallUI( JComponent c ) {
+		super.uninstallUI( c );
+		c.putClientProperty( COMPONENT_TITLE_BAR_CAPTION, null );
 	}
 
 	@Override

--- a/flatlaf-natives/flatlaf-natives-jna/src/main/java/com/formdev/flatlaf/natives/jna/windows/FlatWindowsNativeWindowBorder.java
+++ b/flatlaf-natives/flatlaf-natives-jna/src/main/java/com/formdev/flatlaf/natives/jna/windows/FlatWindowsNativeWindowBorder.java
@@ -164,7 +164,7 @@ public class FlatWindowsNativeWindowBorder
 	}
 
 	@Override
-	public void updateTitleBarInfo( Window window, int titleBarHeight, Predicate<Point> hitTestCallback,
+	public void updateTitleBarInfo( Window window, int titleBarHeight, Predicate<Point> captionHitTestCallback,
 		Rectangle appIconBounds, Rectangle minimizeButtonBounds, Rectangle maximizeButtonBounds,
 		Rectangle closeButtonBounds )
 	{
@@ -173,7 +173,7 @@ public class FlatWindowsNativeWindowBorder
 			return;
 
 		wndProc.titleBarHeight = titleBarHeight;
-		wndProc.hitTestCallback = hitTestCallback;
+		wndProc.captionHitTestCallback = captionHitTestCallback;
 		wndProc.appIconBounds = cloneRectange( appIconBounds );
 		wndProc.minimizeButtonBounds = cloneRectange( minimizeButtonBounds );
 		wndProc.maximizeButtonBounds = cloneRectange( maximizeButtonBounds );
@@ -351,7 +351,7 @@ public class FlatWindowsNativeWindowBorder
 
 		// Swing coordinates/values may be scaled on a HiDPI screen
 		private int titleBarHeight;
-		private Predicate<Point> hitTestCallback;
+		private Predicate<Point> captionHitTestCallback;
 		private Rectangle appIconBounds;
 		private Rectangle minimizeButtonBounds;
 		private Rectangle maximizeButtonBounds;
@@ -684,7 +684,7 @@ public class FlatWindowsNativeWindowBorder
 				// that processes mouse events (e.g. buttons, menus, etc)
 				//   - Windows ignores mouse events in this area
 				try {
-					if( hitTestCallback != null && hitTestCallback.test( pt ) )
+					if( captionHitTestCallback != null && !captionHitTestCallback.test( pt ) )
 						return new LRESULT( HTCLIENT );
 				} catch( Throwable ex ) {
 					// ignore

--- a/flatlaf-natives/flatlaf-natives-jna/src/main/java/com/formdev/flatlaf/natives/jna/windows/FlatWindowsNativeWindowBorder.java
+++ b/flatlaf-natives/flatlaf-natives-jna/src/main/java/com/formdev/flatlaf/natives/jna/windows/FlatWindowsNativeWindowBorder.java
@@ -32,8 +32,8 @@ import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.util.Collections;
 import java.util.IdentityHashMap;
-import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 import javax.swing.JDialog;
 import javax.swing.JFrame;
 import javax.swing.Timer;
@@ -164,7 +164,7 @@ public class FlatWindowsNativeWindowBorder
 	}
 
 	@Override
-	public void updateTitleBarInfo( Window window, int titleBarHeight, List<Rectangle> hitTestSpots,
+	public void updateTitleBarInfo( Window window, int titleBarHeight, Predicate<Point> hitTestCallback,
 		Rectangle appIconBounds, Rectangle minimizeButtonBounds, Rectangle maximizeButtonBounds,
 		Rectangle closeButtonBounds )
 	{
@@ -173,7 +173,7 @@ public class FlatWindowsNativeWindowBorder
 			return;
 
 		wndProc.titleBarHeight = titleBarHeight;
-		wndProc.hitTestSpots = hitTestSpots.toArray( new Rectangle[hitTestSpots.size()] );
+		wndProc.hitTestCallback = hitTestCallback;
 		wndProc.appIconBounds = cloneRectange( appIconBounds );
 		wndProc.minimizeButtonBounds = cloneRectange( minimizeButtonBounds );
 		wndProc.maximizeButtonBounds = cloneRectange( maximizeButtonBounds );
@@ -351,7 +351,7 @@ public class FlatWindowsNativeWindowBorder
 
 		// Swing coordinates/values may be scaled on a HiDPI screen
 		private int titleBarHeight;
-		private Rectangle[] hitTestSpots;
+		private Predicate<Point> hitTestCallback;
 		private Rectangle appIconBounds;
 		private Rectangle minimizeButtonBounds;
 		private Rectangle maximizeButtonBounds;
@@ -644,53 +644,65 @@ public class FlatWindowsNativeWindowBorder
 
 			// scale-down mouse x/y because Swing coordinates/values may be scaled on a HiDPI screen
 			Point pt = scaleDown( x, y );
-			int sx = pt.x;
-			int sy = pt.y;
 
 			// return HTSYSMENU if mouse is over application icon
 			//   - left-click on HTSYSMENU area shows system menu
 			//   - double-left-click sends WM_CLOSE
-			if( contains( appIconBounds, sx, sy ) )
+			if( contains( appIconBounds, pt ) )
 				return new LRESULT( HTSYSMENU );
 
 			// return HTMINBUTTON if mouse is over minimize button
 			//   - hovering mouse over HTMINBUTTON area shows tooltip on Windows 10/11
-			if( contains( minimizeButtonBounds, sx, sy ) )
+			if( contains( minimizeButtonBounds, pt ) )
 				return new LRESULT( HTMINBUTTON );
 
 			// return HTMAXBUTTON if mouse is over maximize/restore button
 			//   - hovering mouse over HTMAXBUTTON area shows tooltip on Windows 10
 			//   - hovering mouse over HTMAXBUTTON area shows snap layouts menu on Windows 11
 			//     https://docs.microsoft.com/en-us/windows/apps/desktop/modernize/apply-snap-layout-menu
-			if( contains( maximizeButtonBounds, sx, sy ) )
+			if( contains( maximizeButtonBounds, pt ) )
 				return new LRESULT( HTMAXBUTTON );
 
 			// return HTCLOSE if mouse is over close button
 			//   - hovering mouse over HTCLOSE area shows tooltip on Windows 10/11
-			if( contains( closeButtonBounds, sx, sy ) )
+			if( contains( closeButtonBounds, pt ) )
 				return new LRESULT( HTCLOSE );
 
 			int resizeBorderHeight = getResizeHandleHeight();
 			boolean isOnResizeBorder = (y < resizeBorderHeight) &&
 				(User32.INSTANCE.GetWindowLong( hwnd, GWL_STYLE ) & WS_THICKFRAME) != 0;
-			boolean isOnTitleBar = (sy < titleBarHeight);
 
+			// return HTTOP if mouse is over top resize border
+			//   - hovering mouse shows vertical resize cursor
+			//   - left-click and drag vertically resizes window
+			if( isOnResizeBorder )
+				return new LRESULT( HTTOP );
+
+			boolean isOnTitleBar = (pt.y < titleBarHeight);
 			if( isOnTitleBar ) {
-				// use a second reference to the array to avoid that it can be changed
-				// in another thread while processing the array
-				Rectangle[] hitTestSpots2 = hitTestSpots;
-				for( Rectangle spot : hitTestSpots2 ) {
-					if( spot.contains( sx, sy ) )
+				// return HTCLIENT if mouse is over any Swing component in title bar
+				// that processes mouse events (e.g. buttons, menus, etc)
+				//   - Windows ignores mouse events in this area
+				try {
+					if( hitTestCallback != null && hitTestCallback.test( pt ) )
 						return new LRESULT( HTCLIENT );
+				} catch( Throwable ex ) {
+					// ignore
 				}
-				return new LRESULT( isOnResizeBorder ? HTTOP : HTCAPTION );
+
+				// return HTCAPTION if mouse is over title bar
+				//   - right-click shows system menu
+				//   - double-left-click maximizes/restores window size
+				return new LRESULT( HTCAPTION );
 			}
 
-			return new LRESULT( isOnResizeBorder ? HTTOP : HTCLIENT );
+			// return HTCLIENT
+			//   - Windows ignores mouse events in this area
+			return new LRESULT( HTCLIENT );
 		}
 
-		private boolean contains( Rectangle rect, int x, int y ) {
-			return (rect != null && rect.contains( x, y ) );
+		private boolean contains( Rectangle rect, Point pt ) {
+			return (rect != null && rect.contains( pt ) );
 		}
 
 		/**

--- a/flatlaf-testing/dumps/uidefaults/FlatDarkLaf_1.8.0.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatDarkLaf_1.8.0.txt
@@ -1264,7 +1264,6 @@ TitlePane.inactiveBackground   #303234  HSL 210   4  20    javax.swing.plaf.Colo
 TitlePane.inactiveForeground   #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
 TitlePane.maximizeIcon         [lazy] 44,30    com.formdev.flatlaf.icons.FlatWindowMaximizeIcon [UI]
 TitlePane.menuBarEmbedded      true
-TitlePane.menuBarResizeHeight  4
 TitlePane.menuBarTitleGap      40
 TitlePane.menuBarTitleMinimumGap 12
 TitlePane.noIconLeftGap        8

--- a/flatlaf-testing/dumps/uidefaults/FlatLightLaf_1.8.0.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatLightLaf_1.8.0.txt
@@ -1269,7 +1269,6 @@ TitlePane.inactiveBackground   #ffffff  HSL   0   0 100    javax.swing.plaf.Colo
 TitlePane.inactiveForeground   #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
 TitlePane.maximizeIcon         [lazy] 44,30    com.formdev.flatlaf.icons.FlatWindowMaximizeIcon [UI]
 TitlePane.menuBarEmbedded      true
-TitlePane.menuBarResizeHeight  4
 TitlePane.menuBarTitleGap      40
 TitlePane.menuBarTitleMinimumGap 12
 TitlePane.noIconLeftGap        8

--- a/flatlaf-testing/dumps/uidefaults/FlatMacDarkLaf_1.8.0.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatMacDarkLaf_1.8.0.txt
@@ -1274,7 +1274,6 @@ TitlePane.inactiveBackground   #323232  HSL   0   0  20    javax.swing.plaf.Colo
 TitlePane.inactiveForeground   #9a9a9a  HSL   0   0  60    javax.swing.plaf.ColorUIResource [UI]
 TitlePane.maximizeIcon         [lazy] 44,30    com.formdev.flatlaf.icons.FlatWindowMaximizeIcon [UI]
 TitlePane.menuBarEmbedded      true
-TitlePane.menuBarResizeHeight  4
 TitlePane.menuBarTitleGap      40
 TitlePane.menuBarTitleMinimumGap 12
 TitlePane.noIconLeftGap        8

--- a/flatlaf-testing/dumps/uidefaults/FlatMacLightLaf_1.8.0.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatMacLightLaf_1.8.0.txt
@@ -1278,7 +1278,6 @@ TitlePane.inactiveBackground   #ececec  HSL   0   0  93    javax.swing.plaf.Colo
 TitlePane.inactiveForeground   #b6b6b6  HSL   0   0  71    javax.swing.plaf.ColorUIResource [UI]
 TitlePane.maximizeIcon         [lazy] 44,30    com.formdev.flatlaf.icons.FlatWindowMaximizeIcon [UI]
 TitlePane.menuBarEmbedded      true
-TitlePane.menuBarResizeHeight  4
 TitlePane.menuBarTitleGap      40
 TitlePane.menuBarTitleMinimumGap 12
 TitlePane.noIconLeftGap        8

--- a/flatlaf-testing/dumps/uidefaults/FlatTestLaf_1.8.0.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatTestLaf_1.8.0.txt
@@ -1305,7 +1305,6 @@ TitlePane.inactiveBackground   #008800  HSL 120 100  27    javax.swing.plaf.Colo
 TitlePane.inactiveForeground   #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
 TitlePane.maximizeIcon         [lazy] 44,30    com.formdev.flatlaf.icons.FlatWindowMaximizeIcon [UI]
 TitlePane.menuBarEmbedded      true
-TitlePane.menuBarResizeHeight  4
 TitlePane.menuBarTitleGap      40
 TitlePane.menuBarTitleMinimumGap 12
 TitlePane.noIconLeftGap        8

--- a/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatWindowDecorationsTest.jfd
+++ b/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatWindowDecorationsTest.jfd
@@ -9,7 +9,7 @@ new FormModel {
 		add( new FormContainer( "com.formdev.flatlaf.testing.FlatTestPanel", new FormLayoutManager( class net.miginfocom.swing.MigLayout ) {
 			"$layoutConstraints": "ltr,insets dialog,hidemode 3"
 			"$columnConstraints": "[left][fill][fill][fill]"
-			"$rowConstraints": "[fill][fill][]"
+			"$rowConstraints": "[fill][fill][][]"
 		} ) {
 			name: "this"
 			add( new FormContainer( "javax.swing.JPanel", new FormLayoutManager( class net.miginfocom.swing.MigLayout ) {
@@ -77,7 +77,7 @@ new FormModel {
 			add( new FormContainer( "javax.swing.JPanel", new FormLayoutManager( class net.miginfocom.swing.MigLayout ) {
 				"$layoutConstraints": "ltr,hidemode 3,gap 0 0"
 				"$columnConstraints": "[grow,left]"
-				"$rowConstraints": "[][][][][]"
+				"$rowConstraints": "[][][][][]rel[]rel[]"
 			} ) {
 				name: "panel4"
 				"border": new javax.swing.border.TitledBorder( "Title Bar" )
@@ -134,6 +134,31 @@ new FormModel {
 					addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "showCloseChanged", false ) )
 				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
 					"value": "cell 0 4"
+				} )
+				add( new FormComponent( "javax.swing.JCheckBox" ) {
+					name: "fullWindowContentCheckBox"
+					"text": "full window content"
+					auxiliary() {
+						"JavaCodeGenerator.variableLocal": false
+					}
+					addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "fullWindowContentChanged", false ) )
+				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+					"value": "cell 0 5"
+				} )
+				add( new FormComponent( "javax.swing.JLabel" ) {
+					name: "fullWindowContentButtonsBoundsLabel"
+					"text": "Buttons bounds:"
+				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+					"value": "cell 0 6"
+				} )
+				add( new FormComponent( "javax.swing.JLabel" ) {
+					name: "fullWindowContentButtonsBoundsField"
+					"text": "null"
+					auxiliary() {
+						"JavaCodeGenerator.variableLocal": false
+					}
+				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+					"value": "cell 0 6"
 				} )
 			}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
 				"value": "cell 1 0"
@@ -204,7 +229,7 @@ new FormModel {
 			add( new FormContainer( "javax.swing.JPanel", new FormLayoutManager( class net.miginfocom.swing.MigLayout ) {
 				"$layoutConstraints": "hidemode 3"
 				"$columnConstraints": "[fill]"
-				"$rowConstraints": "[][][][][]unrel[]"
+				"$rowConstraints": "[][][][][][]unrel[]"
 			} ) {
 				name: "panel3"
 				add( new FormComponent( "javax.swing.JButton" ) {
@@ -238,6 +263,16 @@ new FormModel {
 					"value": "cell 0 2"
 				} )
 				add( new FormComponent( "javax.swing.JButton" ) {
+					name: "addTextFieldButton"
+					"text": "Add text field"
+					auxiliary() {
+						"JavaCodeGenerator.variableLocal": false
+					}
+					addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "addTextField", false ) )
+				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+					"value": "cell 0 3"
+				} )
+				add( new FormComponent( "javax.swing.JButton" ) {
 					name: "removeMenuButton"
 					"text": "Remove menu"
 					auxiliary() {
@@ -245,7 +280,7 @@ new FormModel {
 					}
 					addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "removeMenu", false ) )
 				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-					"value": "cell 0 3"
+					"value": "cell 0 4"
 				} )
 				add( new FormComponent( "javax.swing.JButton" ) {
 					name: "changeMenuButton"
@@ -255,7 +290,7 @@ new FormModel {
 					}
 					addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "changeMenu", false ) )
 				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-					"value": "cell 0 4"
+					"value": "cell 0 5"
 				} )
 				add( new FormComponent( "javax.swing.JButton" ) {
 					name: "changeTitleButton"
@@ -265,7 +300,7 @@ new FormModel {
 					}
 					addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "changeTitle", false ) )
 				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
-					"value": "cell 0 5"
+					"value": "cell 0 6"
 				} )
 			}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
 				"value": "cell 3 0 1 2,aligny top,growy 0"
@@ -551,6 +586,17 @@ new FormModel {
 				}
 			}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
 				"value": "cell 0 2 3 1"
+			} )
+			add( new FormComponent( "javax.swing.JCheckBox" ) {
+				name: "showRectanglesCheckBox"
+				"text": "Show debug title bar rectangles"
+				"selected": true
+				auxiliary() {
+					"JavaCodeGenerator.variableLocal": false
+				}
+				addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "showRectangles", false ) )
+			}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+				"value": "cell 0 3"
 			} )
 		}, new FormLayoutConstraints( null ) {
 			"location": new java.awt.Point( 0, 0 )

--- a/flatlaf-theme-editor/src/main/resources/com/formdev/flatlaf/themeeditor/FlatLafUIKeys.txt
+++ b/flatlaf-theme-editor/src/main/resources/com/formdev/flatlaf/themeeditor/FlatLafUIKeys.txt
@@ -1047,7 +1047,6 @@ TitlePane.inactiveBackground
 TitlePane.inactiveForeground
 TitlePane.maximizeIcon
 TitlePane.menuBarEmbedded
-TitlePane.menuBarResizeHeight
 TitlePane.menuBarTitleGap
 TitlePane.menuBarTitleMinimumGap
 TitlePane.noIconLeftGap
@@ -1079,7 +1078,6 @@ TitlePane.small.iconifyIcon
 TitlePane.small.inactiveBackground
 TitlePane.small.inactiveForeground
 TitlePane.small.maximizeIcon
-TitlePane.small.menuBarResizeHeight
 TitlePane.small.menuBarTitleGap
 TitlePane.small.menuBarTitleMinimumGap
 TitlePane.small.noIconLeftGap


### PR DESCRIPTION
This PR brings "full window content" mode to FlatLaf window decorations on Windows 10/11 (and on Linux). For macOS see [here](https://www.formdev.com/flatlaf/macos/#full_window_content).

Full window content mode allows you to extend the content into the window title bar. This means that the content pane (and glass pane) of the Swing window is extended into the window title bar. The window icon and title are automatically hidden. Only the minimize/maximize/close buttons stay visible. So your application can use (nearly) the whole window area.

The top area (same height as minimize/maximize/close buttons) can still be used to move the window (click-and-drag), maximize window (double-click), or show window menu (right-click). FlatLaf automatically detects components in that area that process mouse events and excludes them.

You can try out "full window content" mode in FlatLaf Demo.
Press the "expand" button on the right side in the tab area (see red arrow):

![grafik](https://github.com/JFormDesigner/FlatLaf/assets/5604048/62db8270-605e-427b-a0ff-6a3430ab7ca1)

The menu bar and toolbar are hidden (from the Demo; not automatically) so that the tabbed pane moves into the title bar area:

![grafik](https://github.com/JFormDesigner/FlatLaf/assets/5604048/93b6d1de-f21b-44dd-b3c5-9d94775a20f3)

**Note**: If your application uses/requires a menu bar, it usually makes not much sense to use full window content mode.

## How to enable

~~~java
frame.getRootPane().putClientProperty( FlatClientProperties.FULL_WINDOW_CONTENT, true );
~~~

## Buttons placeholder

To avoid that your components are overlapped by the minimize/maximize/close buttons, you need to add some placeholder component to the layout of your application. For Windows in the top-right corner (or top-left for right-to-left component orientation). A buttons placeholder is a `JPanel` that has client property `FlatClientProperties.FULL_WINDOW_CONTENT_BUTTONS_PLACEHOLDER` set.

Note that FlatLaf controls the preferred size of the placeholder panel. If fullWindowContent mode is enabled, it gets the size of the buttons area. Otherwise, the preferred size is `0, 0`, which hides the placeholder.

~~~java
JPanel placeholder = new JPanel();
placeholder.putClientProperty( FlatClientProperties.FULL_WINDOW_CONTENT_BUTTONS_PLACEHOLDER, "win" );
~~~


If you have a toolbar at top of your frame, use an additional panel that contains placeholder at EAST (or LINE_END) and toolbar in CENTER:

~~~java
JToolBar toolBar = new JToolBar();
// add tool bar items

JPanel toolBarPanel = new JPanel( new BorderLayout() );
toolBarPanel.add( toolBar, BorderLayout.CENTER );
toolBarPanel.add( placeholder, BorderLayout.LINE_END );

frame.getContentPane().add( toolBarPanel, BorderLayout.NORTH );
~~~

See `FlatClientProperties.FULL_WINDOW_CONTENT_BUTTONS_PLACEHOLDER` javadoc for details.

For testing, you can make the placeholder "visible" with:

~~~java
UIManager.put( "FlatLaf.debug.panel.showPlaceholders", true );
~~~

![grafik](https://github.com/JFormDesigner/FlatLaf/assets/5604048/21c15724-31ac-4d41-96d5-47ec4febb5ec)

The red figure shows that placeholder bounds, the magenta figure the buttons bounds.

## macOS

See https://www.formdev.com/flatlaf/macos/#full_window_content for details on how to enable full window content mode on macOS, which is provided by Java. See also PR #779 for larger close/minimize/zoom buttons spacing and usage of placeholder on macOS.