### PR TITLE
Tree: support wide cell renderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ FlatLaf Change Log
 #### New features and improvements
 
 - Tree: Support for alternate row highlighting. (PR #903)
+- Tree: Support wide cell renderer. (issue #922)
 - Extras: `FlatSVGIcon` color filters now can access painting component to
   implement component state based color mappings. (issue #906)
 

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/FlatClientProperties.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/FlatClientProperties.java
@@ -1410,12 +1410,22 @@ public interface FlatClientProperties
 	//---- JTree --------------------------------------------------------------
 
 	/**
-	 * Override if a tree shows a wide selection. Default is {@code true}.
+	 * Specifies whether tree shows a wide selection. Default is {@code true}.
 	 * <p>
 	 * <strong>Component</strong> {@link javax.swing.JTree}<br>
 	 * <strong>Value type</strong> {@link java.lang.Boolean}
 	 */
 	String TREE_WIDE_SELECTION = "JTree.wideSelection";
+
+	/**
+	 * Specifies whether tree uses a wide cell renderer. Default is {@code false}.
+	 * <p>
+	 * <strong>Component</strong> {@link javax.swing.JTree}<br>
+	 * <strong>Value type</strong> {@link java.lang.Boolean}
+	 *
+	 * @since 3.6
+	 */
+	String TREE_WIDE_CELL_RENDERER = "JTree.wideCellRenderer";
 
 	/**
 	 * Specifies whether tree item selection is painted. Default is {@code true}.

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatTreeUI.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatTreeUI.java
@@ -106,6 +106,7 @@ import com.formdev.flatlaf.util.UIScale;
  * @uiDefault Tree.selectionInsets					Insets
  * @uiDefault Tree.selectionArc						int
  * @uiDefault Tree.wideSelection					boolean
+ * @uiDefault Tree.wideCellRenderer					boolean
  * @uiDefault Tree.showCellFocusIndicator			boolean
  * @uiDefault Tree.showDefaultIcons					boolean
  *
@@ -146,6 +147,7 @@ public class FlatTreeUI
 	/** @since 3 */ @Styleable protected Insets selectionInsets;
 	/** @since 3 */ @Styleable protected int selectionArc;
 	@Styleable protected boolean wideSelection;
+	/** @since 3.6 */ @Styleable protected boolean wideCellRenderer;
 	@Styleable protected boolean showCellFocusIndicator;
 	/** @since 3 */ protected boolean showDefaultIcons;
 
@@ -198,6 +200,7 @@ public class FlatTreeUI
 		selectionInsets = UIManager.getInsets( "Tree.selectionInsets" );
 		selectionArc = UIManager.getInt( "Tree.selectionArc" );
 		wideSelection = UIManager.getBoolean( "Tree.wideSelection" );
+		wideCellRenderer = UIManager.getBoolean( "Tree.wideCellRenderer" );
 		showCellFocusIndicator = UIManager.getBoolean( "Tree.showCellFocusIndicator" );
 		showDefaultIcons = UIManager.getBoolean( "Tree.showDefaultIcons" );
 
@@ -314,6 +317,7 @@ public class FlatTreeUI
 			if( e.getSource() == tree ) {
 				switch( e.getPropertyName() ) {
 					case TREE_WIDE_SELECTION:
+					case TREE_WIDE_CELL_RENDERER:
 					case TREE_PAINT_SELECTION:
 						HiDPIUtils.repaint( tree );
 						break;
@@ -584,6 +588,18 @@ public class FlatTreeUI
 				UIScale.scale( selectionInsets ), arc, arc, arc, arc, 0 );
 		}
 
+		// update bounds for wide cell renderer
+		if( isWideSelection() && isWideCellRenderer() ) {
+			Rectangle wideBounds = new Rectangle( bounds );
+			if( tree.getComponentOrientation().isLeftToRight() )
+				wideBounds.width = tree.getWidth() - bounds.x - insets.right;
+			else {
+				wideBounds.x = insets.left;
+				wideBounds.width = bounds.x + bounds.width - insets.left;
+			}
+			bounds = wideBounds;
+		}
+
 		// do not paint row if editing
 		if( isEditing ) {
 			// paint wide selection
@@ -806,6 +822,11 @@ public class FlatTreeUI
 
 	protected boolean isWideSelection() {
 		return clientPropertyBoolean( tree, TREE_WIDE_SELECTION, wideSelection );
+	}
+
+	/** @since 3.6 */
+	protected boolean isWideCellRenderer() {
+		return clientPropertyBoolean( tree, TREE_WIDE_CELL_RENDERER, wideCellRenderer );
 	}
 
 	protected boolean isPaintSelection() {

--- a/flatlaf-core/src/main/resources/com/formdev/flatlaf/FlatLaf.properties
+++ b/flatlaf-core/src/main/resources/com/formdev/flatlaf/FlatLaf.properties
@@ -934,6 +934,7 @@ Tree.rendererMargins = 1,2,1,2
 Tree.selectionInsets = 0,0,0,0
 Tree.selectionArc = 0
 Tree.wideSelection = true
+Tree.wideCellRenderer = false
 Tree.repaintWholeRow = true
 Tree.paintLines = false
 Tree.showCellFocusIndicator = false

--- a/flatlaf-core/src/test/java/com/formdev/flatlaf/ui/TestFlatStyleableInfo.java
+++ b/flatlaf-core/src/test/java/com/formdev/flatlaf/ui/TestFlatStyleableInfo.java
@@ -969,6 +969,7 @@ public class TestFlatStyleableInfo
 			"selectionInsets", Insets.class,
 			"selectionArc", int.class,
 			"wideSelection", boolean.class,
+			"wideCellRenderer", boolean.class,
 			"showCellFocusIndicator", boolean.class,
 
 			"paintSelection", boolean.class,

--- a/flatlaf-core/src/test/java/com/formdev/flatlaf/ui/TestFlatStyleableValue.java
+++ b/flatlaf-core/src/test/java/com/formdev/flatlaf/ui/TestFlatStyleableValue.java
@@ -942,6 +942,7 @@ public class TestFlatStyleableValue
 		testInsets( c, ui, "selectionInsets", 1,2,3,4 );
 		testInteger( c, ui, "selectionArc", 123 );
 		testBoolean( c, ui, "wideSelection", true );
+		testBoolean( c, ui, "wideCellRenderer", true );
 		testBoolean( c, ui, "showCellFocusIndicator", true );
 
 		testBoolean( c, ui, "paintSelection", false );

--- a/flatlaf-core/src/test/java/com/formdev/flatlaf/ui/TestFlatStyling.java
+++ b/flatlaf-core/src/test/java/com/formdev/flatlaf/ui/TestFlatStyling.java
@@ -1191,6 +1191,7 @@ public class TestFlatStyling
 		ui.applyStyle( "selectionInsets: 1,2,3,4" );
 		ui.applyStyle( "selectionArc: 8" );
 		ui.applyStyle( "wideSelection: true" );
+		ui.applyStyle( "wideCellRenderer: true" );
 		ui.applyStyle( "showCellFocusIndicator: true" );
 
 		ui.applyStyle( "paintSelection: false" );

--- a/flatlaf-extras/src/main/java/com/formdev/flatlaf/extras/components/FlatTree.java
+++ b/flatlaf-extras/src/main/java/com/formdev/flatlaf/extras/components/FlatTree.java
@@ -29,17 +29,35 @@ public class FlatTree
 	implements FlatComponentExtension, FlatStyleableComponent
 {
 	/**
-	 * Returns if the tree shows a wide selection
+	 * Returns whether tree shows a wide selection
 	 */
 	public boolean isWideSelection() {
 		return getClientPropertyBoolean( TREE_WIDE_SELECTION, "Tree.wideSelection" );
 	}
 
 	/**
-	 * Sets if the tree shows a wide selection
+	 * Specifies whether tree shows a wide selection
 	 */
 	public void setWideSelection( boolean wideSelection ) {
 		putClientProperty( TREE_WIDE_SELECTION, wideSelection );
+	}
+
+	/**
+	 * Returns whether tree uses a wide cell renderer.
+	 *
+	 * @since 3.6
+	 */
+	public boolean isWideCellRenderer() {
+		return getClientPropertyBoolean( TREE_WIDE_CELL_RENDERER, "Tree.wideCellRenderer" );
+	}
+
+	/**
+	 * Specifies whether tree uses a wide cell renderer.
+	 *
+	 * @since 3.6
+	 */
+	public void setWideCellRenderer( boolean wideCellRenderer ) {
+		putClientProperty( TREE_WIDE_CELL_RENDERER, wideCellRenderer );
 	}
 
 	/**

--- a/flatlaf-testing/dumps/uidefaults/FlatDarkLaf_1.8.0.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatDarkLaf_1.8.0.txt
@@ -1431,6 +1431,7 @@ Tree.showDefaultIcons          false
 Tree.textBackground            #46494b  HSL 204   3  28    javax.swing.plaf.ColorUIResource [UI]
 Tree.textForeground            #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
 Tree.timeFactor                1000
+Tree.wideCellRenderer          false
 Tree.wideSelection             true
 TreeUI                         com.formdev.flatlaf.ui.FlatTreeUI
 

--- a/flatlaf-testing/dumps/uidefaults/FlatLightLaf_1.8.0.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatLightLaf_1.8.0.txt
@@ -1436,6 +1436,7 @@ Tree.showDefaultIcons          false
 Tree.textBackground            #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
 Tree.textForeground            #000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]
 Tree.timeFactor                1000
+Tree.wideCellRenderer          false
 Tree.wideSelection             true
 TreeUI                         com.formdev.flatlaf.ui.FlatTreeUI
 

--- a/flatlaf-testing/dumps/uidefaults/FlatMacDarkLaf_1.8.0.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatMacDarkLaf_1.8.0.txt
@@ -1441,6 +1441,7 @@ Tree.showDefaultIcons          false
 Tree.textBackground            #282828  HSL   0   0  16    javax.swing.plaf.ColorUIResource [UI]
 Tree.textForeground            #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 Tree.timeFactor                1000
+Tree.wideCellRenderer          false
 Tree.wideSelection             true
 TreeUI                         com.formdev.flatlaf.ui.FlatTreeUI
 

--- a/flatlaf-testing/dumps/uidefaults/FlatMacLightLaf_1.8.0.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatMacLightLaf_1.8.0.txt
@@ -1445,6 +1445,7 @@ Tree.showDefaultIcons          false
 Tree.textBackground            #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
 Tree.textForeground            #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
 Tree.timeFactor                1000
+Tree.wideCellRenderer          false
 Tree.wideSelection             true
 TreeUI                         com.formdev.flatlaf.ui.FlatTreeUI
 

--- a/flatlaf-testing/dumps/uidefaults/FlatTestLaf_1.8.0.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatTestLaf_1.8.0.txt
@@ -1495,6 +1495,7 @@ Tree.showDefaultIcons          false
 Tree.textBackground            #fff0ff  HSL 300 100  97    javax.swing.plaf.ColorUIResource [UI]
 Tree.textForeground            #ff0000  HSL   0 100  50    javax.swing.plaf.ColorUIResource [UI]
 Tree.timeFactor                1000
+Tree.wideCellRenderer          false
 Tree.wideSelection             true
 TreeUI                         com.formdev.flatlaf.ui.FlatTreeUI
 

--- a/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatComponents2Test.java
+++ b/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatComponents2Test.java
@@ -16,6 +16,7 @@
 
 package com.formdev.flatlaf.testing;
 
+import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Component;
 import java.awt.ComponentOrientation;
@@ -32,6 +33,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.function.Supplier;
 import javax.swing.*;
 import javax.swing.border.*;
 import javax.swing.event.TableModelEvent;
@@ -497,54 +499,35 @@ public class FlatComponents2Test
 		if( !(sel instanceof String) )
 			return;
 
-		JTree[] trees = { tree1, tree2, xTree1 };
+		Supplier<TreeCellRenderer> creator;
 		switch( (String) sel ) {
-			case "default":
-				for( JTree tree : trees )
-					tree.setCellRenderer( new DefaultTreeCellRenderer() );
-				break;
-
-			case "defaultSubclass":
-				for( JTree tree : trees )
-					tree.setCellRenderer( new TestDefaultTreeCellRenderer() );
-				break;
-
-			case "defaultWithIcons":
-				for( JTree tree : trees )
-					tree.setCellRenderer( new TestDefaultWithIconsTreeCellRenderer() );
-				break;
-
-			case "defaultWithIcon":
-				for( JTree tree : trees )
-					tree.setCellRenderer( new TestDefaultWithIconTreeCellRenderer() );
-				break;
-
-			case "label":
-				for( JTree tree : trees )
-					tree.setCellRenderer( new TestLabelTreeCellRenderer() );
-				break;
-
-			case "swingxDefault":
-				for( JTree tree : trees )
-					tree.setCellRenderer( new DefaultTreeRenderer() );
-				break;
-
-			case "jideCheckBox":
-				for( JTree tree : trees )
-					tree.setCellRenderer( new CheckBoxTreeCellRenderer( new DefaultTreeCellRenderer() ) );
-				break;
-
-			case "jideStyled":
-				for( JTree tree : trees )
-					tree.setCellRenderer( new StyledTreeCellRenderer() );
-				break;
+			default:
+			case "default":				creator = DefaultTreeCellRenderer::new; break;
+			case "defaultSubclass":		creator = TestDefaultTreeCellRenderer::new; break;
+			case "defaultWithIcons":	creator = TestDefaultWithIconsTreeCellRenderer::new; break;
+			case "defaultWithIcon":		creator = TestDefaultWithIconTreeCellRenderer::new; break;
+			case "label":				creator = TestLabelTreeCellRenderer::new; break;
+			case "wide":				creator = TestWideTreeCellRenderer::new; break;
+			case "swingxDefault":		creator = DefaultTreeRenderer::new; break;
+			case "jideCheckBox":		creator = () -> new CheckBoxTreeCellRenderer( new DefaultTreeCellRenderer() ); break;
+			case "jideStyled":			creator = StyledTreeCellRenderer::new; break;
 		}
+
+		JTree[] trees = { tree1, tree2, xTree1 };
+		for( JTree tree : trees )
+			tree.setCellRenderer( creator.get() );
 	}
 
 	private void treeWideSelectionChanged() {
 		boolean wideSelection = treeWideSelectionCheckBox.isSelected();
 		for( JTree tree : allTrees )
 			tree.putClientProperty( FlatClientProperties.TREE_WIDE_SELECTION, wideSelection );
+	}
+
+	private void treeWideCellRendererChanged() {
+		boolean wideCellRenderer = treeWideCellRendererCheckBox.isSelected();
+		for( JTree tree : allTrees )
+			tree.putClientProperty( FlatClientProperties.TREE_WIDE_CELL_RENDERER, wideCellRenderer );
 	}
 
 	private void treePaintSelectionChanged() {
@@ -691,6 +674,7 @@ public class FlatComponents2Test
 		JLabel treeRendererLabel = new JLabel();
 		treeRendererComboBox = new JComboBox<>();
 		treeWideSelectionCheckBox = new JCheckBox();
+		treeWideCellRendererCheckBox = new JCheckBox();
 		treePaintSelectionCheckBox = new JCheckBox();
 		treePaintLinesCheckBox = new JCheckBox();
 		treeRedLinesCheckBox = new JCheckBox();
@@ -1088,6 +1072,7 @@ public class FlatComponents2Test
 				"defaultWithIcons",
 				"defaultWithIcon",
 				"label",
+				"wide",
 				"swingxDefault",
 				"jideCheckBox",
 				"jideStyled"
@@ -1099,6 +1084,11 @@ public class FlatComponents2Test
 			treeWideSelectionCheckBox.setText("wide selection");
 			treeWideSelectionCheckBox.addActionListener(e -> treeWideSelectionChanged());
 			treeOptionsPanel.add(treeWideSelectionCheckBox, "cell 0 1");
+
+			//---- treeWideCellRendererCheckBox ----
+			treeWideCellRendererCheckBox.setText("wide cell renderer");
+			treeWideCellRendererCheckBox.addActionListener(e -> treeWideCellRendererChanged());
+			treeOptionsPanel.add(treeWideCellRendererCheckBox, "cell 0 1");
 
 			//---- treePaintSelectionCheckBox ----
 			treePaintSelectionCheckBox.setText("paint selection");
@@ -1266,6 +1256,7 @@ public class FlatComponents2Test
 	private JPanel treeOptionsPanel;
 	private JComboBox<String> treeRendererComboBox;
 	private JCheckBox treeWideSelectionCheckBox;
+	private JCheckBox treeWideCellRendererCheckBox;
 	private JCheckBox treePaintSelectionCheckBox;
 	private JCheckBox treePaintLinesCheckBox;
 	private JCheckBox treeRedLinesCheckBox;
@@ -1790,6 +1781,32 @@ public class FlatComponents2Test
 			boolean leaf, int row, boolean hasFocus )
 		{
 			setText( String.valueOf( value ) );
+			return this;
+		}
+	}
+
+	//---- class TestLabelTreeCellRenderer ------------------------------------
+
+	private static class TestWideTreeCellRenderer
+		extends JPanel
+		implements TreeCellRenderer
+	{
+		private final JLabel label = new JLabel();
+		private final JLabel icon = new JLabel( UIManager.getIcon( "FileView.floppyDriveIcon" ) );
+
+		TestWideTreeCellRenderer() {
+			super( new BorderLayout() );
+			setOpaque( false );
+			add( label, BorderLayout.CENTER );
+			add( icon, BorderLayout.LINE_END );
+			setBorder( new LineBorder( Color.red ) );
+		}
+
+		@Override
+		public Component getTreeCellRendererComponent( JTree tree, Object value, boolean selected, boolean expanded,
+			boolean leaf, int row, boolean hasFocus )
+		{
+			label.setText( String.valueOf( value ) );
 			return this;
 		}
 	}

--- a/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatComponents2Test.jfd
+++ b/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatComponents2Test.jfd
@@ -1,4 +1,4 @@
-JFDML JFormDesigner: "8.2.2.0.9999" Java: "21.0.1" encoding: "UTF-8"
+JFDML JFormDesigner: "8.3" encoding: "UTF-8"
 
 new FormModel {
 	contentType: "form/swing"
@@ -484,6 +484,7 @@ new FormModel {
 						addElement( "defaultWithIcons" )
 						addElement( "defaultWithIcon" )
 						addElement( "label" )
+						addElement( "wide" )
 						addElement( "swingxDefault" )
 						addElement( "jideCheckBox" )
 						addElement( "jideStyled" )
@@ -502,6 +503,16 @@ new FormModel {
 						"JavaCodeGenerator.variableLocal": false
 					}
 					addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "treeWideSelectionChanged", false ) )
+				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+					"value": "cell 0 1"
+				} )
+				add( new FormComponent( "javax.swing.JCheckBox" ) {
+					name: "treeWideCellRendererCheckBox"
+					"text": "wide cell renderer"
+					auxiliary() {
+						"JavaCodeGenerator.variableLocal": false
+					}
+					addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "treeWideCellRendererChanged", false ) )
 				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
 					"value": "cell 0 1"
 				} )

--- a/flatlaf-theme-editor/src/main/resources/com/formdev/flatlaf/themeeditor/FlatLafUIKeys.txt
+++ b/flatlaf-theme-editor/src/main/resources/com/formdev/flatlaf/themeeditor/FlatLafUIKeys.txt
@@ -1217,6 +1217,7 @@ Tree.showDefaultIcons
 Tree.textBackground
 Tree.textForeground
 Tree.timeFactor
+Tree.wideCellRenderer
 Tree.wideSelection
 TreeUI
 TristateCheckBox.clearMixed.clientProperty


### PR DESCRIPTION
This PR adds support for wide tree cell renderers, which occupy (nearly) full width of tree.

![image](https://github.com/user-attachments/assets/2129c1be-91d7-4843-89ee-7dd83e63af12) ![image](https://github.com/user-attachments/assets/aa1f2ab2-2718-48e6-9dc6-9a39a43017ed)

Left screenshot shows bounds of wide cells renderers (red rectangles).
Right screenshot shows default (non-wide) cell bounds.

This gives you more flexibility and you can use whole row width to show some extra information. (see issue #922)
E.g. an icon for some rows:

![image](https://github.com/user-attachments/assets/8c2faf40-7285-499f-aa0c-41dec37ac1ed)

## How to enable

For a single tree:

~~~java
tree.putClientProperty( FlatClientProperties.TREE_WIDE_CELL_RENDERER, true );
~~~

For all trees in app use properties file:

~~~properties
Tree.wideCellRenderer = true
~~~
