### PR TITLE
docs: Include a note when using Proguard/Shadow with FlatLaf in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,24 @@ See also
 for instructions on how to redistribute FlatLaf native libraries with your
 application.
 
+Proguard/Shadow JAR
+--------
+
+If you are using [Gradle Shadow JAR Plugin](https://github.com/johnrengelman/shadow) to build the jar for your application and `minimize()` function to minimize the size in the configurations of `shadowJar` task, then you will get an exception `java.lang.Error: no ComponentUI class for:` when running the jar, that's because Swing and Flatlaf both use Reflection, one way to fix this issue without removing the `minimize()` is to exclude Flatlaf from being minimized by using the following:
+
+```groovy
+
+shadowJar {
+    // Your shadow configurations
+    minimize {
+        // Exclude the entire FlatLaf dependency from minimization to fix `no ComponentUI class for: javax.swing.<component>`
+        exclude(dependency("com.formdev:flatlaf:.*"))
+    }
+}
+
+```
+
+Use a similar solution if you use other tools like Proguard, for [more details](https://github.com/JFormDesigner/FlatLaf/issues/648#issuecomment-1441547550)
 
 ### Snapshots
 


### PR DESCRIPTION
Developers who are using Proguard/Shadow JAR to minimize the jar to reduce its size will get an error when running the final jar which leads to a bug, most developers might not always test the jar minimized by Proguard/Shadow JAR (using a run configuration, for example, script or a task) and caught this bug, even if they do, the error might not be very clear, it's because that Flatlaf use reflection (as [mentioned](https://github.com/JFormDesigner/FlatLaf/issues/648#issuecomment-1441547550)), Swing use it too but the imports already included in Java JRE and will not minimize, this PR add a note for the developers who are using any tool that minimize the jar, and provide one solution which is to exclude FlatLaf from being minimized instead of not minimize the JAR and remove this feature completely, there are other solutions but this can work for more use-cases

If you are interested in getting this into the `README.md` as a note, then feel free to ask me for more changes, like what should The section called and where should it be

Thank you for your efforts in this amazing library.