### PR TITLE
Request to add MCreator to list of apps using FlatLAF

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,9 @@ Applications using FlatLaf
 
 - ![New](images/new.svg) ![Sponsor](images/sponsor.svg)
   [BGBlitz](https://www.bgblitz.com/) (**commercial**) - professional Backgammon
+- ![New](images/new.svg) [MCreator](https://github.com/MCreator/MCreator) - 
+  software used to make Minecraft Java Edition mods, Minecraft Bedrock Edition Add-Ons, 
+  and data packs without programming knowledge
 - ![New](images/new.svg) [MapTool](https://github.com/RPTools/maptool) - virtual
   Tabletop for playing role-playing games
 - [MegaMek](https://github.com/MegaMek/megamek),


### PR DESCRIPTION
Hi! Recently, our open-source Minecraft mod-making toolkit [MCreator updated its LAF to FlatLaf](https://github.com/MCreator/MCreator/pull/4683). I hope this is the right way to add software to the readme list :)

Two screenshots of your amazing LAF in action in our software:

![310267925-8a59d752-dc95-4fd4-b450-3af987d62b6b](https://github.com/JFormDesigner/FlatLaf/assets/16374228/814543a7-9f46-4dd3-89f6-18d9be776677)

![newlook](https://github.com/JFormDesigner/FlatLaf/assets/16374228/063f3887-d5a8-49ff-8e8c-8747ccdc8fe0)
