### PR TITLE
Separate check/radio icon from menu item icon

### DIFF
--- a/flatlaf-core/src/main/resources/com/formdev/flatlaf/FlatLaf.properties
+++ b/flatlaf-core/src/main/resources/com/formdev/flatlaf/FlatLaf.properties
@@ -457,6 +457,7 @@ MenuItem.acceleratorDelimiter = "+"
 [mac]MenuItem.acceleratorDelimiter = ""
 MenuItem.selectionInsets = 0,0,0,0
 MenuItem.selectionArc = 0
+MenuItem.separateIconFromCheck = false
 
 # for MenuItem.selectionType = underline
 MenuItem.underlineSelectionBackground = @menuHoverBackground


### PR DESCRIPTION
This is what FlatLaf does, as of now:
![sMRyPWdpYJ](https://github.com/user-attachments/assets/597c9c32-633c-4500-9a39-4dd5f97fc1ab)

It doesn't play well with non-contrast icons and ones that occupy the entire region they're painted on.

This is what I managed to achieve:
![vNh6HiOiA5](https://github.com/user-attachments/assets/9b1a9739-7bb9-45aa-8b15-df9a74a53e07)

Also, note that now the entire check/radio icon is painted instead of just the knob part. I quite like how it looks.

This behavior is disabled by default and can be enabled by setting property `MenuItem.separateIconFromCheck` to `true`.