### PR TITLE
Increase contrast of text for better readability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,13 @@ FlatLaf Change Log
 
 - macOS: Re-enabled rounded popup border (see PR #772) on macOS 14.4+ (was
   disabled in 3.5.x).
-- Increased contrast of text for better readability: (issue #762)
-  - In **FlatLaf Dark**, **FlatLaf Darcula** and many dark IntelliJ themes made
+- Increased contrast of text for better readability: (PR #972; issue #762)
+  - In **FlatLaf Dark**, **FlatLaf Darcula** and many dark IntelliJ themes, made
     all text colors brighter.
-  - In **FlatLaf Light**, **FlatLaf IntelliJ** and many light IntelliJ themes
+  - In **FlatLaf Light**, **FlatLaf IntelliJ** and many light IntelliJ themes,
     made disabled text colors slightly darker.
-  - In **FlatLaf macOS Light** made disabled text colors darker.
-  - In **FlatLaf macOS Dark** made text colors of "default" button and selected
+  - In **FlatLaf macOS Light**, made disabled text colors darker.
+  - In **FlatLaf macOS Dark**, made text colors of "default" button and selected
     ToggleButton lighter.
 - CheckBox: Support styling indeterminate state of
   [tri-state check boxes](https://www.javadoc.io/doc/com.formdev/flatlaf-extras/latest/com/formdev/flatlaf/extras/components/FlatTriStateCheckBox.html).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ FlatLaf Change Log
 
 - macOS: Re-enabled rounded popup border (see PR #772) on macOS 14.4+ (was
   disabled in 3.5.x).
+- Increased contrast of text for better readability: (issue #762)
+  - In **FlatLaf Dark**, **FlatLaf Darcula** and many dark IntelliJ themes made
+    all text colors brighter.
+  - In **FlatLaf Light**, **FlatLaf IntelliJ** and many light IntelliJ themes
+    made disabled text colors slightly darker.
+  - In **FlatLaf macOS Light** made disabled text colors darker.
+  - In **FlatLaf macOS Dark** made text colors of "default" button and selected
+    ToggleButton lighter.
 - CheckBox: Support styling indeterminate state of
   [tri-state check boxes](https://www.javadoc.io/doc/com.formdev/flatlaf-extras/latest/com/formdev/flatlaf/extras/components/FlatTriStateCheckBox.html).
   (PR #936; issue #919)

--- a/flatlaf-core/src/main/resources/com/formdev/flatlaf/FlatDarkLaf.properties
+++ b/flatlaf-core/src/main/resources/com/formdev/flatlaf/FlatDarkLaf.properties
@@ -34,7 +34,7 @@
 
 # general background and foreground (text color)
 @background = #3c3f41
-@foreground = #bbb
+@foreground = #ddd
 @disabledBackground = @background
 @disabledForeground = shade(@foreground,25%)
 
@@ -45,7 +45,7 @@
 
 # selection
 @selectionBackground = @accentSelectionBackground
-@selectionForeground = contrast(@selectionBackground, @background, @foreground, 25%)
+@selectionForeground = contrast(@selectionBackground, shade(@background), tint(@foreground), 25%)
 @selectionInactiveBackground = spin(saturate(shade(@selectionBackground,70%),20%),-15)
 @selectionInactiveForeground = @foreground
 
@@ -262,7 +262,7 @@ PopupMenu.hoverScrollArrowBackground = lighten(@background,5%)
 ProgressBar.background = lighten(@background,8%)
 ProgressBar.foreground = @accentSliderColor
 ProgressBar.selectionBackground = @foreground
-ProgressBar.selectionForeground = contrast($ProgressBar.foreground, @background, @foreground, 25%)
+ProgressBar.selectionForeground = contrast($ProgressBar.foreground, shade(@background), tint(@foreground), 25%)
 
 
 #---- RootPane ----

--- a/flatlaf-core/src/main/resources/com/formdev/flatlaf/FlatDarkLaf.properties
+++ b/flatlaf-core/src/main/resources/com/formdev/flatlaf/FlatDarkLaf.properties
@@ -284,7 +284,7 @@ ScrollBar.pressedButtonBackground = lighten(@background,10%,derived noAutoInvers
 
 #---- Separator ----
 
-Separator.foreground = tint(@background,10%)
+Separator.foreground = tint(@background,15%)
 
 
 #---- Slider ----

--- a/flatlaf-core/src/main/resources/com/formdev/flatlaf/FlatLightLaf.properties
+++ b/flatlaf-core/src/main/resources/com/formdev/flatlaf/FlatLightLaf.properties
@@ -36,7 +36,7 @@
 @background = #f2f2f2
 @foreground = #000
 @disabledBackground = @background
-@disabledForeground = tint(@foreground,55%)
+@disabledForeground = tint(@foreground,50%)
 
 # component background
 @buttonBackground = lighten(@background,5%)

--- a/flatlaf-core/src/main/resources/com/formdev/flatlaf/themes/FlatMacDarkLaf.properties
+++ b/flatlaf-core/src/main/resources/com/formdev/flatlaf/themes/FlatMacDarkLaf.properties
@@ -112,6 +112,7 @@ Button.borderWidth = 0
 Button.disabledBackground = darken($Button.background,10%)
 
 Button.default.borderWidth = 0
+Button.default.foreground = contrast($Button.default.background, @background, @selectionForeground, 25%)
 
 Button.toolbar.hoverBackground = #fff1
 Button.toolbar.pressedBackground = #fff2
@@ -293,6 +294,7 @@ TextPane.selectionForeground = @textSelectionForeground
 
 ToggleButton.disabledBackground = $Button.disabledBackground
 ToggleButton.selectedBackground = lighten($ToggleButton.background,20%,derived)
+ToggleButton.selectedForeground = lighten($ToggleButton.foreground,20%)
 
 ToggleButton.toolbar.selectedBackground = #fff3
 

--- a/flatlaf-core/src/main/resources/com/formdev/flatlaf/themes/FlatMacLightLaf.properties
+++ b/flatlaf-core/src/main/resources/com/formdev/flatlaf/themes/FlatMacLightLaf.properties
@@ -79,7 +79,7 @@
 # general background and foreground (text color)
 @background = #f6f6f6
 @foreground = over(@nsControlTextColor,@background)
-@disabledForeground = over(@nsTertiaryLabelColor,@background)
+@disabledForeground = over(@nsSecondaryLabelColor,@background)
 
 # component background
 @buttonBackground = @nsControlColor

--- a/flatlaf-testing/dumps/uidefaults/FlatDarculaLaf_1.8.0.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatDarculaLaf_1.8.0.txt
@@ -117,5 +117,8 @@
 
 #---- contrast ratio: ProgressBar ----
 
+- contrast ratio: ProgressBar.foreground                              #4c87c8  #3c3f41     2.8  !!!!!
++ contrast ratio: ProgressBar.foreground                              #c4c4c4  #3c3f41     6.1  !
+
 - contrast ratio: ProgressBar.selectionForeground                     #eeeeee  #4c87c8     3.2  !!!!
 + contrast ratio: ProgressBar.selectionForeground                     #3c3f41  #c4c4c4     6.1  !

--- a/flatlaf-testing/dumps/uidefaults/FlatDarculaLaf_1.8.0.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatDarculaLaf_1.8.0.txt
@@ -73,9 +73,9 @@
 #---- ProgressBar ----
 
 - ProgressBar.foreground         #4c87c8  HSL 211  53  54    javax.swing.plaf.ColorUIResource [UI]
-+ ProgressBar.foreground         #a2a2a2  HSL   0   0  64    javax.swing.plaf.ColorUIResource [UI]
++ ProgressBar.foreground         #c4c4c4  HSL   0   0  77    javax.swing.plaf.ColorUIResource [UI]
 
-- ProgressBar.selectionForeground #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+- ProgressBar.selectionForeground #eeeeee  HSL   0   0  93    javax.swing.plaf.ColorUIResource [UI]
 + ProgressBar.selectionForeground #3c3f41  HSL 204   4  25    javax.swing.plaf.ColorUIResource [UI]
 
 
@@ -117,5 +117,5 @@
 
 #---- contrast ratio: ProgressBar ----
 
-- contrast ratio: ProgressBar.selectionForeground                     #bbbbbb  #4c87c8     2.0  !!!!!
-+ contrast ratio: ProgressBar.selectionForeground                     #3c3f41  #a2a2a2     4.2  !!!
+- contrast ratio: ProgressBar.selectionForeground                     #eeeeee  #4c87c8     3.2  !!!!
++ contrast ratio: ProgressBar.selectionForeground                     #3c3f41  #c4c4c4     6.1  !

--- a/flatlaf-testing/dumps/uidefaults/FlatDarculaLaf_1.8.0.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatDarculaLaf_1.8.0.txt
@@ -113,3 +113,9 @@
 
 - ToggleButton.border            [lazy] 1,1,1,1  false    com.formdev.flatlaf.ui.FlatButtonBorder [UI]
 + ToggleButton.border            [lazy] 3,3,3,3  false    com.formdev.flatlaf.ui.FlatButtonBorder [UI]
+
+
+#---- contrast ratio: ProgressBar ----
+
+- contrast ratio: ProgressBar.selectionForeground                     #bbbbbb  #4c87c8     2.0  !!!!!
++ contrast ratio: ProgressBar.selectionForeground                     #3c3f41  #a2a2a2     4.2  !!!

--- a/flatlaf-testing/dumps/uidefaults/FlatDarkLaf_1.8.0.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatDarkLaf_1.8.0.txt
@@ -73,19 +73,19 @@ Button.default.borderColor     #557394  HSL 211  27  46    javax.swing.plaf.Colo
 Button.default.borderWidth     1
 Button.default.focusColor      #416997  HSL 212  40  42    javax.swing.plaf.ColorUIResource [UI]
 Button.default.focusedBorderColor #5b7898  HSL 211  25  48    javax.swing.plaf.ColorUIResource [UI]
-Button.default.foreground      #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+Button.default.foreground      #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 Button.default.hoverBackground #3c618c  HSL 212  40  39    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(3% autoInverse)
 Button.default.hoverBorderColor #5b7898  HSL 211  25  48    javax.swing.plaf.ColorUIResource [UI]
 Button.default.pressedBackground #406996  HSL 211  40  42    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(6% autoInverse)
 Button.defaultButtonFollowsFocus false
 Button.disabledBackground      #3c3f41  HSL 204   4  25    javax.swing.plaf.ColorUIResource [UI]
 Button.disabledBorderColor     #606263  HSL 200   2  38    javax.swing.plaf.ColorUIResource [UI]
-Button.disabledForeground      #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
+Button.disabledForeground      #a6a6a6  HSL   0   0  65    javax.swing.plaf.ColorUIResource [UI]
 Button.disabledSelectedBackground #55585a  HSL 204   3  34    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(3% autoInverse)
-Button.disabledText            #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
+Button.disabledText            #a6a6a6  HSL   0   0  65    javax.swing.plaf.ColorUIResource [UI]
 Button.focusedBorderColor      #446e9e  HSL 212  40  44    javax.swing.plaf.ColorUIResource [UI]
 Button.font                    [active] $defaultFont [UI]
-Button.foreground              #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+Button.foreground              #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 Button.highlight               #232324  HSL 240   1  14    javax.swing.plaf.ColorUIResource [UI]
 Button.hoverBackground         #55585a  HSL 204   3  34    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(3% autoInverse)
 Button.hoverBorderColor        #446e9e  HSL 212  40  44    javax.swing.plaf.ColorUIResource [UI]
@@ -97,7 +97,7 @@ Button.minimumWidth            72
 Button.pressedBackground       #5d5f62  HSL 216   3  37    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(6% autoInverse)
 Button.rollover                true
 Button.selectedBackground      #676a6c  HSL 204   2  41    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(10% autoInverse)
-Button.selectedForeground      #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+Button.selectedForeground      #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 Button.shadow                  #616365  HSL 210   2  39    javax.swing.plaf.ColorUIResource [UI]
 Button.textIconGap             4
 Button.textShiftOffset         0
@@ -119,15 +119,15 @@ Caret.width                    [active] 1
 CheckBox.arc                   4
 CheckBox.background            #3c3f41  HSL 204   4  25    javax.swing.plaf.ColorUIResource [UI]
 CheckBox.border                [lazy] 0,0,0,0  false    com.formdev.flatlaf.ui.FlatMarginBorder [UI]
-CheckBox.disabledText          #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
+CheckBox.disabledText          #a6a6a6  HSL   0   0  65    javax.swing.plaf.ColorUIResource [UI]
 CheckBox.font                  [active] $defaultFont [UI]
-CheckBox.foreground            #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+CheckBox.foreground            #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 CheckBox.icon.background       #46494b  HSL 204   3  28    javax.swing.plaf.ColorUIResource [UI]
 CheckBox.icon.borderColor      #696b6d  HSL 210   2  42    javax.swing.plaf.ColorUIResource [UI]
-CheckBox.icon.checkmarkColor   #a8a8a8  HSL   0   0  66    javax.swing.plaf.ColorUIResource [UI]
+CheckBox.icon.checkmarkColor   #c7c7c7  HSL   0   0  78    javax.swing.plaf.ColorUIResource [UI]
 CheckBox.icon.disabledBackground #3c3f41  HSL 204   4  25    javax.swing.plaf.ColorUIResource [UI]
 CheckBox.icon.disabledBorderColor #545657  HSL 200   2  34    javax.swing.plaf.ColorUIResource [UI]
-CheckBox.icon.disabledCheckmarkColor #686868  HSL   0   0  41    javax.swing.plaf.ColorUIResource [UI]
+CheckBox.icon.disabledCheckmarkColor #878787  HSL   0   0  53    javax.swing.plaf.ColorUIResource [UI]
 CheckBox.icon.focusWidth       1
 CheckBox.icon.focusedBackground #446e9e4d  30%  HSLA 212  40  44 30    javax.swing.plaf.ColorUIResource [UI]
 CheckBox.icon.focusedBorderColor #446e9e  HSL 212  40  44    javax.swing.plaf.ColorUIResource [UI]
@@ -140,10 +140,10 @@ CheckBox.icon.selectedBorderColor #87898a  HSL 200   1  54    javax.swing.plaf.C
 CheckBox.icon                  [lazy] 15,15    com.formdev.flatlaf.icons.FlatCheckBoxIcon [UI]
 CheckBox.iconTextGap           4
 CheckBox.icon[filled].checkmarkColor #46494b  HSL 204   3  28    javax.swing.plaf.ColorUIResource [UI]
-CheckBox.icon[filled].hoverSelectedBackground #a0a0a0  HSL   0   0  63    com.formdev.flatlaf.util.DerivedColor [UI]    darken(3% autoInverse)
-CheckBox.icon[filled].pressedSelectedBackground #999999  HSL   0   0  60    com.formdev.flatlaf.util.DerivedColor [UI]    darken(6% autoInverse)
-CheckBox.icon[filled].selectedBackground #a8a8a8  HSL   0   0  66    javax.swing.plaf.ColorUIResource [UI]
-CheckBox.icon[filled].selectedBorderColor #a8a8a8  HSL   0   0  66    javax.swing.plaf.ColorUIResource [UI]
+CheckBox.icon[filled].hoverSelectedBackground #bfbfbf  HSL   0   0  75    com.formdev.flatlaf.util.DerivedColor [UI]    darken(3% autoInverse)
+CheckBox.icon[filled].pressedSelectedBackground #b8b8b8  HSL   0   0  72    com.formdev.flatlaf.util.DerivedColor [UI]    darken(6% autoInverse)
+CheckBox.icon[filled].selectedBackground #c7c7c7  HSL   0   0  78    javax.swing.plaf.ColorUIResource [UI]
+CheckBox.icon[filled].selectedBorderColor #c7c7c7  HSL   0   0  78    javax.swing.plaf.ColorUIResource [UI]
 CheckBox.margin                2,2,2,2    javax.swing.plaf.InsetsUIResource [UI]
 CheckBox.rollover              true
 CheckBox.textIconGap           4
@@ -153,22 +153,22 @@ CheckBox.textShiftOffset       0
 #---- CheckBoxMenuItem ----
 
 CheckBoxMenuItem.acceleratorFont [active] $defaultFont [UI]
-CheckBoxMenuItem.acceleratorForeground #959595  HSL   0   0  58    javax.swing.plaf.ColorUIResource [UI]
-CheckBoxMenuItem.acceleratorSelectionForeground #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+CheckBoxMenuItem.acceleratorForeground #b7b7b7  HSL   0   0  72    javax.swing.plaf.ColorUIResource [UI]
+CheckBoxMenuItem.acceleratorSelectionForeground #eeeeee  HSL   0   0  93    javax.swing.plaf.ColorUIResource [UI]
 CheckBoxMenuItem.arrowIcon     [lazy] 6,10    com.formdev.flatlaf.icons.FlatMenuItemArrowIcon [UI]
 CheckBoxMenuItem.background    #303234  HSL 210   4  20    javax.swing.plaf.ColorUIResource [UI]
 CheckBoxMenuItem.border        [lazy] 0,0,0,0  false    com.formdev.flatlaf.ui.FlatMenuItemBorder [UI]
 CheckBoxMenuItem.borderPainted true
 CheckBoxMenuItem.checkIcon     [lazy] 15,15    com.formdev.flatlaf.icons.FlatCheckBoxMenuItemIcon [UI]
-CheckBoxMenuItem.disabledForeground #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
+CheckBoxMenuItem.disabledForeground #a6a6a6  HSL   0   0  65    javax.swing.plaf.ColorUIResource [UI]
 CheckBoxMenuItem.font          [active] $defaultFont [UI]
-CheckBoxMenuItem.foreground    #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
-CheckBoxMenuItem.icon.checkmarkColor #9b9b9b  HSL   0   0  61    javax.swing.plaf.ColorUIResource [UI]
-CheckBoxMenuItem.icon.disabledCheckmarkColor #5b5b5b  HSL   0   0  36    javax.swing.plaf.ColorUIResource [UI]
+CheckBoxMenuItem.foreground    #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+CheckBoxMenuItem.icon.checkmarkColor #b7b7b7  HSL   0   0  72    javax.swing.plaf.ColorUIResource [UI]
+CheckBoxMenuItem.icon.disabledCheckmarkColor #777777  HSL   0   0  47    javax.swing.plaf.ColorUIResource [UI]
 CheckBoxMenuItem.margin        3,6,3,6    javax.swing.plaf.InsetsUIResource [UI]
 CheckBoxMenuItem.opaque        false
 CheckBoxMenuItem.selectionBackground #4b6eaf  HSL 219  40  49    javax.swing.plaf.ColorUIResource [UI]
-CheckBoxMenuItem.selectionForeground #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+CheckBoxMenuItem.selectionForeground #eeeeee  HSL   0   0  93    javax.swing.plaf.ColorUIResource [UI]
 CheckBoxMenuItemUI             com.formdev.flatlaf.ui.FlatCheckBoxMenuItemUI
 
 
@@ -181,7 +181,7 @@ CheckBoxUI                     com.formdev.flatlaf.ui.FlatCheckBoxUI
 
 ColorChooser.background        #3c3f41  HSL 204   4  25    javax.swing.plaf.ColorUIResource [UI]
 ColorChooser.font              [active] $defaultFont [UI]
-ColorChooser.foreground        #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+ColorChooser.foreground        #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 ColorChooser.swatchesDefaultRecentColor #3c3f41  HSL 204   4  25    javax.swing.plaf.ColorUIResource [UI]
 ColorChooser.swatchesRecentSwatchSize [active] 16,16    javax.swing.plaf.DimensionUIResource [UI]
 ColorChooser.swatchesSwatchSize [active] 16,16    javax.swing.plaf.DimensionUIResource [UI]
@@ -191,7 +191,7 @@ ColorChooserUI                 com.formdev.flatlaf.ui.FlatColorChooserUI
 #---- ColumnControlButton ----
 
 ColumnControlButton.actionIcon [lazy] 10,10    com.formdev.flatlaf.swingx.icons.FlatColumnControlIcon [UI]
-ColumnControlButton.iconColor  #a8a8a8  HSL   0   0  66    javax.swing.plaf.ColorUIResource [UI]
+ColumnControlButton.iconColor  #c7c7c7  HSL   0   0  78    javax.swing.plaf.ColorUIResource [UI]
 
 
 #---- ComboBox ----
@@ -199,23 +199,23 @@ ColumnControlButton.iconColor  #a8a8a8  HSL   0   0  66    javax.swing.plaf.Colo
 ComboBox.background            #46494b  HSL 204   3  28    javax.swing.plaf.ColorUIResource [UI]
 ComboBox.border                [lazy] 1,1,1,1  false    com.formdev.flatlaf.ui.FlatRoundBorder [UI]
 ComboBox.borderCornerRadius    4
-ComboBox.buttonArrowColor      #9b9b9b  HSL   0   0  61    javax.swing.plaf.ColorUIResource [UI]
+ComboBox.buttonArrowColor      #b7b7b7  HSL   0   0  72    javax.swing.plaf.ColorUIResource [UI]
 ComboBox.buttonBackground      #46494b  HSL 204   3  28    javax.swing.plaf.ColorUIResource [UI]
 ComboBox.buttonDarkShadow      #7a7d7f  HSL 204   2  49    javax.swing.plaf.ColorUIResource [UI]
-ComboBox.buttonDisabledArrowColor #5b5b5b  HSL   0   0  36    javax.swing.plaf.ColorUIResource [UI]
+ComboBox.buttonDisabledArrowColor #777777  HSL   0   0  47    javax.swing.plaf.ColorUIResource [UI]
 ComboBox.buttonDisabledSeparatorColor #616365  HSL 210   2  39    javax.swing.plaf.ColorUIResource [UI]
 ComboBox.buttonEditableBackground #414446  HSL 204   4  26    javax.swing.plaf.ColorUIResource [UI]
 ComboBox.buttonHighlight       #232324  HSL 240   1  14    javax.swing.plaf.ColorUIResource [UI]
-ComboBox.buttonHoverArrowColor #b5b5b5  HSL   0   0  71    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(10%)
-ComboBox.buttonPressedArrowColor #cecece  HSL   0   0  81    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(20%)
+ComboBox.buttonHoverArrowColor #d1d1d1  HSL   0   0  82    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(10%)
+ComboBox.buttonPressedArrowColor #eaeaea  HSL   0   0  92    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(20%)
 ComboBox.buttonSeparatorColor  #616365  HSL 210   2  39    javax.swing.plaf.ColorUIResource [UI]
 ComboBox.buttonShadow          #616365  HSL 210   2  39    javax.swing.plaf.ColorUIResource [UI]
 ComboBox.buttonStyle           auto
 ComboBox.disabledBackground    #3c3f41  HSL 204   4  25    javax.swing.plaf.ColorUIResource [UI]
-ComboBox.disabledForeground    #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
+ComboBox.disabledForeground    #a6a6a6  HSL   0   0  65    javax.swing.plaf.ColorUIResource [UI]
 ComboBox.editorColumns         0
 ComboBox.font                  [active] $defaultFont [UI]
-ComboBox.foreground            #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+ComboBox.foreground            #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 ComboBox.isEnterSelectablePopup false
 ComboBox.maximumRowCount       15
 ComboBox.minimumWidth          72
@@ -224,7 +224,7 @@ ComboBox.padding               2,6,2,6    javax.swing.plaf.InsetsUIResource [UI]
 ComboBox.popupInsets           0,0,0,0    javax.swing.plaf.InsetsUIResource [UI]
 ComboBox.selectionArc          0
 ComboBox.selectionBackground   #4b6eaf  HSL 219  40  49    javax.swing.plaf.ColorUIResource [UI]
-ComboBox.selectionForeground   #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+ComboBox.selectionForeground   #eeeeee  HSL   0   0  93    javax.swing.plaf.ColorUIResource [UI]
 ComboBox.selectionInsets       0,0,0,0    javax.swing.plaf.InsetsUIResource [UI]
 ComboBox.timeFactor            1000
 ComboBoxUI                     com.formdev.flatlaf.ui.FlatComboBoxUI
@@ -271,7 +271,7 @@ DesktopIcon.background         #555c68  HSL 218  10  37    com.formdev.flatlaf.u
 DesktopIcon.border             [lazy] 4,4,4,4  false    com.formdev.flatlaf.ui.FlatEmptyBorder [UI]
 DesktopIcon.closeIcon          [lazy] 24,24    com.formdev.flatlaf.icons.FlatInternalFrameCloseIcon [UI]
 DesktopIcon.closeSize          20,20    javax.swing.plaf.DimensionUIResource [UI]
-DesktopIcon.foreground         #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+DesktopIcon.foreground         #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 DesktopIcon.iconSize           64,64    javax.swing.plaf.DimensionUIResource [UI]
 DesktopIconUI                  com.formdev.flatlaf.ui.FlatDesktopIconUI
 
@@ -286,15 +286,15 @@ DesktopPaneUI                  com.formdev.flatlaf.ui.FlatDesktopPaneUI
 EditorPane.background          #46494b  HSL 204   3  28    javax.swing.plaf.ColorUIResource [UI]
 EditorPane.border              [lazy] 0,0,0,0  false    com.formdev.flatlaf.ui.FlatMarginBorder [UI]
 EditorPane.caretBlinkRate      500
-EditorPane.caretForeground     #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+EditorPane.caretForeground     #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 EditorPane.disabledBackground  #3c3f41  HSL 204   4  25    javax.swing.plaf.ColorUIResource [UI]
 EditorPane.font                [active] $defaultFont [UI]
-EditorPane.foreground          #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+EditorPane.foreground          #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 EditorPane.inactiveBackground  #3c3f41  HSL 204   4  25    javax.swing.plaf.ColorUIResource [UI]
-EditorPane.inactiveForeground  #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
+EditorPane.inactiveForeground  #a6a6a6  HSL   0   0  65    javax.swing.plaf.ColorUIResource [UI]
 EditorPane.margin              2,6,2,6    javax.swing.plaf.InsetsUIResource [UI]
 EditorPane.selectionBackground #4b6eaf  HSL 219  40  49    javax.swing.plaf.ColorUIResource [UI]
-EditorPane.selectionForeground #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+EditorPane.selectionForeground #eeeeee  HSL   0   0  93    javax.swing.plaf.ColorUIResource [UI]
 EditorPaneUI                   com.formdev.flatlaf.ui.FlatEditorPaneUI
 
 
@@ -326,17 +326,17 @@ FileView.hardDriveIcon         [lazy] 16,16    com.formdev.flatlaf.icons.FlatFil
 FormattedTextField.background  #46494b  HSL 204   3  28    javax.swing.plaf.ColorUIResource [UI]
 FormattedTextField.border      [lazy] 1,1,1,1  false    com.formdev.flatlaf.ui.FlatTextBorder [UI]
 FormattedTextField.caretBlinkRate 500
-FormattedTextField.caretForeground #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+FormattedTextField.caretForeground #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 FormattedTextField.disabledBackground #3c3f41  HSL 204   4  25    javax.swing.plaf.ColorUIResource [UI]
 FormattedTextField.font        [active] $defaultFont [UI]
-FormattedTextField.foreground  #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+FormattedTextField.foreground  #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 FormattedTextField.iconTextGap 4
 FormattedTextField.inactiveBackground #3c3f41  HSL 204   4  25    javax.swing.plaf.ColorUIResource [UI]
-FormattedTextField.inactiveForeground #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
+FormattedTextField.inactiveForeground #a6a6a6  HSL   0   0  65    javax.swing.plaf.ColorUIResource [UI]
 FormattedTextField.margin      2,6,2,6    javax.swing.plaf.InsetsUIResource [UI]
-FormattedTextField.placeholderForeground #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
+FormattedTextField.placeholderForeground #a6a6a6  HSL   0   0  65    javax.swing.plaf.ColorUIResource [UI]
 FormattedTextField.selectionBackground #4b6eaf  HSL 219  40  49    javax.swing.plaf.ColorUIResource [UI]
-FormattedTextField.selectionForeground #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+FormattedTextField.selectionForeground #eeeeee  HSL   0   0  93    javax.swing.plaf.ColorUIResource [UI]
 FormattedTextFieldUI           com.formdev.flatlaf.ui.FlatFormattedTextFieldUI
 
 
@@ -359,12 +359,12 @@ HelpButton.hoverBorderColor    #446e9e  HSL 212  40  44    javax.swing.plaf.Colo
 HelpButton.icon                [lazy] 22,22    com.formdev.flatlaf.icons.FlatHelpButtonIcon [UI]
 HelpButton.innerFocusWidth     1
 HelpButton.pressedBackground   #5d5f62  HSL 216   3  37    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(6% autoInverse)
-HelpButton.questionMarkColor   #a8a8a8  HSL   0   0  66    javax.swing.plaf.ColorUIResource [UI]
+HelpButton.questionMarkColor   #c7c7c7  HSL   0   0  78    javax.swing.plaf.ColorUIResource [UI]
 
 
 #---- Hyperlink ----
 
-Hyperlink.disabledText         #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
+Hyperlink.disabledText         #a6a6a6  HSL   0   0  65    javax.swing.plaf.ColorUIResource [UI]
 Hyperlink.linkColor            #579bf6  HSL 214  90  65    javax.swing.plaf.ColorUIResource [UI]
 Hyperlink.visitedColor         #579bf6  HSL 214  90  65    javax.swing.plaf.ColorUIResource [UI]
 HyperlinkUI                    com.formdev.flatlaf.swingx.ui.FlatHyperlinkUI
@@ -376,7 +376,7 @@ InternalFrame.activeBorderColor #2b2d2e  HSL 200   3  17    javax.swing.plaf.Col
 InternalFrame.activeDropShadowInsets 5,5,6,6    javax.swing.plaf.InsetsUIResource [UI]
 InternalFrame.activeDropShadowOpacity 0.5
 InternalFrame.activeTitleBackground #242526  HSL 210   3  15    javax.swing.plaf.ColorUIResource [UI]
-InternalFrame.activeTitleForeground #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+InternalFrame.activeTitleForeground #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 InternalFrame.border           [lazy] 6,6,6,6  false    com.formdev.flatlaf.ui.FlatInternalFrameUI$FlatInternalFrameBorder [UI]
 InternalFrame.borderColor      #3c3f41  HSL 204   4  25    javax.swing.plaf.ColorUIResource [UI]
 InternalFrame.borderDarkShadow #7a7d7f  HSL 204   2  49    javax.swing.plaf.ColorUIResource [UI]
@@ -400,7 +400,7 @@ InternalFrame.inactiveBorderColor #353739  HSL 210   4  22    javax.swing.plaf.C
 InternalFrame.inactiveDropShadowInsets 3,3,4,4    javax.swing.plaf.InsetsUIResource [UI]
 InternalFrame.inactiveDropShadowOpacity 0.75
 InternalFrame.inactiveTitleBackground #303233  HSL 200   3  19    javax.swing.plaf.ColorUIResource [UI]
-InternalFrame.inactiveTitleForeground #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
+InternalFrame.inactiveTitleForeground #a6a6a6  HSL   0   0  65    javax.swing.plaf.ColorUIResource [UI]
 InternalFrame.maximizeIcon     [lazy] 24,24    com.formdev.flatlaf.icons.FlatInternalFrameMaximizeIcon [UI]
 InternalFrame.minimizeIcon     [lazy] 24,24    com.formdev.flatlaf.icons.FlatInternalFrameRestoreIcon [UI]
 InternalFrame.titleFont        [active] $defaultFont [UI]
@@ -440,20 +440,20 @@ JXHeader.titleFont             [active] Segoe UI bold 12    javax.swing.plaf.Fon
 
 #---- JXMonthView ----
 
-JXMonthView.arrowColor         #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+JXMonthView.arrowColor         #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 JXMonthView.background         #46494b  HSL 204   3  28    javax.swing.plaf.ColorUIResource [UI]
 JXMonthView.daysOfTheWeekForeground #aaaaaa  HSL   0   0  67    javax.swing.plaf.ColorUIResource [UI]
-JXMonthView.disabledArrowColor #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
+JXMonthView.disabledArrowColor #a6a6a6  HSL   0   0  65    javax.swing.plaf.ColorUIResource [UI]
 JXMonthView.flaggedDayForeground #e05555  HSL   0  69  61    javax.swing.plaf.ColorUIResource [UI]
 JXMonthView.font               [active] $defaultFont [UI]
-JXMonthView.leadingDayForeground #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
+JXMonthView.leadingDayForeground #a6a6a6  HSL   0   0  65    javax.swing.plaf.ColorUIResource [UI]
 JXMonthView.monthDownFileName  [lazy] 20,20    com.formdev.flatlaf.swingx.ui.FlatMonthDownIcon [UI]
 JXMonthView.monthStringBackground #4c5052  HSL 200   4  31    javax.swing.plaf.ColorUIResource [UI]
-JXMonthView.monthStringForeground #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+JXMonthView.monthStringForeground #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 JXMonthView.monthUpFileName    [lazy] 20,20    com.formdev.flatlaf.swingx.ui.FlatMonthUpIcon [UI]
 JXMonthView.selectedBackground #4b6eaf  HSL 219  40  49    javax.swing.plaf.ColorUIResource [UI]
-JXMonthView.todayColor         #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
-JXMonthView.trailingDayForeground #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
+JXMonthView.todayColor         #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+JXMonthView.trailingDayForeground #a6a6a6  HSL   0   0  65    javax.swing.plaf.ColorUIResource [UI]
 JXMonthView.unselectableDayForeground #e05555  HSL   0  69  61    javax.swing.plaf.ColorUIResource [UI]
 JXMonthView.weekOfTheYearForeground #888888  HSL   0   0  53    javax.swing.plaf.ColorUIResource [UI]
 
@@ -464,7 +464,7 @@ JXTitledPanel.borderColor      #606263  HSL 200   2  38    javax.swing.plaf.Colo
 JXTitledPanel.captionInsets    4,10,4,10    javax.swing.plaf.InsetsUIResource [UI]
 JXTitledPanel.titleBackground  #4c5052  HSL 200   4  31    javax.swing.plaf.ColorUIResource [UI]
 JXTitledPanel.titleFont        [active] Segoe UI bold 12    javax.swing.plaf.FontUIResource [UI]
-JXTitledPanel.titleForeground  #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+JXTitledPanel.titleForeground  #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 
 
 #---- JideButton ----
@@ -474,7 +474,7 @@ JideButton.border              [lazy] 0,0,0,0  false    com.formdev.flatlaf.ui.F
 JideButton.borderColor         #606263  HSL 200   2  38    javax.swing.plaf.ColorUIResource [UI]
 JideButton.darkShadow          #606263  HSL 200   2  38    javax.swing.plaf.ColorUIResource [UI]
 JideButton.focusedBackground   #505355  HSL 204   3  32    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(1% autoInverse)
-JideButton.foreground          #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+JideButton.foreground          #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 JideButton.highlight           #676a6c  HSL 204   2  41    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(10% autoInverse)
 JideButton.light               #606263  HSL 200   2  38    javax.swing.plaf.ColorUIResource [UI]
 JideButton.margin              3,3,3,3    javax.swing.plaf.InsetsUIResource [UI]
@@ -488,8 +488,8 @@ JideButtonUI                   com.formdev.flatlaf.jideoss.ui.FlatJideButtonUI
 #---- JideLabel ----
 
 JideLabel.background           #3c3f41  HSL 204   4  25    javax.swing.plaf.ColorUIResource [UI]
-JideLabel.disabledForeground   #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
-JideLabel.foreground           #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+JideLabel.disabledForeground   #a6a6a6  HSL   0   0  65    javax.swing.plaf.ColorUIResource [UI]
+JideLabel.foreground           #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 JideLabelUI                    com.formdev.flatlaf.jideoss.ui.FlatJideLabelUI
 
 
@@ -502,11 +502,11 @@ JidePopupMenuUI                com.formdev.flatlaf.jideoss.ui.FlatJidePopupMenuU
 
 JideSplitButton.background     #4e5052  HSL 210   2  31    javax.swing.plaf.ColorUIResource [UI]
 JideSplitButton.border         [lazy] 0,0,0,0  false    com.formdev.flatlaf.ui.FlatMarginBorder [UI]
-JideSplitButton.buttonArrowColor #9b9b9b  HSL   0   0  61    javax.swing.plaf.ColorUIResource [UI]
-JideSplitButton.buttonDisabledArrowColor #5b5b5b  HSL   0   0  36    javax.swing.plaf.ColorUIResource [UI]
-JideSplitButton.foreground     #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+JideSplitButton.buttonArrowColor #b7b7b7  HSL   0   0  72    javax.swing.plaf.ColorUIResource [UI]
+JideSplitButton.buttonDisabledArrowColor #777777  HSL   0   0  47    javax.swing.plaf.ColorUIResource [UI]
+JideSplitButton.foreground     #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 JideSplitButton.margin         3,3,3,3    javax.swing.plaf.InsetsUIResource [UI]
-JideSplitButton.selectionForeground #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+JideSplitButton.selectionForeground #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 JideSplitButton.textIconGap    [active] 4
 JideSplitButtonUI              com.formdev.flatlaf.jideoss.ui.FlatJideSplitButtonUI
 
@@ -519,7 +519,7 @@ JideTabbedPane.closeButtonRightMargin 0
 JideTabbedPane.contentBorderInsets 0,0,0,0    javax.swing.plaf.InsetsUIResource [UI]
 JideTabbedPane.fitStyleBoundSize 0
 JideTabbedPane.fitStyleFirstTabMargin 0
-JideTabbedPane.foreground      #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+JideTabbedPane.foreground      #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 JideTabbedPane.shadow          #3c3f41  HSL 204   4  25    javax.swing.plaf.ColorUIResource [UI]
 JideTabbedPane.tabAreaBackground #3c3f41  HSL 204   4  25    javax.swing.plaf.ColorUIResource [UI]
 JideTabbedPane.tabAreaInsets   0,0,0,0    javax.swing.plaf.InsetsUIResource [UI]
@@ -531,10 +531,10 @@ JideTabbedPaneUI               com.formdev.flatlaf.jideoss.ui.FlatJideTabbedPane
 #---- Label ----
 
 Label.background               #3c3f41  HSL 204   4  25    javax.swing.plaf.ColorUIResource [UI]
-Label.disabledForeground       #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
+Label.disabledForeground       #a6a6a6  HSL   0   0  65    javax.swing.plaf.ColorUIResource [UI]
 Label.disabledShadow           #616365  HSL 210   2  39    javax.swing.plaf.ColorUIResource [UI]
 Label.font                     [active] $defaultFont [UI]
-Label.foreground               #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+Label.foreground               #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 LabelUI                        com.formdev.flatlaf.ui.FlatLabelUI
 
 
@@ -547,18 +547,18 @@ List.cellMargins               1,6,1,6    javax.swing.plaf.InsetsUIResource [UI]
 List.cellNoFocusBorder         [lazy] 1,6,1,6  false    com.formdev.flatlaf.ui.FlatListCellBorder$Default [UI]    lineColor=#6d8ac0  HSL 219  40  59    javax.swing.plaf.ColorUIResource [UI]    lineThickness=1.000000
 List.cellRenderer              [active] javax.swing.DefaultListCellRenderer$UIResource [UI]
 List.dropCellBackground        [lazy] #3c588b  HSL 219  40  39    javax.swing.plaf.ColorUIResource [UI]
-List.dropCellForeground        [lazy] #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+List.dropCellForeground        [lazy] #eeeeee  HSL   0   0  93    javax.swing.plaf.ColorUIResource [UI]
 List.dropLineColor             [lazy] #6d8ac0  HSL 219  40  59    javax.swing.plaf.ColorUIResource [UI]
 List.focusCellHighlightBorder  [lazy] 1,6,1,6  false    com.formdev.flatlaf.ui.FlatListCellBorder$Focused [UI]    lineColor=#6d8ac0  HSL 219  40  59    javax.swing.plaf.ColorUIResource [UI]    lineThickness=1.000000
 List.focusSelectedCellHighlightBorder [lazy] 1,6,1,6  false    com.formdev.flatlaf.ui.FlatListCellBorder$Selected [UI]    lineColor=#6d8ac0  HSL 219  40  59    javax.swing.plaf.ColorUIResource [UI]    lineThickness=1.000000
 List.font                      [active] $defaultFont [UI]
-List.foreground                #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+List.foreground                #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 List.noFocusBorder             1,1,1,1  false    javax.swing.plaf.BorderUIResource$EmptyBorderUIResource [UI]
 List.selectionArc              0
 List.selectionBackground       #4b6eaf  HSL 219  40  49    javax.swing.plaf.ColorUIResource [UI]
-List.selectionForeground       #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+List.selectionForeground       #eeeeee  HSL   0   0  93    javax.swing.plaf.ColorUIResource [UI]
 List.selectionInactiveBackground #0f2a3d  HSL 205  61  15    javax.swing.plaf.ColorUIResource [UI]
-List.selectionInactiveForeground #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+List.selectionInactiveForeground #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 List.selectionInsets           0,0,0,0    javax.swing.plaf.InsetsUIResource [UI]
 List.showCellFocusIndicator    false
 List.timeFactor                1000
@@ -568,26 +568,26 @@ ListUI                         com.formdev.flatlaf.ui.FlatListUI
 #---- Menu ----
 
 Menu.acceleratorFont           [active] $defaultFont [UI]
-Menu.acceleratorForeground     #959595  HSL   0   0  58    javax.swing.plaf.ColorUIResource [UI]
-Menu.acceleratorSelectionForeground #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+Menu.acceleratorForeground     #b7b7b7  HSL   0   0  72    javax.swing.plaf.ColorUIResource [UI]
+Menu.acceleratorSelectionForeground #eeeeee  HSL   0   0  93    javax.swing.plaf.ColorUIResource [UI]
 Menu.arrowIcon                 [lazy] 6,10    com.formdev.flatlaf.icons.FlatMenuArrowIcon [UI]
 Menu.background                #303234  HSL 210   4  20    javax.swing.plaf.ColorUIResource [UI]
 Menu.border                    [lazy] 0,0,0,0  false    com.formdev.flatlaf.ui.FlatMenuItemBorder [UI]
 Menu.borderPainted             true
 Menu.cancelMode                hideLastSubmenu
 Menu.crossMenuMnemonic         true
-Menu.disabledForeground        #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
+Menu.disabledForeground        #a6a6a6  HSL   0   0  65    javax.swing.plaf.ColorUIResource [UI]
 Menu.font                      [active] $defaultFont [UI]
-Menu.foreground                #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
-Menu.icon.arrowColor           #9b9b9b  HSL   0   0  61    javax.swing.plaf.ColorUIResource [UI]
-Menu.icon.disabledArrowColor   #5b5b5b  HSL   0   0  36    javax.swing.plaf.ColorUIResource [UI]
+Menu.foreground                #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+Menu.icon.arrowColor           #b7b7b7  HSL   0   0  72    javax.swing.plaf.ColorUIResource [UI]
+Menu.icon.disabledArrowColor   #777777  HSL   0   0  47    javax.swing.plaf.ColorUIResource [UI]
 Menu.margin                    3,6,3,6    javax.swing.plaf.InsetsUIResource [UI]
 Menu.menuPopupOffsetX          0
 Menu.menuPopupOffsetY          0
 Menu.opaque                    false
 Menu.preserveTopLevelSelection false
 Menu.selectionBackground       #4b6eaf  HSL 219  40  49    javax.swing.plaf.ColorUIResource [UI]
-Menu.selectionForeground       #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+Menu.selectionForeground       #eeeeee  HSL   0   0  93    javax.swing.plaf.ColorUIResource [UI]
 Menu.shortcutKeys              length=1    [I
     [0] 8
 Menu.submenuPopupOffsetX       [active] -4
@@ -600,7 +600,7 @@ MenuBar.background             #303234  HSL 210   4  20    javax.swing.plaf.Colo
 MenuBar.border                 [lazy] 0,0,1,0  false    com.formdev.flatlaf.ui.FlatMenuBarBorder [UI]
 MenuBar.borderColor            #505254  HSL 210   2  32    javax.swing.plaf.ColorUIResource [UI]
 MenuBar.font                   [active] $defaultFont [UI]
-MenuBar.foreground             #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+MenuBar.foreground             #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 MenuBar.highlight              #232324  HSL 240   1  14    javax.swing.plaf.ColorUIResource [UI]
 MenuBar.hoverBackground        #484c4f  HSL 206   5  30    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(10% autoInverse)
 MenuBar.itemMargins            3,8,3,8    javax.swing.plaf.InsetsUIResource [UI]
@@ -619,17 +619,17 @@ MenuBarUI                      com.formdev.flatlaf.ui.FlatMenuBarUI
 MenuItem.acceleratorArrowGap   2
 MenuItem.acceleratorDelimiter  +
 MenuItem.acceleratorFont       [active] $defaultFont [UI]
-MenuItem.acceleratorForeground #959595  HSL   0   0  58    javax.swing.plaf.ColorUIResource [UI]
-MenuItem.acceleratorSelectionForeground #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+MenuItem.acceleratorForeground #b7b7b7  HSL   0   0  72    javax.swing.plaf.ColorUIResource [UI]
+MenuItem.acceleratorSelectionForeground #eeeeee  HSL   0   0  93    javax.swing.plaf.ColorUIResource [UI]
 MenuItem.arrowIcon             [lazy] 6,10    com.formdev.flatlaf.icons.FlatMenuItemArrowIcon [UI]
 MenuItem.background            #303234  HSL 210   4  20    javax.swing.plaf.ColorUIResource [UI]
 MenuItem.border                [lazy] 0,0,0,0  false    com.formdev.flatlaf.ui.FlatMenuItemBorder [UI]
 MenuItem.borderPainted         true
 MenuItem.checkBackground       #3c588b  HSL 219  40  39    com.formdev.flatlaf.util.DerivedColor [UI]    darken(10%)
 MenuItem.checkMargins          2,2,2,2    javax.swing.plaf.InsetsUIResource [UI]
-MenuItem.disabledForeground    #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
+MenuItem.disabledForeground    #a6a6a6  HSL   0   0  65    javax.swing.plaf.ColorUIResource [UI]
 MenuItem.font                  [active] $defaultFont [UI]
-MenuItem.foreground            #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+MenuItem.foreground            #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 MenuItem.iconTextGap           6
 MenuItem.margin                3,6,3,6    javax.swing.plaf.InsetsUIResource [UI]
 MenuItem.minimumIconSize       16,16    javax.swing.plaf.DimensionUIResource [UI]
@@ -637,7 +637,7 @@ MenuItem.minimumWidth          72
 MenuItem.opaque                false
 MenuItem.selectionArc          0
 MenuItem.selectionBackground   #4b6eaf  HSL 219  40  49    javax.swing.plaf.ColorUIResource [UI]
-MenuItem.selectionForeground   #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+MenuItem.selectionForeground   #eeeeee  HSL   0   0  93    javax.swing.plaf.ColorUIResource [UI]
 MenuItem.selectionInsets       0,0,0,0    javax.swing.plaf.InsetsUIResource [UI]
 MenuItem.textAcceleratorGap    24
 MenuItem.textNoAcceleratorGap  6
@@ -685,7 +685,7 @@ OptionPane.buttonOrientation   4
 OptionPane.buttonPadding       8
 OptionPane.errorIcon           [lazy] 32,32    com.formdev.flatlaf.icons.FlatOptionPaneErrorIcon [UI]
 OptionPane.font                [active] $defaultFont [UI]
-OptionPane.foreground          #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+OptionPane.foreground          #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 OptionPane.iconMessageGap      16
 OptionPane.informationIcon     [lazy] 32,32    com.formdev.flatlaf.icons.FlatOptionPaneInformationIcon [UI]
 OptionPane.maxCharactersPerLine 80
@@ -707,7 +707,7 @@ OptionPaneUI                   com.formdev.flatlaf.ui.FlatOptionPaneUI
 
 Panel.background               #3c3f41  HSL 204   4  25    javax.swing.plaf.ColorUIResource [UI]
 Panel.font                     [active] $defaultFont [UI]
-Panel.foreground               #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+Panel.foreground               #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 PanelUI                        com.formdev.flatlaf.ui.FlatPanelUI
 
 
@@ -718,20 +718,20 @@ PasswordField.border           [lazy] 1,1,1,1  false    com.formdev.flatlaf.ui.F
 PasswordField.capsLockIcon     [lazy] 16,16    com.formdev.flatlaf.icons.FlatCapsLockIcon [UI]
 PasswordField.capsLockIconColor #ffffff64  39%  HSLA   0   0 100 39    javax.swing.plaf.ColorUIResource [UI]
 PasswordField.caretBlinkRate   500
-PasswordField.caretForeground  #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+PasswordField.caretForeground  #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 PasswordField.disabledBackground #3c3f41  HSL 204   4  25    javax.swing.plaf.ColorUIResource [UI]
 PasswordField.echoChar         '\u2022'
 PasswordField.font             [active] $defaultFont [UI]
-PasswordField.foreground       #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+PasswordField.foreground       #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 PasswordField.iconTextGap      4
 PasswordField.inactiveBackground #3c3f41  HSL 204   4  25    javax.swing.plaf.ColorUIResource [UI]
-PasswordField.inactiveForeground #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
+PasswordField.inactiveForeground #a6a6a6  HSL   0   0  65    javax.swing.plaf.ColorUIResource [UI]
 PasswordField.margin           2,6,2,6    javax.swing.plaf.InsetsUIResource [UI]
-PasswordField.placeholderForeground #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
+PasswordField.placeholderForeground #a6a6a6  HSL   0   0  65    javax.swing.plaf.ColorUIResource [UI]
 PasswordField.revealIcon       [lazy] 16,16    com.formdev.flatlaf.icons.FlatRevealIcon [UI]
-PasswordField.revealIconColor  #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+PasswordField.revealIconColor  #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 PasswordField.selectionBackground #4b6eaf  HSL 219  40  49    javax.swing.plaf.ColorUIResource [UI]
-PasswordField.selectionForeground #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+PasswordField.selectionForeground #eeeeee  HSL   0   0  93    javax.swing.plaf.ColorUIResource [UI]
 PasswordField.showCapsLock     true
 PasswordField.showRevealButton false
 PasswordFieldUI                com.formdev.flatlaf.ui.FlatPasswordFieldUI
@@ -755,9 +755,9 @@ PopupMenu.borderCornerRadius   4
 PopupMenu.borderInsets         4,1,4,1    javax.swing.plaf.InsetsUIResource [UI]
 PopupMenu.consumeEventOnClose  false
 PopupMenu.font                 [active] $defaultFont [UI]
-PopupMenu.foreground           #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+PopupMenu.foreground           #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 PopupMenu.hoverScrollArrowBackground #484c4e  HSL 200   4  29    javax.swing.plaf.ColorUIResource [UI]
-PopupMenu.scrollArrowColor     #9b9b9b  HSL   0   0  61    javax.swing.plaf.ColorUIResource [UI]
+PopupMenu.scrollArrowColor     #b7b7b7  HSL   0   0  72    javax.swing.plaf.ColorUIResource [UI]
 
 
 #---- PopupMenuSeparator ----
@@ -785,8 +785,8 @@ ProgressBar.font               [active] Segoe UI plain 10    javax.swing.plaf.Fo
 ProgressBar.foreground         #4c87c8  HSL 211  53  54    javax.swing.plaf.ColorUIResource [UI]
 ProgressBar.horizontalSize     146,4    javax.swing.plaf.DimensionUIResource [UI]
 ProgressBar.repaintInterval    15
-ProgressBar.selectionBackground #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
-ProgressBar.selectionForeground #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+ProgressBar.selectionBackground #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+ProgressBar.selectionForeground #eeeeee  HSL   0   0  93    javax.swing.plaf.ColorUIResource [UI]
 ProgressBar.verticalSize       4,146    javax.swing.plaf.DimensionUIResource [UI]
 ProgressBarUI                  com.formdev.flatlaf.ui.FlatProgressBarUI
 
@@ -796,9 +796,9 @@ ProgressBarUI                  com.formdev.flatlaf.ui.FlatProgressBarUI
 RadioButton.background         #3c3f41  HSL 204   4  25    javax.swing.plaf.ColorUIResource [UI]
 RadioButton.border             [lazy] 0,0,0,0  false    com.formdev.flatlaf.ui.FlatMarginBorder [UI]
 RadioButton.darkShadow         #7a7d7f  HSL 204   2  49    javax.swing.plaf.ColorUIResource [UI]
-RadioButton.disabledText       #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
+RadioButton.disabledText       #a6a6a6  HSL   0   0  65    javax.swing.plaf.ColorUIResource [UI]
 RadioButton.font               [active] $defaultFont [UI]
-RadioButton.foreground         #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+RadioButton.foreground         #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 RadioButton.highlight          #232324  HSL 240   1  14    javax.swing.plaf.ColorUIResource [UI]
 RadioButton.icon.centerDiameter 8
 RadioButton.icon               [lazy] 15,15    com.formdev.flatlaf.icons.FlatRadioButtonIcon [UI]
@@ -815,20 +815,20 @@ RadioButton.textShiftOffset    0
 #---- RadioButtonMenuItem ----
 
 RadioButtonMenuItem.acceleratorFont [active] $defaultFont [UI]
-RadioButtonMenuItem.acceleratorForeground #959595  HSL   0   0  58    javax.swing.plaf.ColorUIResource [UI]
-RadioButtonMenuItem.acceleratorSelectionForeground #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+RadioButtonMenuItem.acceleratorForeground #b7b7b7  HSL   0   0  72    javax.swing.plaf.ColorUIResource [UI]
+RadioButtonMenuItem.acceleratorSelectionForeground #eeeeee  HSL   0   0  93    javax.swing.plaf.ColorUIResource [UI]
 RadioButtonMenuItem.arrowIcon  [lazy] 6,10    com.formdev.flatlaf.icons.FlatMenuItemArrowIcon [UI]
 RadioButtonMenuItem.background #303234  HSL 210   4  20    javax.swing.plaf.ColorUIResource [UI]
 RadioButtonMenuItem.border     [lazy] 0,0,0,0  false    com.formdev.flatlaf.ui.FlatMenuItemBorder [UI]
 RadioButtonMenuItem.borderPainted true
 RadioButtonMenuItem.checkIcon  [lazy] 15,15    com.formdev.flatlaf.icons.FlatRadioButtonMenuItemIcon [UI]
-RadioButtonMenuItem.disabledForeground #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
+RadioButtonMenuItem.disabledForeground #a6a6a6  HSL   0   0  65    javax.swing.plaf.ColorUIResource [UI]
 RadioButtonMenuItem.font       [active] $defaultFont [UI]
-RadioButtonMenuItem.foreground #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+RadioButtonMenuItem.foreground #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 RadioButtonMenuItem.margin     3,6,3,6    javax.swing.plaf.InsetsUIResource [UI]
 RadioButtonMenuItem.opaque     false
 RadioButtonMenuItem.selectionBackground #4b6eaf  HSL 219  40  49    javax.swing.plaf.ColorUIResource [UI]
-RadioButtonMenuItem.selectionForeground #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+RadioButtonMenuItem.selectionForeground #eeeeee  HSL   0   0  93    javax.swing.plaf.ColorUIResource [UI]
 RadioButtonMenuItemUI          com.formdev.flatlaf.ui.FlatRadioButtonMenuItemUI
 
 
@@ -864,7 +864,7 @@ RootPane.defaultButtonWindowKeyBindings length=8    [Ljava.lang.Object;
     [6] ctrl released ENTER
     [7] release
 RootPane.font                  [active] $defaultFont [UI]
-RootPane.foreground            #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+RootPane.foreground            #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 RootPane.honorDialogMinimumSizeOnResize true
 RootPane.honorFrameMinimumSizeOnResize false
 RootPane.inactiveBorderColor   #484c4e  HSL 200   4  29    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(5% autoInverse)
@@ -875,9 +875,9 @@ RootPaneUI                     com.formdev.flatlaf.ui.FlatRootPaneUI
 
 ScrollBar.allowsAbsolutePositioning true
 ScrollBar.background           #3c3f41  HSL 204   4  25    javax.swing.plaf.ColorUIResource [UI]
-ScrollBar.buttonArrowColor     #9b9b9b  HSL   0   0  61    javax.swing.plaf.ColorUIResource [UI]
-ScrollBar.buttonDisabledArrowColor #5b5b5b  HSL   0   0  36    javax.swing.plaf.ColorUIResource [UI]
-ScrollBar.foreground           #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+ScrollBar.buttonArrowColor     #b7b7b7  HSL   0   0  72    javax.swing.plaf.ColorUIResource [UI]
+ScrollBar.buttonDisabledArrowColor #777777  HSL   0   0  47    javax.swing.plaf.ColorUIResource [UI]
+ScrollBar.foreground           #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 ScrollBar.hoverButtonBackground #484c4e  HSL 200   4  29    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(5%)
 ScrollBar.hoverThumbColor      #6e767a  HSL 200   5  45    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(10%)
 ScrollBar.hoverThumbWithTrack  false
@@ -911,7 +911,7 @@ ScrollPane.background          #3e4244  HSL 200   5  25    com.formdev.flatlaf.u
 ScrollPane.border              [lazy] 1,1,1,1  false    com.formdev.flatlaf.ui.FlatScrollPaneBorder [UI]
 ScrollPane.fillUpperCorner     true
 ScrollPane.font                [active] $defaultFont [UI]
-ScrollPane.foreground          #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+ScrollPane.foreground          #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 ScrollPane.smoothScrolling     true
 ScrollPaneUI                   com.formdev.flatlaf.ui.FlatScrollPaneUI
 
@@ -957,7 +957,7 @@ Slider.focusInsets             0,0,0,0    javax.swing.plaf.InsetsUIResource [UI]
 Slider.focusWidth              4
 Slider.focusedColor            #7097c24d  30%  HSLA 211  40  60 30    com.formdev.flatlaf.util.DerivedColor [UI]    changeLightness(60%) fade(30%)
 Slider.font                    [active] $defaultFont [UI]
-Slider.foreground              #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+Slider.foreground              #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 Slider.highlight               #232324  HSL 240   1  14    javax.swing.plaf.ColorUIResource [UI]
 Slider.horizontalSize          200,21    java.awt.Dimension
 Slider.hoverThumbColor         #6094ce  HSL 212  53  59    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(5% autoInverse)
@@ -968,7 +968,7 @@ Slider.pressedThumbColor       #6b9cd2  HSL 211  53  62    com.formdev.flatlaf.u
 Slider.shadow                  #616365  HSL 210   2  39    javax.swing.plaf.ColorUIResource [UI]
 Slider.thumbColor              #4c87c8  HSL 211  53  54    javax.swing.plaf.ColorUIResource [UI]
 Slider.thumbSize               12,12    javax.swing.plaf.DimensionUIResource [UI]
-Slider.tickColor               #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
+Slider.tickColor               #a6a6a6  HSL   0   0  65    javax.swing.plaf.ColorUIResource [UI]
 Slider.trackColor              #616669  HSL 203   4  40    javax.swing.plaf.ColorUIResource [UI]
 Slider.trackValueColor         #4c87c8  HSL 211  53  54    javax.swing.plaf.ColorUIResource [UI]
 Slider.trackWidth              2
@@ -981,20 +981,20 @@ SliderUI                       com.formdev.flatlaf.ui.FlatSliderUI
 Spinner.arrowButtonSize        16,5    java.awt.Dimension
 Spinner.background             #46494b  HSL 204   3  28    javax.swing.plaf.ColorUIResource [UI]
 Spinner.border                 [lazy] 1,1,1,1  false    com.formdev.flatlaf.ui.FlatRoundBorder [UI]
-Spinner.buttonArrowColor       #9b9b9b  HSL   0   0  61    javax.swing.plaf.ColorUIResource [UI]
+Spinner.buttonArrowColor       #b7b7b7  HSL   0   0  72    javax.swing.plaf.ColorUIResource [UI]
 Spinner.buttonBackground       #414446  HSL 204   4  26    javax.swing.plaf.ColorUIResource [UI]
-Spinner.buttonDisabledArrowColor #5b5b5b  HSL   0   0  36    javax.swing.plaf.ColorUIResource [UI]
+Spinner.buttonDisabledArrowColor #777777  HSL   0   0  47    javax.swing.plaf.ColorUIResource [UI]
 Spinner.buttonDisabledSeparatorColor #616365  HSL 210   2  39    javax.swing.plaf.ColorUIResource [UI]
-Spinner.buttonHoverArrowColor  #b5b5b5  HSL   0   0  71    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(10%)
-Spinner.buttonPressedArrowColor #cecece  HSL   0   0  81    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(20%)
+Spinner.buttonHoverArrowColor  #d1d1d1  HSL   0   0  82    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(10%)
+Spinner.buttonPressedArrowColor #eaeaea  HSL   0   0  92    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(20%)
 Spinner.buttonSeparatorColor   #616365  HSL 210   2  39    javax.swing.plaf.ColorUIResource [UI]
 Spinner.buttonStyle            button
 Spinner.disabledBackground     #3c3f41  HSL 204   4  25    javax.swing.plaf.ColorUIResource [UI]
-Spinner.disabledForeground     #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
+Spinner.disabledForeground     #a6a6a6  HSL   0   0  65    javax.swing.plaf.ColorUIResource [UI]
 Spinner.editorAlignment        11
 Spinner.editorBorderPainted    false
 Spinner.font                   [active] $defaultFont [UI]
-Spinner.foreground             #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+Spinner.foreground             #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 Spinner.padding                2,6,2,6    javax.swing.plaf.InsetsUIResource [UI]
 SpinnerUI                      com.formdev.flatlaf.ui.FlatSpinnerUI
 
@@ -1015,13 +1015,13 @@ SplitPane.shadow               #616365  HSL 210   2  39    javax.swing.plaf.Colo
 #---- SplitPaneDivider ----
 
 SplitPaneDivider.draggingColor #616365  HSL 210   2  39    javax.swing.plaf.ColorUIResource [UI]
-SplitPaneDivider.gripColor     #aeaeae  HSL   0   0  68    javax.swing.plaf.ColorUIResource [UI]
+SplitPaneDivider.gripColor     #cecece  HSL   0   0  81    javax.swing.plaf.ColorUIResource [UI]
 SplitPaneDivider.gripDotCount  3
 SplitPaneDivider.gripDotSize   3
 SplitPaneDivider.gripGap       2
-SplitPaneDivider.oneTouchArrowColor #9b9b9b  HSL   0   0  61    javax.swing.plaf.ColorUIResource [UI]
-SplitPaneDivider.oneTouchHoverArrowColor #b5b5b5  HSL   0   0  71    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(10%)
-SplitPaneDivider.oneTouchPressedArrowColor #cecece  HSL   0   0  81    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(20%)
+SplitPaneDivider.oneTouchArrowColor #b7b7b7  HSL   0   0  72    javax.swing.plaf.ColorUIResource [UI]
+SplitPaneDivider.oneTouchHoverArrowColor #d1d1d1  HSL   0   0  82    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(10%)
+SplitPaneDivider.oneTouchPressedArrowColor #eaeaea  HSL   0   0  92    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(20%)
 SplitPaneDivider.style         grip
 
 
@@ -1044,23 +1044,23 @@ TabbedPane.closeArc            4
 TabbedPane.closeCrossFilledSize 7.5
 TabbedPane.closeCrossLineWidth 1
 TabbedPane.closeCrossPlainSize 7.5
-TabbedPane.closeForeground     #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
+TabbedPane.closeForeground     #a6a6a6  HSL   0   0  65    javax.swing.plaf.ColorUIResource [UI]
 TabbedPane.closeHoverBackground #484c4e  HSL 200   4  29    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(5% autoInverse)
-TabbedPane.closeHoverForeground #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+TabbedPane.closeHoverForeground #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 TabbedPane.closeIcon           [lazy] 16,16    com.formdev.flatlaf.icons.FlatTabbedPaneCloseIcon [UI]
 TabbedPane.closePressedBackground #54595c  HSL 203   5  35    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(10% autoInverse)
-TabbedPane.closePressedForeground #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+TabbedPane.closePressedForeground #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 TabbedPane.closeSize           16,16    javax.swing.plaf.DimensionUIResource [UI]
 TabbedPane.contentAreaColor    #616365  HSL 210   2  39    javax.swing.plaf.ColorUIResource [UI]
 TabbedPane.contentOpaque       true
 TabbedPane.contentSeparatorHeight 1
 TabbedPane.darkShadow          #7a7d7f  HSL 204   2  49    javax.swing.plaf.ColorUIResource [UI]
-TabbedPane.disabledForeground  #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
+TabbedPane.disabledForeground  #a6a6a6  HSL   0   0  65    javax.swing.plaf.ColorUIResource [UI]
 TabbedPane.disabledUnderlineColor #747a7e  HSL 204   4  47    javax.swing.plaf.ColorUIResource [UI]
-TabbedPane.focus               #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+TabbedPane.focus               #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 TabbedPane.focusColor          #404b5d  HSL 217  18  31    javax.swing.plaf.ColorUIResource [UI]
 TabbedPane.font                [active] $defaultFont [UI]
-TabbedPane.foreground          #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+TabbedPane.foreground          #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 TabbedPane.hasFullBorder       false
 TabbedPane.hiddenTabsNavigation moreTabsButton
 TabbedPane.highlight           #232324  HSL 240   1  14    javax.swing.plaf.ColorUIResource [UI]
@@ -1108,29 +1108,29 @@ Table.cellNoFocusBorder        [lazy] 2,3,2,3  false    com.formdev.flatlaf.ui.F
 Table.consistentHomeEndKeyBehavior true
 Table.descendingSortIcon       [lazy] 10,5    com.formdev.flatlaf.icons.FlatDescendingSortIcon [UI]
 Table.dropCellBackground       [lazy] #3c588b  HSL 219  40  39    javax.swing.plaf.ColorUIResource [UI]
-Table.dropCellForeground       [lazy] #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+Table.dropCellForeground       [lazy] #eeeeee  HSL   0   0  93    javax.swing.plaf.ColorUIResource [UI]
 Table.dropLineColor            [lazy] #6d8ac0  HSL 219  40  59    javax.swing.plaf.ColorUIResource [UI]
 Table.dropLineShortColor       [lazy] #b4c3df  HSL 219  40  79    javax.swing.plaf.ColorUIResource [UI]
 Table.editorSelectAllOnStartEditing true
 Table.focusCellBackground      #46494b  HSL 204   3  28    javax.swing.plaf.ColorUIResource [UI]
-Table.focusCellForeground      #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+Table.focusCellForeground      #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 Table.focusCellHighlightBorder [lazy] 2,3,2,3  false    com.formdev.flatlaf.ui.FlatTableCellBorder$Focused [UI]    lineColor=#6d8ac0  HSL 219  40  59    javax.swing.plaf.ColorUIResource [UI]    lineThickness=1.000000
 Table.focusSelectedCellHighlightBorder [lazy] 2,3,2,3  false    com.formdev.flatlaf.ui.FlatTableCellBorder$Selected [UI]    lineColor=#6d8ac0  HSL 219  40  59    javax.swing.plaf.ColorUIResource [UI]    lineThickness=1.000000
 Table.font                     [active] $defaultFont [UI]
-Table.foreground               #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+Table.foreground               #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 Table.gridColor                #5a5e60  HSL 200   3  36    javax.swing.plaf.ColorUIResource [UI]
 Table.intercellSpacing         0,0    javax.swing.plaf.DimensionUIResource [UI]
 Table.paintOutsideAlternateRows false
 Table.rowHeight                20
 Table.scrollPaneBorder         [lazy] 1,1,1,1  false    com.formdev.flatlaf.ui.FlatScrollPaneBorder [UI]
 Table.selectionBackground      #4b6eaf  HSL 219  40  49    javax.swing.plaf.ColorUIResource [UI]
-Table.selectionForeground      #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+Table.selectionForeground      #eeeeee  HSL   0   0  93    javax.swing.plaf.ColorUIResource [UI]
 Table.selectionInactiveBackground #0f2a3d  HSL 205  61  15    javax.swing.plaf.ColorUIResource [UI]
-Table.selectionInactiveForeground #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+Table.selectionInactiveForeground #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 Table.showHorizontalLines      false
 Table.showTrailingVerticalLine false
 Table.showVerticalLines        false
-Table.sortIconColor            #aeaeae  HSL   0   0  68    javax.swing.plaf.ColorUIResource [UI]
+Table.sortIconColor            #cecece  HSL   0   0  81    javax.swing.plaf.ColorUIResource [UI]
 
 
 #---- TableHeader ----
@@ -1141,7 +1141,7 @@ TableHeader.cellBorder         [lazy] 2,3,2,3  false    com.formdev.flatlaf.ui.F
 TableHeader.cellMargins        2,3,2,3    javax.swing.plaf.InsetsUIResource [UI]
 TableHeader.focusCellBackground #46494b  HSL 204   3  28    javax.swing.plaf.ColorUIResource [UI]
 TableHeader.font               [active] $defaultFont [UI]
-TableHeader.foreground         #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+TableHeader.foreground         #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 TableHeader.height             25
 TableHeader.hoverBackground    #525658  HSL 200   4  33    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(5% autoInverse)
 TableHeader.pressedBackground  #5f6365  HSL 200   3  38    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(10% autoInverse)
@@ -1165,7 +1165,7 @@ TaskPane.specialTitleBackground #afafaf  HSL   0   0  69    javax.swing.plaf.Col
 TaskPane.specialTitleForeground #222222  HSL   0   0  13    javax.swing.plaf.ColorUIResource [UI]
 TaskPane.specialTitleOver      #666666  HSL   0   0  40    javax.swing.plaf.ColorUIResource [UI]
 TaskPane.titleBackgroundGradientStart #4c5052  HSL 200   4  31    javax.swing.plaf.ColorUIResource [UI]
-TaskPane.titleForeground       #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+TaskPane.titleForeground       #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 TaskPane.titleOver             #888888  HSL   0   0  53    javax.swing.plaf.ColorUIResource [UI]
 
 
@@ -1180,15 +1180,15 @@ TaskPaneContainer.border       [lazy] 10,10,10,10  false    com.formdev.flatlaf.
 TextArea.background            #46494b  HSL 204   3  28    javax.swing.plaf.ColorUIResource [UI]
 TextArea.border                [lazy] 0,0,0,0  false    com.formdev.flatlaf.ui.FlatMarginBorder [UI]
 TextArea.caretBlinkRate        500
-TextArea.caretForeground       #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+TextArea.caretForeground       #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 TextArea.disabledBackground    #3c3f41  HSL 204   4  25    javax.swing.plaf.ColorUIResource [UI]
 TextArea.font                  [active] $defaultFont [UI]
-TextArea.foreground            #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+TextArea.foreground            #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 TextArea.inactiveBackground    #3c3f41  HSL 204   4  25    javax.swing.plaf.ColorUIResource [UI]
-TextArea.inactiveForeground    #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
+TextArea.inactiveForeground    #a6a6a6  HSL   0   0  65    javax.swing.plaf.ColorUIResource [UI]
 TextArea.margin                2,6,2,6    javax.swing.plaf.InsetsUIResource [UI]
 TextArea.selectionBackground   #4b6eaf  HSL 219  40  49    javax.swing.plaf.ColorUIResource [UI]
-TextArea.selectionForeground   #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+TextArea.selectionForeground   #eeeeee  HSL   0   0  93    javax.swing.plaf.ColorUIResource [UI]
 TextAreaUI                     com.formdev.flatlaf.ui.FlatTextAreaUI
 
 
@@ -1204,20 +1204,20 @@ TextComponent.selectAllOnMouseClick false
 TextField.background           #46494b  HSL 204   3  28    javax.swing.plaf.ColorUIResource [UI]
 TextField.border               [lazy] 1,1,1,1  false    com.formdev.flatlaf.ui.FlatTextBorder [UI]
 TextField.caretBlinkRate       500
-TextField.caretForeground      #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+TextField.caretForeground      #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 TextField.darkShadow           #7a7d7f  HSL 204   2  49    javax.swing.plaf.ColorUIResource [UI]
 TextField.disabledBackground   #3c3f41  HSL 204   4  25    javax.swing.plaf.ColorUIResource [UI]
 TextField.font                 [active] $defaultFont [UI]
-TextField.foreground           #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+TextField.foreground           #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 TextField.highlight            #232324  HSL 240   1  14    javax.swing.plaf.ColorUIResource [UI]
 TextField.iconTextGap          4
 TextField.inactiveBackground   #3c3f41  HSL 204   4  25    javax.swing.plaf.ColorUIResource [UI]
-TextField.inactiveForeground   #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
+TextField.inactiveForeground   #a6a6a6  HSL   0   0  65    javax.swing.plaf.ColorUIResource [UI]
 TextField.light                #2f3031  HSL 210   2  19    javax.swing.plaf.ColorUIResource [UI]
 TextField.margin               2,6,2,6    javax.swing.plaf.InsetsUIResource [UI]
-TextField.placeholderForeground #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
+TextField.placeholderForeground #a6a6a6  HSL   0   0  65    javax.swing.plaf.ColorUIResource [UI]
 TextField.selectionBackground  #4b6eaf  HSL 219  40  49    javax.swing.plaf.ColorUIResource [UI]
-TextField.selectionForeground  #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+TextField.selectionForeground  #eeeeee  HSL   0   0  93    javax.swing.plaf.ColorUIResource [UI]
 TextField.shadow               #616365  HSL 210   2  39    javax.swing.plaf.ColorUIResource [UI]
 TextFieldUI                    com.formdev.flatlaf.ui.FlatTextFieldUI
 
@@ -1227,15 +1227,15 @@ TextFieldUI                    com.formdev.flatlaf.ui.FlatTextFieldUI
 TextPane.background            #46494b  HSL 204   3  28    javax.swing.plaf.ColorUIResource [UI]
 TextPane.border                [lazy] 0,0,0,0  false    com.formdev.flatlaf.ui.FlatMarginBorder [UI]
 TextPane.caretBlinkRate        500
-TextPane.caretForeground       #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+TextPane.caretForeground       #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 TextPane.disabledBackground    #3c3f41  HSL 204   4  25    javax.swing.plaf.ColorUIResource [UI]
 TextPane.font                  [active] $defaultFont [UI]
-TextPane.foreground            #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+TextPane.foreground            #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 TextPane.inactiveBackground    #3c3f41  HSL 204   4  25    javax.swing.plaf.ColorUIResource [UI]
-TextPane.inactiveForeground    #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
+TextPane.inactiveForeground    #a6a6a6  HSL   0   0  65    javax.swing.plaf.ColorUIResource [UI]
 TextPane.margin                2,6,2,6    javax.swing.plaf.InsetsUIResource [UI]
 TextPane.selectionBackground   #4b6eaf  HSL 219  40  49    javax.swing.plaf.ColorUIResource [UI]
-TextPane.selectionForeground   #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+TextPane.selectionForeground   #eeeeee  HSL   0   0  93    javax.swing.plaf.ColorUIResource [UI]
 TextPaneUI                     com.formdev.flatlaf.ui.FlatTextPaneUI
 
 
@@ -1255,15 +1255,15 @@ TitlePane.closeHoverForeground #ffffff  HSL   0   0 100    javax.swing.plaf.Colo
 TitlePane.closeIcon            [lazy] 44,30    com.formdev.flatlaf.icons.FlatWindowCloseIcon [UI]
 TitlePane.closePressedBackground #c42b1ce6  90%  HSLA   5  75  44 90    javax.swing.plaf.ColorUIResource [UI]
 TitlePane.closePressedForeground #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
-TitlePane.embeddedForeground   #959595  HSL   0   0  58    javax.swing.plaf.ColorUIResource [UI]
+TitlePane.embeddedForeground   #b7b7b7  HSL   0   0  72    javax.swing.plaf.ColorUIResource [UI]
 TitlePane.font                 [active] $defaultFont [UI]
-TitlePane.foreground           #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+TitlePane.foreground           #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 TitlePane.icon                 [lazy] 16,16    sun.swing.ImageIconUIResource [UI]  (sun.awt.image.ToolkitImage)
 TitlePane.iconMargins          3,8,3,8    javax.swing.plaf.InsetsUIResource [UI]
 TitlePane.iconSize             16,16    javax.swing.plaf.DimensionUIResource [UI]
 TitlePane.iconifyIcon          [lazy] 44,30    com.formdev.flatlaf.icons.FlatWindowIconifyIcon [UI]
 TitlePane.inactiveBackground   #303234  HSL 210   4  20    javax.swing.plaf.ColorUIResource [UI]
-TitlePane.inactiveForeground   #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
+TitlePane.inactiveForeground   #a6a6a6  HSL   0   0  65    javax.swing.plaf.ColorUIResource [UI]
 TitlePane.maximizeIcon         [lazy] 44,30    com.formdev.flatlaf.icons.FlatWindowMaximizeIcon [UI]
 TitlePane.menuBarEmbedded      true
 TitlePane.menuBarTitleGap      40
@@ -1291,7 +1291,7 @@ TitlePane.useWindowDecorations true
 
 TitledBorder.border            [lazy] 1,1,1,1  false    com.formdev.flatlaf.ui.FlatLineBorder [UI]    lineColor=#505254  HSL 210   2  32    javax.swing.plaf.ColorUIResource [UI]    lineThickness=1.000000
 TitledBorder.font              [active] $defaultFont [UI]
-TitledBorder.titleColor        #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+TitledBorder.titleColor        #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 
 
 #---- TitledPanel ----
@@ -1306,9 +1306,9 @@ ToggleButton.border            [lazy] 1,1,1,1  false    com.formdev.flatlaf.ui.F
 ToggleButton.darkShadow        #7a7d7f  HSL 204   2  49    javax.swing.plaf.ColorUIResource [UI]
 ToggleButton.disabledBackground #3c3f41  HSL 204   4  25    javax.swing.plaf.ColorUIResource [UI]
 ToggleButton.disabledSelectedBackground #55585a  HSL 204   3  34    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(3% autoInverse)
-ToggleButton.disabledText      #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
+ToggleButton.disabledText      #a6a6a6  HSL   0   0  65    javax.swing.plaf.ColorUIResource [UI]
 ToggleButton.font              [active] $defaultFont [UI]
-ToggleButton.foreground        #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+ToggleButton.foreground        #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 ToggleButton.highlight         #232324  HSL 240   1  14    javax.swing.plaf.ColorUIResource [UI]
 ToggleButton.iconTextGap       4
 ToggleButton.light             #2f3031  HSL 210   2  19    javax.swing.plaf.ColorUIResource [UI]
@@ -1316,7 +1316,7 @@ ToggleButton.margin            2,14,2,14    javax.swing.plaf.InsetsUIResource [U
 ToggleButton.pressedBackground #5d5f62  HSL 216   3  37    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(6% autoInverse)
 ToggleButton.rollover          true
 ToggleButton.selectedBackground #676a6c  HSL 204   2  41    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(10% autoInverse)
-ToggleButton.selectedForeground #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+ToggleButton.selectedForeground #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 ToggleButton.shadow            #616365  HSL 210   2  39    javax.swing.plaf.ColorUIResource [UI]
 ToggleButton.tab.disabledUnderlineColor #747a7e  HSL 204   4  47    javax.swing.plaf.ColorUIResource [UI]
 ToggleButton.tab.focusBackground #404b5d  HSL 217  18  31    javax.swing.plaf.ColorUIResource [UI]
@@ -1345,8 +1345,8 @@ ToolBar.floatingBackground     #3c3f41  HSL 204   4  25    javax.swing.plaf.Colo
 ToolBar.floatingForeground     #616365  HSL 210   2  39    javax.swing.plaf.ColorUIResource [UI]
 ToolBar.focusableButtons       false
 ToolBar.font                   [active] $defaultFont [UI]
-ToolBar.foreground             #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
-ToolBar.gripColor              #aeaeae  HSL   0   0  68    javax.swing.plaf.ColorUIResource [UI]
+ToolBar.foreground             #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+ToolBar.gripColor              #cecece  HSL   0   0  81    javax.swing.plaf.ColorUIResource [UI]
 ToolBar.highlight              #232324  HSL 240   1  14    javax.swing.plaf.ColorUIResource [UI]
 ToolBar.hoverButtonGroupArc    8
 ToolBar.hoverButtonGroupBackground #434749  HSL 200   4  27    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(3% autoInverse)
@@ -1374,7 +1374,7 @@ ToolTip.background             #1e2021  HSL 200   5  12    javax.swing.plaf.Colo
 ToolTip.border                 [lazy] 4,6,4,6  false    com.formdev.flatlaf.ui.FlatEmptyBorder [UI]
 ToolTip.borderCornerRadius     4
 ToolTip.font                   [active] $defaultFont [UI]
-ToolTip.foreground             #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+ToolTip.foreground             #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 
 
 #---- ToolTipManager ----
@@ -1396,18 +1396,18 @@ Tree.closedIcon                [lazy] 16,16    com.formdev.flatlaf.icons.FlatTre
 Tree.collapsedIcon             [lazy] 11,11    com.formdev.flatlaf.icons.FlatTreeCollapsedIcon [UI]
 Tree.drawsFocusBorderAroundIcon false
 Tree.dropCellBackground        [lazy] #3c588b  HSL 219  40  39    javax.swing.plaf.ColorUIResource [UI]
-Tree.dropCellForeground        [lazy] #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+Tree.dropCellForeground        [lazy] #eeeeee  HSL   0   0  93    javax.swing.plaf.ColorUIResource [UI]
 Tree.dropLineColor             [lazy] #6d8ac0  HSL 219  40  59    javax.swing.plaf.ColorUIResource [UI]
 Tree.editorBorder              [lazy] 1,1,1,1  false    com.formdev.flatlaf.ui.FlatLineBorder [UI]    lineColor=#6d8ac0  HSL 219  40  59    javax.swing.plaf.ColorUIResource [UI]    lineThickness=1.000000
 Tree.expandedIcon              [lazy] 11,11    com.formdev.flatlaf.icons.FlatTreeExpandedIcon [UI]
 Tree.font                      [active] $defaultFont [UI]
-Tree.foreground                #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+Tree.foreground                #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 Tree.hash                      #525658  HSL 200   4  33    javax.swing.plaf.ColorUIResource [UI]
-Tree.icon.closedColor          #aeaeae  HSL   0   0  68    javax.swing.plaf.ColorUIResource [UI]
-Tree.icon.collapsedColor       #aeaeae  HSL   0   0  68    javax.swing.plaf.ColorUIResource [UI]
-Tree.icon.expandedColor        #aeaeae  HSL   0   0  68    javax.swing.plaf.ColorUIResource [UI]
-Tree.icon.leafColor            #aeaeae  HSL   0   0  68    javax.swing.plaf.ColorUIResource [UI]
-Tree.icon.openColor            #aeaeae  HSL   0   0  68    javax.swing.plaf.ColorUIResource [UI]
+Tree.icon.closedColor          #cecece  HSL   0   0  81    javax.swing.plaf.ColorUIResource [UI]
+Tree.icon.collapsedColor       #cecece  HSL   0   0  81    javax.swing.plaf.ColorUIResource [UI]
+Tree.icon.expandedColor        #cecece  HSL   0   0  81    javax.swing.plaf.ColorUIResource [UI]
+Tree.icon.leafColor            #cecece  HSL   0   0  81    javax.swing.plaf.ColorUIResource [UI]
+Tree.icon.openColor            #cecece  HSL   0   0  81    javax.swing.plaf.ColorUIResource [UI]
 Tree.leafIcon                  [lazy] 16,16    com.formdev.flatlaf.icons.FlatTreeLeafIcon [UI]
 Tree.leftChildIndent           7
 Tree.lineTypeDashed            false
@@ -1422,14 +1422,14 @@ Tree.scrollsOnExpand           true
 Tree.selectionArc              0
 Tree.selectionBackground       #4b6eaf  HSL 219  40  49    javax.swing.plaf.ColorUIResource [UI]
 Tree.selectionBorderColor      #6d8ac0  HSL 219  40  59    javax.swing.plaf.ColorUIResource [UI]
-Tree.selectionForeground       #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+Tree.selectionForeground       #eeeeee  HSL   0   0  93    javax.swing.plaf.ColorUIResource [UI]
 Tree.selectionInactiveBackground #0f2a3d  HSL 205  61  15    javax.swing.plaf.ColorUIResource [UI]
-Tree.selectionInactiveForeground #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+Tree.selectionInactiveForeground #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 Tree.selectionInsets           0,0,0,0    javax.swing.plaf.InsetsUIResource [UI]
 Tree.showCellFocusIndicator    false
 Tree.showDefaultIcons          false
 Tree.textBackground            #46494b  HSL 204   3  28    javax.swing.plaf.ColorUIResource [UI]
-Tree.textForeground            #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+Tree.textForeground            #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 Tree.timeFactor                1000
 Tree.wideCellRenderer          false
 Tree.wideSelection             true
@@ -1455,7 +1455,7 @@ UIColorHighlighter.stripingBackground #525658  HSL 200   4  33    javax.swing.pl
 
 Viewport.background            #3c3f41  HSL 204   4  25    javax.swing.plaf.ColorUIResource [UI]
 Viewport.font                  [active] $defaultFont [UI]
-Viewport.foreground            #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+Viewport.foreground            #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 ViewportUI                     com.formdev.flatlaf.ui.FlatViewportUI
 
 
@@ -1504,13 +1504,13 @@ ViewportUI                     com.formdev.flatlaf.ui.FlatViewportUI
 
 activeCaption                  #434e60  HSL 217  18  32    javax.swing.plaf.ColorUIResource [UI]
 activeCaptionBorder            #434e60  HSL 217  18  32    javax.swing.plaf.ColorUIResource [UI]
-activeCaptionText              #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+activeCaptionText              #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 control                        #3c3f41  HSL 204   4  25    javax.swing.plaf.ColorUIResource [UI]
 controlDkShadow                #7a7d7f  HSL 204   2  49    javax.swing.plaf.ColorUIResource [UI]
 controlHighlight               #2f3031  HSL 210   2  19    javax.swing.plaf.ColorUIResource [UI]
 controlLtHighlight             #232324  HSL 240   1  14    javax.swing.plaf.ColorUIResource [UI]
 controlShadow                  #616365  HSL 210   2  39    javax.swing.plaf.ColorUIResource [UI]
-controlText                    #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+controlText                    #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 defaultFont                    Segoe UI plain 12    javax.swing.plaf.FontUIResource [UI]
 desktop                        #46494b  HSL 204   3  28    javax.swing.plaf.ColorUIResource [UI]
 
@@ -1558,9 +1558,9 @@ html.pendingImage              [lazy] 38,38    sun.swing.ImageIconUIResource [UI
 
 inactiveCaption                #393c3d  HSL 195   3  23    javax.swing.plaf.ColorUIResource [UI]
 inactiveCaptionBorder          #393c3d  HSL 195   3  23    javax.swing.plaf.ColorUIResource [UI]
-inactiveCaptionText            #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+inactiveCaptionText            #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 info                           #1e2021  HSL 200   5  12    javax.swing.plaf.ColorUIResource [UI]
-infoText                       #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+infoText                       #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 
 
 #---- laf ----
@@ -1587,7 +1587,7 @@ medium.font                    [active] Segoe UI plain 11    javax.swing.plaf.Fo
 #----  ----
 
 menu                           #3c3f41  HSL 204   4  25    javax.swing.plaf.ColorUIResource [UI]
-menuText                       #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+menuText                       #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 
 
 #---- mini ----
@@ -1624,12 +1624,12 @@ swingx/TaskPaneUI              com.formdev.flatlaf.swingx.ui.FlatTaskPaneUI
 
 text                           #46494b  HSL 204   3  28    javax.swing.plaf.ColorUIResource [UI]
 textHighlight                  #4b6eaf  HSL 219  40  49    javax.swing.plaf.ColorUIResource [UI]
-textHighlightText              #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
-textInactiveText               #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
-textText                       #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+textHighlightText              #eeeeee  HSL   0   0  93    javax.swing.plaf.ColorUIResource [UI]
+textInactiveText               #a6a6a6  HSL   0   0  65    javax.swing.plaf.ColorUIResource [UI]
+textText                       #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 window                         #3c3f41  HSL 204   4  25    javax.swing.plaf.ColorUIResource [UI]
-windowBorder                   #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
-windowText                     #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+windowBorder                   #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+windowText                     #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 
 
 #-------- Contrast Ratios --------
@@ -1639,114 +1639,114 @@ windowText                     #bbbbbb  HSL   0   0  73    javax.swing.plaf.Colo
 
 
 #-- activeTitleForeground --
-InternalFrame.activeTitleForeground                 #bbbbbb  #242526     8.0
+InternalFrame.activeTitleForeground                 #dddddd  #242526    11.3
 
 #-- disabledForeground --
-ComboBox.disabledForeground                         #8c8c8c  #3c3f41     3.2  !!!!
-Label.disabledForeground                            #8c8c8c  #3c3f41     3.2  !!!!
-Spinner.disabledForeground                          #8c8c8c  #3c3f41     3.2  !!!!
+ComboBox.disabledForeground                         #a6a6a6  #3c3f41     4.4  !!!
+Label.disabledForeground                            #a6a6a6  #3c3f41     4.4  !!!
+Spinner.disabledForeground                          #a6a6a6  #3c3f41     4.4  !!!
 
 #-- disabledText --
-Button.disabledText                                 #8c8c8c  #3c3f41     3.2  !!!!
-CheckBox.disabledText                               #8c8c8c  #3c3f41     3.2  !!!!
-RadioButton.disabledText                            #8c8c8c  #3c3f41     3.2  !!!!
-ToggleButton.disabledText                           #8c8c8c  #3c3f41     3.2  !!!!
+Button.disabledText                                 #a6a6a6  #3c3f41     4.4  !!!
+CheckBox.disabledText                               #a6a6a6  #3c3f41     4.4  !!!
+RadioButton.disabledText                            #a6a6a6  #3c3f41     4.4  !!!
+ToggleButton.disabledText                           #a6a6a6  #3c3f41     4.4  !!!
 
 #-- dropCellForeground --
-List.dropCellForeground                             #bbbbbb  #3c588b     3.7  !!!!
-Table.dropCellForeground                            #bbbbbb  #3c588b     3.7  !!!!
-Tree.dropCellForeground                             #bbbbbb  #3c588b     3.7  !!!!
+List.dropCellForeground                             #eeeeee  #3c588b     6.1  !
+Table.dropCellForeground                            #eeeeee  #3c588b     6.1  !
+Tree.dropCellForeground                             #eeeeee  #3c588b     6.1  !
 
 #-- focusCellForeground --
-Table.focusCellForeground                           #bbbbbb  #46494b     4.7  !!!
+Table.focusCellForeground                           #dddddd  #46494b     6.7  !
 
 #-- foreground --
-Button.foreground                                   #bbbbbb  #4e5052     4.2  !!!
-Button.default.foreground                           #bbbbbb  #375a81     3.7  !!!!
-CheckBox.foreground                                 #bbbbbb  #3c3f41     5.5  !!
-CheckBoxMenuItem.foreground                         #bbbbbb  #303234     6.7  !
-ColorChooser.foreground                             #bbbbbb  #3c3f41     5.5  !!
-ComboBox.foreground                                 #bbbbbb  #46494b     4.7  !!!
-DesktopIcon.foreground                              #bbbbbb  #555c68     3.5  !!!!
-EditorPane.foreground                               #bbbbbb  #46494b     4.7  !!!
-FormattedTextField.foreground                       #bbbbbb  #46494b     4.7  !!!
-JideButton.foreground                               #bbbbbb  #4e5052     4.2  !!!
-JideLabel.foreground                                #bbbbbb  #3c3f41     5.5  !!
-JideSplitButton.foreground                          #bbbbbb  #4e5052     4.2  !!!
-JideTabbedPane.foreground                           #bbbbbb  #3c3f41     5.5  !!
-Label.foreground                                    #bbbbbb  #3c3f41     5.5  !!
-List.foreground                                     #bbbbbb  #46494b     4.7  !!!
-Menu.foreground                                     #bbbbbb  #303234     6.7  !
-MenuBar.foreground                                  #bbbbbb  #303234     6.7  !
-MenuItem.foreground                                 #bbbbbb  #303234     6.7  !
-OptionPane.foreground                               #bbbbbb  #3c3f41     5.5  !!
-Panel.foreground                                    #bbbbbb  #3c3f41     5.5  !!
-PasswordField.foreground                            #bbbbbb  #46494b     4.7  !!!
-PopupMenu.foreground                                #bbbbbb  #303234     6.7  !
-RadioButton.foreground                              #bbbbbb  #3c3f41     5.5  !!
-RadioButtonMenuItem.foreground                      #bbbbbb  #303234     6.7  !
-RootPane.foreground                                 #bbbbbb  #3c3f41     5.5  !!
-Spinner.foreground                                  #bbbbbb  #46494b     4.7  !!!
-TabbedPane.foreground                               #bbbbbb  #3c3f41     5.5  !!
-Table.foreground                                    #bbbbbb  #46494b     4.7  !!!
-TableHeader.foreground                              #bbbbbb  #46494b     4.7  !!!
-TextArea.foreground                                 #bbbbbb  #46494b     4.7  !!!
-TextField.foreground                                #bbbbbb  #46494b     4.7  !!!
-TextPane.foreground                                 #bbbbbb  #46494b     4.7  !!!
-TitlePane.foreground                                #bbbbbb  #303234     6.7  !
-ToggleButton.foreground                             #bbbbbb  #4e5052     4.2  !!!
-ToolTip.foreground                                  #bbbbbb  #1e2021     8.5
-Tree.foreground                                     #bbbbbb  #46494b     4.7  !!!
+Button.foreground                                   #dddddd  #4e5052     6.0  !
+Button.default.foreground                           #dddddd  #375a81     5.3  !!
+CheckBox.foreground                                 #dddddd  #3c3f41     7.8
+CheckBoxMenuItem.foreground                         #dddddd  #303234     9.5
+ColorChooser.foreground                             #dddddd  #3c3f41     7.8
+ComboBox.foreground                                 #dddddd  #46494b     6.7  !
+DesktopIcon.foreground                              #dddddd  #555c68     5.0  !!
+EditorPane.foreground                               #dddddd  #46494b     6.7  !
+FormattedTextField.foreground                       #dddddd  #46494b     6.7  !
+JideButton.foreground                               #dddddd  #4e5052     6.0  !
+JideLabel.foreground                                #dddddd  #3c3f41     7.8
+JideSplitButton.foreground                          #dddddd  #4e5052     6.0  !
+JideTabbedPane.foreground                           #dddddd  #3c3f41     7.8
+Label.foreground                                    #dddddd  #3c3f41     7.8
+List.foreground                                     #dddddd  #46494b     6.7  !
+Menu.foreground                                     #dddddd  #303234     9.5
+MenuBar.foreground                                  #dddddd  #303234     9.5
+MenuItem.foreground                                 #dddddd  #303234     9.5
+OptionPane.foreground                               #dddddd  #3c3f41     7.8
+Panel.foreground                                    #dddddd  #3c3f41     7.8
+PasswordField.foreground                            #dddddd  #46494b     6.7  !
+PopupMenu.foreground                                #dddddd  #303234     9.5
+RadioButton.foreground                              #dddddd  #3c3f41     7.8
+RadioButtonMenuItem.foreground                      #dddddd  #303234     9.5
+RootPane.foreground                                 #dddddd  #3c3f41     7.8
+Spinner.foreground                                  #dddddd  #46494b     6.7  !
+TabbedPane.foreground                               #dddddd  #3c3f41     7.8
+Table.foreground                                    #dddddd  #46494b     6.7  !
+TableHeader.foreground                              #dddddd  #46494b     6.7  !
+TextArea.foreground                                 #dddddd  #46494b     6.7  !
+TextField.foreground                                #dddddd  #46494b     6.7  !
+TextPane.foreground                                 #dddddd  #46494b     6.7  !
+TitlePane.foreground                                #dddddd  #303234     9.5
+ToggleButton.foreground                             #dddddd  #4e5052     6.0  !
+ToolTip.foreground                                  #dddddd  #1e2021    12.0
+Tree.foreground                                     #dddddd  #46494b     6.7  !
 
 #-- inactiveForeground --
-EditorPane.inactiveForeground                       #8c8c8c  #3c3f41     3.2  !!!!
-FormattedTextField.inactiveForeground               #8c8c8c  #3c3f41     3.2  !!!!
-PasswordField.inactiveForeground                    #8c8c8c  #3c3f41     3.2  !!!!
-TextArea.inactiveForeground                         #8c8c8c  #3c3f41     3.2  !!!!
-TextField.inactiveForeground                        #8c8c8c  #3c3f41     3.2  !!!!
-TextPane.inactiveForeground                         #8c8c8c  #3c3f41     3.2  !!!!
-TitlePane.inactiveForeground                        #8c8c8c  #303234     3.8  !!!!
+EditorPane.inactiveForeground                       #a6a6a6  #3c3f41     4.4  !!!
+FormattedTextField.inactiveForeground               #a6a6a6  #3c3f41     4.4  !!!
+PasswordField.inactiveForeground                    #a6a6a6  #3c3f41     4.4  !!!
+TextArea.inactiveForeground                         #a6a6a6  #3c3f41     4.4  !!!
+TextField.inactiveForeground                        #a6a6a6  #3c3f41     4.4  !!!
+TextPane.inactiveForeground                         #a6a6a6  #3c3f41     4.4  !!!
+TitlePane.inactiveForeground                        #a6a6a6  #303234     5.3  !!
 
 #-- inactiveTitleForeground --
-InternalFrame.inactiveTitleForeground               #8c8c8c  #303233     3.8  !!!!
+InternalFrame.inactiveTitleForeground               #a6a6a6  #303233     5.3  !!
 
 #-- monthStringForeground --
-JXMonthView.monthStringForeground                   #bbbbbb  #4c5052     4.2  !!!
+JXMonthView.monthStringForeground                   #dddddd  #4c5052     6.0  !
 
 #-- selectedForeground --
-Button.selectedForeground                           #bbbbbb  #676a6c     2.8  !!!!!
-ToggleButton.selectedForeground                     #bbbbbb  #676a6c     2.8  !!!!!
+Button.selectedForeground                           #dddddd  #676a6c     4.0  !!!
+ToggleButton.selectedForeground                     #dddddd  #676a6c     4.0  !!!
 
 #-- selectionBackground --
-ProgressBar.selectionBackground                     #bbbbbb  #505456     4.0  !!!
+ProgressBar.selectionBackground                     #dddddd  #505456     5.6  !!
 
 #-- selectionForeground --
-CheckBoxMenuItem.selectionForeground                #bbbbbb  #4b6eaf     2.6  !!!!!
-ComboBox.selectionForeground                        #bbbbbb  #4b6eaf     2.6  !!!!!
-EditorPane.selectionForeground                      #bbbbbb  #4b6eaf     2.6  !!!!!
-FormattedTextField.selectionForeground              #bbbbbb  #4b6eaf     2.6  !!!!!
-List.selectionForeground                            #bbbbbb  #4b6eaf     2.6  !!!!!
-Menu.selectionForeground                            #bbbbbb  #4b6eaf     2.6  !!!!!
-MenuItem.selectionForeground                        #bbbbbb  #4b6eaf     2.6  !!!!!
-PasswordField.selectionForeground                   #bbbbbb  #4b6eaf     2.6  !!!!!
-ProgressBar.selectionForeground                     #bbbbbb  #4c87c8     2.0  !!!!!
-RadioButtonMenuItem.selectionForeground             #bbbbbb  #4b6eaf     2.6  !!!!!
-Table.selectionForeground                           #bbbbbb  #4b6eaf     2.6  !!!!!
-TextArea.selectionForeground                        #bbbbbb  #4b6eaf     2.6  !!!!!
-TextField.selectionForeground                       #bbbbbb  #4b6eaf     2.6  !!!!!
-TextPane.selectionForeground                        #bbbbbb  #4b6eaf     2.6  !!!!!
-Tree.selectionForeground                            #bbbbbb  #4b6eaf     2.6  !!!!!
+CheckBoxMenuItem.selectionForeground                #eeeeee  #4b6eaf     4.4  !!!
+ComboBox.selectionForeground                        #eeeeee  #4b6eaf     4.4  !!!
+EditorPane.selectionForeground                      #eeeeee  #4b6eaf     4.4  !!!
+FormattedTextField.selectionForeground              #eeeeee  #4b6eaf     4.4  !!!
+List.selectionForeground                            #eeeeee  #4b6eaf     4.4  !!!
+Menu.selectionForeground                            #eeeeee  #4b6eaf     4.4  !!!
+MenuItem.selectionForeground                        #eeeeee  #4b6eaf     4.4  !!!
+PasswordField.selectionForeground                   #eeeeee  #4b6eaf     4.4  !!!
+ProgressBar.selectionForeground                     #eeeeee  #4c87c8     3.2  !!!!
+RadioButtonMenuItem.selectionForeground             #eeeeee  #4b6eaf     4.4  !!!
+Table.selectionForeground                           #eeeeee  #4b6eaf     4.4  !!!
+TextArea.selectionForeground                        #eeeeee  #4b6eaf     4.4  !!!
+TextField.selectionForeground                       #eeeeee  #4b6eaf     4.4  !!!
+TextPane.selectionForeground                        #eeeeee  #4b6eaf     4.4  !!!
+Tree.selectionForeground                            #eeeeee  #4b6eaf     4.4  !!!
 
 #-- selectionInactiveForeground --
-List.selectionInactiveForeground                    #bbbbbb  #0f2a3d     7.7
-Table.selectionInactiveForeground                   #bbbbbb  #0f2a3d     7.7
-Tree.selectionInactiveForeground                    #bbbbbb  #0f2a3d     7.7
+List.selectionInactiveForeground                    #dddddd  #0f2a3d    10.9
+Table.selectionInactiveForeground                   #dddddd  #0f2a3d    10.9
+Tree.selectionInactiveForeground                    #dddddd  #0f2a3d    10.9
 
 #-- specialTitleForeground --
 TaskPane.specialTitleForeground                     #222222  #afafaf     7.3
 
 #-- textForeground --
-Tree.textForeground                                 #bbbbbb  #46494b     4.7  !!!
+Tree.textForeground                                 #dddddd  #46494b     6.7  !
 
 #-- titleForeground --
-JXTitledPanel.titleForeground                       #bbbbbb  #4c5052     4.2  !!!
+JXTitledPanel.titleForeground                       #dddddd  #4c5052     6.0  !

--- a/flatlaf-testing/dumps/uidefaults/FlatDarkLaf_1.8.0.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatDarkLaf_1.8.0.txt
@@ -1630,3 +1630,123 @@ textText                       #bbbbbb  HSL   0   0  73    javax.swing.plaf.Colo
 window                         #3c3f41  HSL 204   4  25    javax.swing.plaf.ColorUIResource [UI]
 windowBorder                   #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
 windowText                     #bbbbbb  HSL   0   0  73    javax.swing.plaf.ColorUIResource [UI]
+
+
+#-------- Contrast Ratios --------
+
+# WCAG 2 Contrast Requirements: minimum 4.5; enhanced 7.0
+# https://webaim.org/articles/contrast/#sc143
+
+
+#-- activeTitleForeground --
+InternalFrame.activeTitleForeground                 #bbbbbb  #242526     8.0
+
+#-- disabledForeground --
+ComboBox.disabledForeground                         #8c8c8c  #3c3f41     3.2  !!!!
+Label.disabledForeground                            #8c8c8c  #3c3f41     3.2  !!!!
+Spinner.disabledForeground                          #8c8c8c  #3c3f41     3.2  !!!!
+
+#-- disabledText --
+Button.disabledText                                 #8c8c8c  #3c3f41     3.2  !!!!
+CheckBox.disabledText                               #8c8c8c  #3c3f41     3.2  !!!!
+RadioButton.disabledText                            #8c8c8c  #3c3f41     3.2  !!!!
+ToggleButton.disabledText                           #8c8c8c  #3c3f41     3.2  !!!!
+
+#-- dropCellForeground --
+List.dropCellForeground                             #bbbbbb  #3c588b     3.7  !!!!
+Table.dropCellForeground                            #bbbbbb  #3c588b     3.7  !!!!
+Tree.dropCellForeground                             #bbbbbb  #3c588b     3.7  !!!!
+
+#-- focusCellForeground --
+Table.focusCellForeground                           #bbbbbb  #46494b     4.7  !!!
+
+#-- foreground --
+Button.foreground                                   #bbbbbb  #4e5052     4.2  !!!
+Button.default.foreground                           #bbbbbb  #375a81     3.7  !!!!
+CheckBox.foreground                                 #bbbbbb  #3c3f41     5.5  !!
+CheckBoxMenuItem.foreground                         #bbbbbb  #303234     6.7  !
+ColorChooser.foreground                             #bbbbbb  #3c3f41     5.5  !!
+ComboBox.foreground                                 #bbbbbb  #46494b     4.7  !!!
+DesktopIcon.foreground                              #bbbbbb  #555c68     3.5  !!!!
+EditorPane.foreground                               #bbbbbb  #46494b     4.7  !!!
+FormattedTextField.foreground                       #bbbbbb  #46494b     4.7  !!!
+JideButton.foreground                               #bbbbbb  #4e5052     4.2  !!!
+JideLabel.foreground                                #bbbbbb  #3c3f41     5.5  !!
+JideSplitButton.foreground                          #bbbbbb  #4e5052     4.2  !!!
+JideTabbedPane.foreground                           #bbbbbb  #3c3f41     5.5  !!
+Label.foreground                                    #bbbbbb  #3c3f41     5.5  !!
+List.foreground                                     #bbbbbb  #46494b     4.7  !!!
+Menu.foreground                                     #bbbbbb  #303234     6.7  !
+MenuBar.foreground                                  #bbbbbb  #303234     6.7  !
+MenuItem.foreground                                 #bbbbbb  #303234     6.7  !
+OptionPane.foreground                               #bbbbbb  #3c3f41     5.5  !!
+Panel.foreground                                    #bbbbbb  #3c3f41     5.5  !!
+PasswordField.foreground                            #bbbbbb  #46494b     4.7  !!!
+PopupMenu.foreground                                #bbbbbb  #303234     6.7  !
+RadioButton.foreground                              #bbbbbb  #3c3f41     5.5  !!
+RadioButtonMenuItem.foreground                      #bbbbbb  #303234     6.7  !
+RootPane.foreground                                 #bbbbbb  #3c3f41     5.5  !!
+Spinner.foreground                                  #bbbbbb  #46494b     4.7  !!!
+TabbedPane.foreground                               #bbbbbb  #3c3f41     5.5  !!
+Table.foreground                                    #bbbbbb  #46494b     4.7  !!!
+TableHeader.foreground                              #bbbbbb  #46494b     4.7  !!!
+TextArea.foreground                                 #bbbbbb  #46494b     4.7  !!!
+TextField.foreground                                #bbbbbb  #46494b     4.7  !!!
+TextPane.foreground                                 #bbbbbb  #46494b     4.7  !!!
+TitlePane.foreground                                #bbbbbb  #303234     6.7  !
+ToggleButton.foreground                             #bbbbbb  #4e5052     4.2  !!!
+ToolTip.foreground                                  #bbbbbb  #1e2021     8.5
+Tree.foreground                                     #bbbbbb  #46494b     4.7  !!!
+
+#-- inactiveForeground --
+EditorPane.inactiveForeground                       #8c8c8c  #3c3f41     3.2  !!!!
+FormattedTextField.inactiveForeground               #8c8c8c  #3c3f41     3.2  !!!!
+PasswordField.inactiveForeground                    #8c8c8c  #3c3f41     3.2  !!!!
+TextArea.inactiveForeground                         #8c8c8c  #3c3f41     3.2  !!!!
+TextField.inactiveForeground                        #8c8c8c  #3c3f41     3.2  !!!!
+TextPane.inactiveForeground                         #8c8c8c  #3c3f41     3.2  !!!!
+TitlePane.inactiveForeground                        #8c8c8c  #303234     3.8  !!!!
+
+#-- inactiveTitleForeground --
+InternalFrame.inactiveTitleForeground               #8c8c8c  #303233     3.8  !!!!
+
+#-- monthStringForeground --
+JXMonthView.monthStringForeground                   #bbbbbb  #4c5052     4.2  !!!
+
+#-- selectedForeground --
+Button.selectedForeground                           #bbbbbb  #676a6c     2.8  !!!!!
+ToggleButton.selectedForeground                     #bbbbbb  #676a6c     2.8  !!!!!
+
+#-- selectionBackground --
+ProgressBar.selectionBackground                     #bbbbbb  #505456     4.0  !!!
+
+#-- selectionForeground --
+CheckBoxMenuItem.selectionForeground                #bbbbbb  #4b6eaf     2.6  !!!!!
+ComboBox.selectionForeground                        #bbbbbb  #4b6eaf     2.6  !!!!!
+EditorPane.selectionForeground                      #bbbbbb  #4b6eaf     2.6  !!!!!
+FormattedTextField.selectionForeground              #bbbbbb  #4b6eaf     2.6  !!!!!
+List.selectionForeground                            #bbbbbb  #4b6eaf     2.6  !!!!!
+Menu.selectionForeground                            #bbbbbb  #4b6eaf     2.6  !!!!!
+MenuItem.selectionForeground                        #bbbbbb  #4b6eaf     2.6  !!!!!
+PasswordField.selectionForeground                   #bbbbbb  #4b6eaf     2.6  !!!!!
+ProgressBar.selectionForeground                     #bbbbbb  #4c87c8     2.0  !!!!!
+RadioButtonMenuItem.selectionForeground             #bbbbbb  #4b6eaf     2.6  !!!!!
+Table.selectionForeground                           #bbbbbb  #4b6eaf     2.6  !!!!!
+TextArea.selectionForeground                        #bbbbbb  #4b6eaf     2.6  !!!!!
+TextField.selectionForeground                       #bbbbbb  #4b6eaf     2.6  !!!!!
+TextPane.selectionForeground                        #bbbbbb  #4b6eaf     2.6  !!!!!
+Tree.selectionForeground                            #bbbbbb  #4b6eaf     2.6  !!!!!
+
+#-- selectionInactiveForeground --
+List.selectionInactiveForeground                    #bbbbbb  #0f2a3d     7.7
+Table.selectionInactiveForeground                   #bbbbbb  #0f2a3d     7.7
+Tree.selectionInactiveForeground                    #bbbbbb  #0f2a3d     7.7
+
+#-- specialTitleForeground --
+TaskPane.specialTitleForeground                     #222222  #afafaf     7.3
+
+#-- textForeground --
+Tree.textForeground                                 #bbbbbb  #46494b     4.7  !!!
+
+#-- titleForeground --
+JXTitledPanel.titleForeground                       #bbbbbb  #4c5052     4.2  !!!

--- a/flatlaf-testing/dumps/uidefaults/FlatDarkLaf_1.8.0.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatDarkLaf_1.8.0.txt
@@ -598,7 +598,7 @@ Menu.submenuPopupOffsetY       [active] -4
 
 MenuBar.background             #303234  HSL 210   4  20    javax.swing.plaf.ColorUIResource [UI]
 MenuBar.border                 [lazy] 0,0,1,0  false    com.formdev.flatlaf.ui.FlatMenuBarBorder [UI]
-MenuBar.borderColor            #505254  HSL 210   2  32    javax.swing.plaf.ColorUIResource [UI]
+MenuBar.borderColor            #595c5e  HSL 204   3  36    javax.swing.plaf.ColorUIResource [UI]
 MenuBar.font                   [active] $defaultFont [UI]
 MenuBar.foreground             #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 MenuBar.highlight              #232324  HSL 240   1  14    javax.swing.plaf.ColorUIResource [UI]
@@ -938,7 +938,7 @@ SearchField.searchIconPressedColor [lazy] #7f8b9180  50%  HSLA 200   8  53 50   
 #---- Separator ----
 
 Separator.background           #3c3f41  HSL 204   4  25    javax.swing.plaf.ColorUIResource [UI]
-Separator.foreground           #505254  HSL 210   2  32    javax.swing.plaf.ColorUIResource [UI]
+Separator.foreground           #595c5e  HSL 204   3  36    javax.swing.plaf.ColorUIResource [UI]
 Separator.height               3
 Separator.highlight            #232324  HSL 240   1  14    javax.swing.plaf.ColorUIResource [UI]
 Separator.shadow               #616365  HSL 210   2  39    javax.swing.plaf.ColorUIResource [UI]
@@ -1289,7 +1289,7 @@ TitlePane.useWindowDecorations true
 
 #---- TitledBorder ----
 
-TitledBorder.border            [lazy] 1,1,1,1  false    com.formdev.flatlaf.ui.FlatLineBorder [UI]    lineColor=#505254  HSL 210   2  32    javax.swing.plaf.ColorUIResource [UI]    lineThickness=1.000000
+TitledBorder.border            [lazy] 1,1,1,1  false    com.formdev.flatlaf.ui.FlatLineBorder [UI]    lineColor=#595c5e  HSL 204   3  36    javax.swing.plaf.ColorUIResource [UI]    lineThickness=1.000000
 TitledBorder.font              [active] $defaultFont [UI]
 TitledBorder.titleColor        #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 
@@ -1352,7 +1352,7 @@ ToolBar.hoverButtonGroupArc    8
 ToolBar.hoverButtonGroupBackground #434749  HSL 200   4  27    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(3% autoInverse)
 ToolBar.isRollover             true
 ToolBar.light                  #2f3031  HSL 210   2  19    javax.swing.plaf.ColorUIResource [UI]
-ToolBar.separatorColor         #505254  HSL 210   2  32    javax.swing.plaf.ColorUIResource [UI]
+ToolBar.separatorColor         #595c5e  HSL 204   3  36    javax.swing.plaf.ColorUIResource [UI]
 ToolBar.separatorWidth         7
 ToolBar.shadow                 #616365  HSL 210   2  39    javax.swing.plaf.ColorUIResource [UI]
 ToolBar.spacingBorder          [lazy] 1,2,1,2  false    com.formdev.flatlaf.ui.FlatEmptyBorder [UI]
@@ -1750,3 +1750,17 @@ Tree.textForeground                                 #dddddd  #46494b     6.7  !
 
 #-- titleForeground --
 JXTitledPanel.titleForeground                       #dddddd  #4c5052     6.0  !
+
+#-- non-text --
+CheckBoxMenuItem.icon.checkmarkColor                #b7b7b7  #3c3f41     5.3  !!
+CheckBoxMenuItem.icon.disabledCheckmarkColor        #777777  #3c3f41     2.4  !!!!!
+Menu.icon.arrowColor                                #b7b7b7  #3c3f41     5.3  !!
+Menu.icon.disabledArrowColor                        #777777  #3c3f41     2.4  !!!!!
+ProgressBar.background                              #505456  #3c3f41     1.4  !!!!!!
+ProgressBar.foreground                              #4c87c8  #3c3f41     2.8  !!!!!
+Separator.foreground                                #595c5e  #3c3f41     1.6  !!!!!!
+Slider.disabledTrackColor                           #54595c  #3c3f41     1.5  !!!!!!
+Slider.trackColor                                   #616669  #3c3f41     1.8  !!!!!!
+Slider.trackValueColor                              #4c87c8  #3c3f41     2.8  !!!!!
+TabbedPane.contentAreaColor                         #616365  #3c3f41     1.8  !!!!!!
+ToolBar.separatorColor                              #595c5e  #3c3f41     1.6  !!!!!!

--- a/flatlaf-testing/dumps/uidefaults/FlatIntelliJLaf_1.8.0.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatIntelliJLaf_1.8.0.txt
@@ -133,3 +133,9 @@
 
 - ToggleButton.border            [lazy] 1,1,1,1  false    com.formdev.flatlaf.ui.FlatButtonBorder [UI]
 + ToggleButton.border            [lazy] 3,3,3,3  false    com.formdev.flatlaf.ui.FlatButtonBorder [UI]
+
+
+#---- contrast ratio: Button ----
+
+- contrast ratio: Button.default.foreground                           #000000  #ffffff    21.0
++ contrast ratio: Button.default.foreground                           #ffffff  #478ac9     3.7  !!!!

--- a/flatlaf-testing/dumps/uidefaults/FlatLightLaf_1.8.0.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatLightLaf_1.8.0.txt
@@ -1635,3 +1635,123 @@ textText                       #000000  HSL   0   0   0    javax.swing.plaf.Colo
 window                         #f2f2f2  HSL   0   0  95    javax.swing.plaf.ColorUIResource [UI]
 windowBorder                   #000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]
 windowText                     #000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]
+
+
+#-------- Contrast Ratios --------
+
+# WCAG 2 Contrast Requirements: minimum 4.5; enhanced 7.0
+# https://webaim.org/articles/contrast/#sc143
+
+
+#-- activeTitleForeground --
+InternalFrame.activeTitleForeground                 #000000  #ffffff    21.0
+
+#-- disabledForeground --
+ComboBox.disabledForeground                         #8c8c8c  #f2f2f2     3.0  !!!!
+Label.disabledForeground                            #8c8c8c  #f2f2f2     3.0  !!!!
+Spinner.disabledForeground                          #8c8c8c  #f2f2f2     3.0  !!!!
+
+#-- disabledText --
+Button.disabledText                                 #8c8c8c  #f2f2f2     3.0  !!!!
+CheckBox.disabledText                               #8c8c8c  #f2f2f2     3.0  !!!!
+RadioButton.disabledText                            #8c8c8c  #f2f2f2     3.0  !!!!
+ToggleButton.disabledText                           #8c8c8c  #f2f2f2     3.0  !!!!
+
+#-- dropCellForeground --
+List.dropCellForeground                             #ffffff  #3f8fd9     3.4  !!!!
+Table.dropCellForeground                            #ffffff  #3f8fd9     3.4  !!!!
+Tree.dropCellForeground                             #ffffff  #3f8fd9     3.4  !!!!
+
+#-- focusCellForeground --
+Table.focusCellForeground                           #000000  #ffffff    21.0
+
+#-- foreground --
+Button.foreground                                   #000000  #ffffff    21.0
+Button.default.foreground                           #000000  #ffffff    21.0
+CheckBox.foreground                                 #000000  #f2f2f2    18.8
+CheckBoxMenuItem.foreground                         #000000  #ffffff    21.0
+ColorChooser.foreground                             #000000  #f2f2f2    18.8
+ComboBox.foreground                                 #000000  #ffffff    21.0
+DesktopIcon.foreground                              #000000  #c6d2dd    13.7
+EditorPane.foreground                               #000000  #ffffff    21.0
+FormattedTextField.foreground                       #000000  #ffffff    21.0
+JideButton.foreground                               #000000  #ffffff    21.0
+JideLabel.foreground                                #000000  #f2f2f2    18.8
+JideSplitButton.foreground                          #000000  #ffffff    21.0
+JideTabbedPane.foreground                           #000000  #f2f2f2    18.8
+Label.foreground                                    #000000  #f2f2f2    18.8
+List.foreground                                     #000000  #ffffff    21.0
+Menu.foreground                                     #000000  #ffffff    21.0
+MenuBar.foreground                                  #000000  #ffffff    21.0
+MenuItem.foreground                                 #000000  #ffffff    21.0
+OptionPane.foreground                               #000000  #f2f2f2    18.8
+Panel.foreground                                    #000000  #f2f2f2    18.8
+PasswordField.foreground                            #000000  #ffffff    21.0
+PopupMenu.foreground                                #000000  #ffffff    21.0
+RadioButton.foreground                              #000000  #f2f2f2    18.8
+RadioButtonMenuItem.foreground                      #000000  #ffffff    21.0
+RootPane.foreground                                 #000000  #f2f2f2    18.8
+Spinner.foreground                                  #000000  #ffffff    21.0
+TabbedPane.foreground                               #000000  #f2f2f2    18.8
+Table.foreground                                    #000000  #ffffff    21.0
+TableHeader.foreground                              #000000  #ffffff    21.0
+TextArea.foreground                                 #000000  #ffffff    21.0
+TextField.foreground                                #000000  #ffffff    21.0
+TextPane.foreground                                 #000000  #ffffff    21.0
+TitlePane.foreground                                #000000  #ffffff    21.0
+ToggleButton.foreground                             #000000  #ffffff    21.0
+ToolTip.foreground                                  #000000  #fafafa    20.1
+Tree.foreground                                     #000000  #ffffff    21.0
+
+#-- inactiveForeground --
+EditorPane.inactiveForeground                       #8c8c8c  #f2f2f2     3.0  !!!!
+FormattedTextField.inactiveForeground               #8c8c8c  #f2f2f2     3.0  !!!!
+PasswordField.inactiveForeground                    #8c8c8c  #f2f2f2     3.0  !!!!
+TextArea.inactiveForeground                         #8c8c8c  #f2f2f2     3.0  !!!!
+TextField.inactiveForeground                        #8c8c8c  #f2f2f2     3.0  !!!!
+TextPane.inactiveForeground                         #8c8c8c  #f2f2f2     3.0  !!!!
+TitlePane.inactiveForeground                        #8c8c8c  #ffffff     3.4  !!!!
+
+#-- inactiveTitleForeground --
+InternalFrame.inactiveTitleForeground               #8c8c8c  #fafafa     3.2  !!!!
+
+#-- monthStringForeground --
+JXMonthView.monthStringForeground                   #000000  #dfdfdf    15.8
+
+#-- selectedForeground --
+Button.selectedForeground                           #000000  #cccccc    13.1
+ToggleButton.selectedForeground                     #000000  #cccccc    13.1
+
+#-- selectionBackground --
+ProgressBar.selectionBackground                     #000000  #d1d1d1    13.8
+
+#-- selectionForeground --
+CheckBoxMenuItem.selectionForeground                #ffffff  #2675bf     4.8  !!!
+ComboBox.selectionForeground                        #ffffff  #2675bf     4.8  !!!
+EditorPane.selectionForeground                      #ffffff  #2675bf     4.8  !!!
+FormattedTextField.selectionForeground              #ffffff  #2675bf     4.8  !!!
+List.selectionForeground                            #ffffff  #2675bf     4.8  !!!
+Menu.selectionForeground                            #ffffff  #2675bf     4.8  !!!
+MenuItem.selectionForeground                        #ffffff  #2675bf     4.8  !!!
+PasswordField.selectionForeground                   #ffffff  #2675bf     4.8  !!!
+ProgressBar.selectionForeground                     #ffffff  #2285e1     3.8  !!!!
+RadioButtonMenuItem.selectionForeground             #ffffff  #2675bf     4.8  !!!
+Table.selectionForeground                           #ffffff  #2675bf     4.8  !!!
+TextArea.selectionForeground                        #ffffff  #2675bf     4.8  !!!
+TextField.selectionForeground                       #ffffff  #2675bf     4.8  !!!
+TextPane.selectionForeground                        #ffffff  #2675bf     4.8  !!!
+Tree.selectionForeground                            #ffffff  #2675bf     4.8  !!!
+
+#-- selectionInactiveForeground --
+List.selectionInactiveForeground                    #000000  #d3d3d3    14.0
+Table.selectionInactiveForeground                   #000000  #d3d3d3    14.0
+Tree.selectionInactiveForeground                    #000000  #d3d3d3    14.0
+
+#-- specialTitleForeground --
+TaskPane.specialTitleForeground                     #222222  #afafaf     7.3
+
+#-- textForeground --
+Tree.textForeground                                 #000000  #ffffff    21.0
+
+#-- titleForeground --
+JXTitledPanel.titleForeground                       #222222  #dfdfdf    11.9

--- a/flatlaf-testing/dumps/uidefaults/FlatLightLaf_1.8.0.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatLightLaf_1.8.0.txt
@@ -80,9 +80,9 @@ Button.default.pressedBackground #e6e6e6  HSL   0   0  90    com.formdev.flatlaf
 Button.defaultButtonFollowsFocus false
 Button.disabledBackground      #f2f2f2  HSL   0   0  95    javax.swing.plaf.ColorUIResource [UI]
 Button.disabledBorderColor     #cecece  HSL   0   0  81    javax.swing.plaf.ColorUIResource [UI]
-Button.disabledForeground      #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
+Button.disabledForeground      #808080  HSL   0   0  50    javax.swing.plaf.ColorUIResource [UI]
 Button.disabledSelectedBackground #dedede  HSL   0   0  87    com.formdev.flatlaf.util.DerivedColor [UI]    darken(13% autoInverse)
-Button.disabledText            #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
+Button.disabledText            #808080  HSL   0   0  50    javax.swing.plaf.ColorUIResource [UI]
 Button.focusedBackground       #eaf3fb  HSL 208  68  95    javax.swing.plaf.ColorUIResource [UI]
 Button.focusedBorderColor      #89b0d4  HSL 209  47  68    javax.swing.plaf.ColorUIResource [UI]
 Button.font                    [active] $defaultFont [UI]
@@ -120,7 +120,7 @@ Caret.width                    [active] 1
 CheckBox.arc                   4
 CheckBox.background            #f2f2f2  HSL   0   0  95    javax.swing.plaf.ColorUIResource [UI]
 CheckBox.border                [lazy] 0,0,0,0  false    com.formdev.flatlaf.ui.FlatMarginBorder [UI]
-CheckBox.disabledText          #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
+CheckBox.disabledText          #808080  HSL   0   0  50    javax.swing.plaf.ColorUIResource [UI]
 CheckBox.font                  [active] $defaultFont [UI]
 CheckBox.foreground            #000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]
 CheckBox.icon.background       #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
@@ -164,7 +164,7 @@ CheckBoxMenuItem.background    #ffffff  HSL   0   0 100    javax.swing.plaf.Colo
 CheckBoxMenuItem.border        [lazy] 0,0,0,0  false    com.formdev.flatlaf.ui.FlatMenuItemBorder [UI]
 CheckBoxMenuItem.borderPainted true
 CheckBoxMenuItem.checkIcon     [lazy] 15,15    com.formdev.flatlaf.icons.FlatCheckBoxMenuItemIcon [UI]
-CheckBoxMenuItem.disabledForeground #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
+CheckBoxMenuItem.disabledForeground #808080  HSL   0   0  50    javax.swing.plaf.ColorUIResource [UI]
 CheckBoxMenuItem.font          [active] $defaultFont [UI]
 CheckBoxMenuItem.foreground    #000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]
 CheckBoxMenuItem.icon.checkmarkColor #4e9de7  HSL 209  76  61    javax.swing.plaf.ColorUIResource [UI]
@@ -216,7 +216,7 @@ ComboBox.buttonSeparatorColor  #c2c2c2  HSL   0   0  76    javax.swing.plaf.Colo
 ComboBox.buttonShadow          #c2c2c2  HSL   0   0  76    javax.swing.plaf.ColorUIResource [UI]
 ComboBox.buttonStyle           auto
 ComboBox.disabledBackground    #f2f2f2  HSL   0   0  95    javax.swing.plaf.ColorUIResource [UI]
-ComboBox.disabledForeground    #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
+ComboBox.disabledForeground    #808080  HSL   0   0  50    javax.swing.plaf.ColorUIResource [UI]
 ComboBox.editorColumns         0
 ComboBox.font                  [active] $defaultFont [UI]
 ComboBox.foreground            #000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]
@@ -295,7 +295,7 @@ EditorPane.disabledBackground  #f2f2f2  HSL   0   0  95    javax.swing.plaf.Colo
 EditorPane.font                [active] $defaultFont [UI]
 EditorPane.foreground          #000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]
 EditorPane.inactiveBackground  #f2f2f2  HSL   0   0  95    javax.swing.plaf.ColorUIResource [UI]
-EditorPane.inactiveForeground  #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
+EditorPane.inactiveForeground  #808080  HSL   0   0  50    javax.swing.plaf.ColorUIResource [UI]
 EditorPane.margin              2,6,2,6    javax.swing.plaf.InsetsUIResource [UI]
 EditorPane.selectionBackground #2675bf  HSL 209  67  45    javax.swing.plaf.ColorUIResource [UI]
 EditorPane.selectionForeground #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
@@ -336,9 +336,9 @@ FormattedTextField.font        [active] $defaultFont [UI]
 FormattedTextField.foreground  #000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]
 FormattedTextField.iconTextGap 4
 FormattedTextField.inactiveBackground #f2f2f2  HSL   0   0  95    javax.swing.plaf.ColorUIResource [UI]
-FormattedTextField.inactiveForeground #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
+FormattedTextField.inactiveForeground #808080  HSL   0   0  50    javax.swing.plaf.ColorUIResource [UI]
 FormattedTextField.margin      2,6,2,6    javax.swing.plaf.InsetsUIResource [UI]
-FormattedTextField.placeholderForeground #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
+FormattedTextField.placeholderForeground #808080  HSL   0   0  50    javax.swing.plaf.ColorUIResource [UI]
 FormattedTextField.selectionBackground #2675bf  HSL 209  67  45    javax.swing.plaf.ColorUIResource [UI]
 FormattedTextField.selectionForeground #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
 FormattedTextFieldUI           com.formdev.flatlaf.ui.FlatFormattedTextFieldUI
@@ -369,7 +369,7 @@ HelpButton.questionMarkColor   #4e9de7  HSL 209  76  61    javax.swing.plaf.Colo
 
 #---- Hyperlink ----
 
-Hyperlink.disabledText         #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
+Hyperlink.disabledText         #808080  HSL   0   0  50    javax.swing.plaf.ColorUIResource [UI]
 Hyperlink.linkColor            #236db2  HSL 209  67  42    javax.swing.plaf.ColorUIResource [UI]
 Hyperlink.visitedColor         #236db2  HSL 209  67  42    javax.swing.plaf.ColorUIResource [UI]
 HyperlinkUI                    com.formdev.flatlaf.swingx.ui.FlatHyperlinkUI
@@ -405,7 +405,7 @@ InternalFrame.inactiveBorderColor #c2c2c2  HSL   0   0  76    javax.swing.plaf.C
 InternalFrame.inactiveDropShadowInsets 3,3,4,4    javax.swing.plaf.InsetsUIResource [UI]
 InternalFrame.inactiveDropShadowOpacity 0.5
 InternalFrame.inactiveTitleBackground #fafafa  HSL   0   0  98    javax.swing.plaf.ColorUIResource [UI]
-InternalFrame.inactiveTitleForeground #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
+InternalFrame.inactiveTitleForeground #808080  HSL   0   0  50    javax.swing.plaf.ColorUIResource [UI]
 InternalFrame.maximizeIcon     [lazy] 24,24    com.formdev.flatlaf.icons.FlatInternalFrameMaximizeIcon [UI]
 InternalFrame.minimizeIcon     [lazy] 24,24    com.formdev.flatlaf.icons.FlatInternalFrameRestoreIcon [UI]
 InternalFrame.titleFont        [active] $defaultFont [UI]
@@ -448,17 +448,17 @@ JXHeader.titleFont             [active] Segoe UI bold 12    javax.swing.plaf.Fon
 JXMonthView.arrowColor         #000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]
 JXMonthView.background         #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
 JXMonthView.daysOfTheWeekForeground #444444  HSL   0   0  27    javax.swing.plaf.ColorUIResource [UI]
-JXMonthView.disabledArrowColor #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
+JXMonthView.disabledArrowColor #808080  HSL   0   0  50    javax.swing.plaf.ColorUIResource [UI]
 JXMonthView.flaggedDayForeground #e02222  HSL   0  75  51    javax.swing.plaf.ColorUIResource [UI]
 JXMonthView.font               [active] $defaultFont [UI]
-JXMonthView.leadingDayForeground #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
+JXMonthView.leadingDayForeground #808080  HSL   0   0  50    javax.swing.plaf.ColorUIResource [UI]
 JXMonthView.monthDownFileName  [lazy] 20,20    com.formdev.flatlaf.swingx.ui.FlatMonthDownIcon [UI]
 JXMonthView.monthStringBackground #dfdfdf  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 JXMonthView.monthStringForeground #000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]
 JXMonthView.monthUpFileName    [lazy] 20,20    com.formdev.flatlaf.swingx.ui.FlatMonthUpIcon [UI]
 JXMonthView.selectedBackground #bfdaf2  HSL 208  66  85    javax.swing.plaf.ColorUIResource [UI]
 JXMonthView.todayColor         #000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]
-JXMonthView.trailingDayForeground #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
+JXMonthView.trailingDayForeground #808080  HSL   0   0  50    javax.swing.plaf.ColorUIResource [UI]
 JXMonthView.unselectableDayForeground #e02222  HSL   0  75  51    javax.swing.plaf.ColorUIResource [UI]
 JXMonthView.weekOfTheYearForeground #666666  HSL   0   0  40    javax.swing.plaf.ColorUIResource [UI]
 
@@ -493,7 +493,7 @@ JideButtonUI                   com.formdev.flatlaf.jideoss.ui.FlatJideButtonUI
 #---- JideLabel ----
 
 JideLabel.background           #f2f2f2  HSL   0   0  95    javax.swing.plaf.ColorUIResource [UI]
-JideLabel.disabledForeground   #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
+JideLabel.disabledForeground   #808080  HSL   0   0  50    javax.swing.plaf.ColorUIResource [UI]
 JideLabel.foreground           #000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]
 JideLabelUI                    com.formdev.flatlaf.jideoss.ui.FlatJideLabelUI
 
@@ -536,7 +536,7 @@ JideTabbedPaneUI               com.formdev.flatlaf.jideoss.ui.FlatJideTabbedPane
 #---- Label ----
 
 Label.background               #f2f2f2  HSL   0   0  95    javax.swing.plaf.ColorUIResource [UI]
-Label.disabledForeground       #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
+Label.disabledForeground       #808080  HSL   0   0  50    javax.swing.plaf.ColorUIResource [UI]
 Label.disabledShadow           #c2c2c2  HSL   0   0  76    javax.swing.plaf.ColorUIResource [UI]
 Label.font                     [active] $defaultFont [UI]
 Label.foreground               #000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]
@@ -581,7 +581,7 @@ Menu.border                    [lazy] 0,0,0,0  false    com.formdev.flatlaf.ui.F
 Menu.borderPainted             true
 Menu.cancelMode                hideLastSubmenu
 Menu.crossMenuMnemonic         true
-Menu.disabledForeground        #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
+Menu.disabledForeground        #808080  HSL   0   0  50    javax.swing.plaf.ColorUIResource [UI]
 Menu.font                      [active] $defaultFont [UI]
 Menu.foreground                #000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]
 Menu.icon.arrowColor           #666666  HSL   0   0  40    javax.swing.plaf.ColorUIResource [UI]
@@ -632,7 +632,7 @@ MenuItem.border                [lazy] 0,0,0,0  false    com.formdev.flatlaf.ui.F
 MenuItem.borderPainted         true
 MenuItem.checkBackground       #bfd9f2  HSL 209  66  85    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(40%)
 MenuItem.checkMargins          2,2,2,2    javax.swing.plaf.InsetsUIResource [UI]
-MenuItem.disabledForeground    #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
+MenuItem.disabledForeground    #808080  HSL   0   0  50    javax.swing.plaf.ColorUIResource [UI]
 MenuItem.font                  [active] $defaultFont [UI]
 MenuItem.foreground            #000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]
 MenuItem.iconTextGap           6
@@ -730,9 +730,9 @@ PasswordField.font             [active] $defaultFont [UI]
 PasswordField.foreground       #000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]
 PasswordField.iconTextGap      4
 PasswordField.inactiveBackground #f2f2f2  HSL   0   0  95    javax.swing.plaf.ColorUIResource [UI]
-PasswordField.inactiveForeground #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
+PasswordField.inactiveForeground #808080  HSL   0   0  50    javax.swing.plaf.ColorUIResource [UI]
 PasswordField.margin           2,6,2,6    javax.swing.plaf.InsetsUIResource [UI]
-PasswordField.placeholderForeground #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
+PasswordField.placeholderForeground #808080  HSL   0   0  50    javax.swing.plaf.ColorUIResource [UI]
 PasswordField.revealIcon       [lazy] 16,16    com.formdev.flatlaf.icons.FlatRevealIcon [UI]
 PasswordField.revealIconColor  #666666  HSL   0   0  40    javax.swing.plaf.ColorUIResource [UI]
 PasswordField.selectionBackground #2675bf  HSL 209  67  45    javax.swing.plaf.ColorUIResource [UI]
@@ -801,7 +801,7 @@ ProgressBarUI                  com.formdev.flatlaf.ui.FlatProgressBarUI
 RadioButton.background         #f2f2f2  HSL   0   0  95    javax.swing.plaf.ColorUIResource [UI]
 RadioButton.border             [lazy] 0,0,0,0  false    com.formdev.flatlaf.ui.FlatMarginBorder [UI]
 RadioButton.darkShadow         #9c9c9c  HSL   0   0  61    javax.swing.plaf.ColorUIResource [UI]
-RadioButton.disabledText       #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
+RadioButton.disabledText       #808080  HSL   0   0  50    javax.swing.plaf.ColorUIResource [UI]
 RadioButton.font               [active] $defaultFont [UI]
 RadioButton.foreground         #000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]
 RadioButton.highlight          #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
@@ -827,7 +827,7 @@ RadioButtonMenuItem.background #ffffff  HSL   0   0 100    javax.swing.plaf.Colo
 RadioButtonMenuItem.border     [lazy] 0,0,0,0  false    com.formdev.flatlaf.ui.FlatMenuItemBorder [UI]
 RadioButtonMenuItem.borderPainted true
 RadioButtonMenuItem.checkIcon  [lazy] 15,15    com.formdev.flatlaf.icons.FlatRadioButtonMenuItemIcon [UI]
-RadioButtonMenuItem.disabledForeground #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
+RadioButtonMenuItem.disabledForeground #808080  HSL   0   0  50    javax.swing.plaf.ColorUIResource [UI]
 RadioButtonMenuItem.font       [active] $defaultFont [UI]
 RadioButtonMenuItem.foreground #000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]
 RadioButtonMenuItem.margin     3,6,3,6    javax.swing.plaf.InsetsUIResource [UI]
@@ -973,7 +973,7 @@ Slider.pressedThumbColor       #1a70c0  HSL 209  76  43    com.formdev.flatlaf.u
 Slider.shadow                  #c2c2c2  HSL   0   0  76    javax.swing.plaf.ColorUIResource [UI]
 Slider.thumbColor              #2285e1  HSL 209  76  51    javax.swing.plaf.ColorUIResource [UI]
 Slider.thumbSize               12,12    javax.swing.plaf.DimensionUIResource [UI]
-Slider.tickColor               #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
+Slider.tickColor               #808080  HSL   0   0  50    javax.swing.plaf.ColorUIResource [UI]
 Slider.trackColor              #c4c4c4  HSL   0   0  77    javax.swing.plaf.ColorUIResource [UI]
 Slider.trackValueColor         #2285e1  HSL 209  76  51    javax.swing.plaf.ColorUIResource [UI]
 Slider.trackWidth              2
@@ -995,7 +995,7 @@ Spinner.buttonPressedArrowColor #b3b3b3  HSL   0   0  70    com.formdev.flatlaf.
 Spinner.buttonSeparatorColor   #c2c2c2  HSL   0   0  76    javax.swing.plaf.ColorUIResource [UI]
 Spinner.buttonStyle            button
 Spinner.disabledBackground     #f2f2f2  HSL   0   0  95    javax.swing.plaf.ColorUIResource [UI]
-Spinner.disabledForeground     #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
+Spinner.disabledForeground     #808080  HSL   0   0  50    javax.swing.plaf.ColorUIResource [UI]
 Spinner.editorAlignment        11
 Spinner.editorBorderPainted    false
 Spinner.font                   [active] $defaultFont [UI]
@@ -1049,7 +1049,7 @@ TabbedPane.closeArc            4
 TabbedPane.closeCrossFilledSize 7.5
 TabbedPane.closeCrossLineWidth 1
 TabbedPane.closeCrossPlainSize 7.5
-TabbedPane.closeForeground     #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
+TabbedPane.closeForeground     #808080  HSL   0   0  50    javax.swing.plaf.ColorUIResource [UI]
 TabbedPane.closeHoverBackground #bfbfbf  HSL   0   0  75    com.formdev.flatlaf.util.DerivedColor [UI]    darken(20% autoInverse)
 TabbedPane.closeHoverForeground #000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]
 TabbedPane.closeIcon           [lazy] 16,16    com.formdev.flatlaf.icons.FlatTabbedPaneCloseIcon [UI]
@@ -1060,7 +1060,7 @@ TabbedPane.contentAreaColor    #c2c2c2  HSL   0   0  76    javax.swing.plaf.Colo
 TabbedPane.contentOpaque       true
 TabbedPane.contentSeparatorHeight 1
 TabbedPane.darkShadow          #9c9c9c  HSL   0   0  61    javax.swing.plaf.ColorUIResource [UI]
-TabbedPane.disabledForeground  #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
+TabbedPane.disabledForeground  #808080  HSL   0   0  50    javax.swing.plaf.ColorUIResource [UI]
 TabbedPane.disabledUnderlineColor #ababab  HSL   0   0  67    javax.swing.plaf.ColorUIResource [UI]
 TabbedPane.focus               #000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]
 TabbedPane.focusColor          #dee6ed  HSL 208  29  90    javax.swing.plaf.ColorUIResource [UI]
@@ -1190,7 +1190,7 @@ TextArea.disabledBackground    #f2f2f2  HSL   0   0  95    javax.swing.plaf.Colo
 TextArea.font                  [active] $defaultFont [UI]
 TextArea.foreground            #000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]
 TextArea.inactiveBackground    #f2f2f2  HSL   0   0  95    javax.swing.plaf.ColorUIResource [UI]
-TextArea.inactiveForeground    #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
+TextArea.inactiveForeground    #808080  HSL   0   0  50    javax.swing.plaf.ColorUIResource [UI]
 TextArea.margin                2,6,2,6    javax.swing.plaf.InsetsUIResource [UI]
 TextArea.selectionBackground   #2675bf  HSL 209  67  45    javax.swing.plaf.ColorUIResource [UI]
 TextArea.selectionForeground   #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
@@ -1217,10 +1217,10 @@ TextField.foreground           #000000  HSL   0   0   0    javax.swing.plaf.Colo
 TextField.highlight            #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
 TextField.iconTextGap          4
 TextField.inactiveBackground   #f2f2f2  HSL   0   0  95    javax.swing.plaf.ColorUIResource [UI]
-TextField.inactiveForeground   #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
+TextField.inactiveForeground   #808080  HSL   0   0  50    javax.swing.plaf.ColorUIResource [UI]
 TextField.light                #e1e1e1  HSL   0   0  88    javax.swing.plaf.ColorUIResource [UI]
 TextField.margin               2,6,2,6    javax.swing.plaf.InsetsUIResource [UI]
-TextField.placeholderForeground #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
+TextField.placeholderForeground #808080  HSL   0   0  50    javax.swing.plaf.ColorUIResource [UI]
 TextField.selectionBackground  #2675bf  HSL 209  67  45    javax.swing.plaf.ColorUIResource [UI]
 TextField.selectionForeground  #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
 TextField.shadow               #c2c2c2  HSL   0   0  76    javax.swing.plaf.ColorUIResource [UI]
@@ -1237,7 +1237,7 @@ TextPane.disabledBackground    #f2f2f2  HSL   0   0  95    javax.swing.plaf.Colo
 TextPane.font                  [active] $defaultFont [UI]
 TextPane.foreground            #000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]
 TextPane.inactiveBackground    #f2f2f2  HSL   0   0  95    javax.swing.plaf.ColorUIResource [UI]
-TextPane.inactiveForeground    #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
+TextPane.inactiveForeground    #808080  HSL   0   0  50    javax.swing.plaf.ColorUIResource [UI]
 TextPane.margin                2,6,2,6    javax.swing.plaf.InsetsUIResource [UI]
 TextPane.selectionBackground   #2675bf  HSL 209  67  45    javax.swing.plaf.ColorUIResource [UI]
 TextPane.selectionForeground   #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
@@ -1268,7 +1268,7 @@ TitlePane.iconMargins          3,8,3,8    javax.swing.plaf.InsetsUIResource [UI]
 TitlePane.iconSize             16,16    javax.swing.plaf.DimensionUIResource [UI]
 TitlePane.iconifyIcon          [lazy] 44,30    com.formdev.flatlaf.icons.FlatWindowIconifyIcon [UI]
 TitlePane.inactiveBackground   #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
-TitlePane.inactiveForeground   #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
+TitlePane.inactiveForeground   #808080  HSL   0   0  50    javax.swing.plaf.ColorUIResource [UI]
 TitlePane.maximizeIcon         [lazy] 44,30    com.formdev.flatlaf.icons.FlatWindowMaximizeIcon [UI]
 TitlePane.menuBarEmbedded      true
 TitlePane.menuBarTitleGap      40
@@ -1311,7 +1311,7 @@ ToggleButton.border            [lazy] 1,1,1,1  false    com.formdev.flatlaf.ui.F
 ToggleButton.darkShadow        #9c9c9c  HSL   0   0  61    javax.swing.plaf.ColorUIResource [UI]
 ToggleButton.disabledBackground #f2f2f2  HSL   0   0  95    javax.swing.plaf.ColorUIResource [UI]
 ToggleButton.disabledSelectedBackground #dedede  HSL   0   0  87    com.formdev.flatlaf.util.DerivedColor [UI]    darken(13% autoInverse)
-ToggleButton.disabledText      #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
+ToggleButton.disabledText      #808080  HSL   0   0  50    javax.swing.plaf.ColorUIResource [UI]
 ToggleButton.font              [active] $defaultFont [UI]
 ToggleButton.foreground        #000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]
 ToggleButton.highlight         #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
@@ -1630,7 +1630,7 @@ swingx/TaskPaneUI              com.formdev.flatlaf.swingx.ui.FlatTaskPaneUI
 text                           #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
 textHighlight                  #2675bf  HSL 209  67  45    javax.swing.plaf.ColorUIResource [UI]
 textHighlightText              #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
-textInactiveText               #8c8c8c  HSL   0   0  55    javax.swing.plaf.ColorUIResource [UI]
+textInactiveText               #808080  HSL   0   0  50    javax.swing.plaf.ColorUIResource [UI]
 textText                       #000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]
 window                         #f2f2f2  HSL   0   0  95    javax.swing.plaf.ColorUIResource [UI]
 windowBorder                   #000000  HSL   0   0   0    javax.swing.plaf.ColorUIResource [UI]
@@ -1647,15 +1647,15 @@ windowText                     #000000  HSL   0   0   0    javax.swing.plaf.Colo
 InternalFrame.activeTitleForeground                 #000000  #ffffff    21.0
 
 #-- disabledForeground --
-ComboBox.disabledForeground                         #8c8c8c  #f2f2f2     3.0  !!!!
-Label.disabledForeground                            #8c8c8c  #f2f2f2     3.0  !!!!
-Spinner.disabledForeground                          #8c8c8c  #f2f2f2     3.0  !!!!
+ComboBox.disabledForeground                         #808080  #f2f2f2     3.5  !!!!
+Label.disabledForeground                            #808080  #f2f2f2     3.5  !!!!
+Spinner.disabledForeground                          #808080  #f2f2f2     3.5  !!!!
 
 #-- disabledText --
-Button.disabledText                                 #8c8c8c  #f2f2f2     3.0  !!!!
-CheckBox.disabledText                               #8c8c8c  #f2f2f2     3.0  !!!!
-RadioButton.disabledText                            #8c8c8c  #f2f2f2     3.0  !!!!
-ToggleButton.disabledText                           #8c8c8c  #f2f2f2     3.0  !!!!
+Button.disabledText                                 #808080  #f2f2f2     3.5  !!!!
+CheckBox.disabledText                               #808080  #f2f2f2     3.5  !!!!
+RadioButton.disabledText                            #808080  #f2f2f2     3.5  !!!!
+ToggleButton.disabledText                           #808080  #f2f2f2     3.5  !!!!
 
 #-- dropCellForeground --
 List.dropCellForeground                             #ffffff  #3f8fd9     3.4  !!!!
@@ -1704,16 +1704,16 @@ ToolTip.foreground                                  #000000  #fafafa    20.1
 Tree.foreground                                     #000000  #ffffff    21.0
 
 #-- inactiveForeground --
-EditorPane.inactiveForeground                       #8c8c8c  #f2f2f2     3.0  !!!!
-FormattedTextField.inactiveForeground               #8c8c8c  #f2f2f2     3.0  !!!!
-PasswordField.inactiveForeground                    #8c8c8c  #f2f2f2     3.0  !!!!
-TextArea.inactiveForeground                         #8c8c8c  #f2f2f2     3.0  !!!!
-TextField.inactiveForeground                        #8c8c8c  #f2f2f2     3.0  !!!!
-TextPane.inactiveForeground                         #8c8c8c  #f2f2f2     3.0  !!!!
-TitlePane.inactiveForeground                        #8c8c8c  #ffffff     3.4  !!!!
+EditorPane.inactiveForeground                       #808080  #f2f2f2     3.5  !!!!
+FormattedTextField.inactiveForeground               #808080  #f2f2f2     3.5  !!!!
+PasswordField.inactiveForeground                    #808080  #f2f2f2     3.5  !!!!
+TextArea.inactiveForeground                         #808080  #f2f2f2     3.5  !!!!
+TextField.inactiveForeground                        #808080  #f2f2f2     3.5  !!!!
+TextPane.inactiveForeground                         #808080  #f2f2f2     3.5  !!!!
+TitlePane.inactiveForeground                        #808080  #ffffff     3.9  !!!!
 
 #-- inactiveTitleForeground --
-InternalFrame.inactiveTitleForeground               #8c8c8c  #fafafa     3.2  !!!!
+InternalFrame.inactiveTitleForeground               #808080  #fafafa     3.8  !!!!
 
 #-- monthStringForeground --
 JXMonthView.monthStringForeground                   #000000  #dfdfdf    15.8

--- a/flatlaf-testing/dumps/uidefaults/FlatLightLaf_1.8.0.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatLightLaf_1.8.0.txt
@@ -1755,3 +1755,17 @@ Tree.textForeground                                 #000000  #ffffff    21.0
 
 #-- titleForeground --
 JXTitledPanel.titleForeground                       #222222  #dfdfdf    11.9
+
+#-- non-text --
+CheckBoxMenuItem.icon.checkmarkColor                #4e9de7  #f2f2f2     2.6  !!!!!
+CheckBoxMenuItem.icon.disabledCheckmarkColor        #a6a6a6  #f2f2f2     2.2  !!!!!
+Menu.icon.arrowColor                                #666666  #f2f2f2     5.1  !!
+Menu.icon.disabledArrowColor                        #a6a6a6  #f2f2f2     2.2  !!!!!
+ProgressBar.background                              #d1d1d1  #f2f2f2     1.4  !!!!!!
+ProgressBar.foreground                              #2285e1  #f2f2f2     3.4  !!!!
+Separator.foreground                                #cecece  #f2f2f2     1.4  !!!!!!
+Slider.disabledTrackColor                           #d1d1d1  #f2f2f2     1.4  !!!!!!
+Slider.trackColor                                   #c4c4c4  #f2f2f2     1.6  !!!!!!
+Slider.trackValueColor                              #2285e1  #f2f2f2     3.4  !!!!
+TabbedPane.contentAreaColor                         #c2c2c2  #f2f2f2     1.6  !!!!!!
+ToolBar.separatorColor                              #cecece  #f2f2f2     1.4  !!!!!!

--- a/flatlaf-testing/dumps/uidefaults/FlatMacDarkLaf_1.8.0.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatMacDarkLaf_1.8.0.txt
@@ -1761,3 +1761,17 @@ Tree.textForeground                                 #dddddd  #282828    10.9
 
 #-- titleForeground --
 JXTitledPanel.titleForeground                       #dddddd  #4c5052     6.0  !
+
+#-- non-text --
+CheckBoxMenuItem.icon.checkmarkColor                #b7b7b7  #1e1e1e     8.3
+CheckBoxMenuItem.icon.disabledCheckmarkColor        #777777  #1e1e1e     3.7  !!!!
+Menu.icon.arrowColor                                #b7b7b7  #1e1e1e     8.3
+Menu.icon.disabledArrowColor                        #777777  #1e1e1e     3.7  !!!!
+ProgressBar.background                              #323232  #1e1e1e     1.3  !!!!!!
+ProgressBar.foreground                              #007aff  #1e1e1e     4.2  !!!
+Separator.foreground                                #343434  #1e1e1e     1.3  !!!!!!    #ffffff19  10%
+Slider.disabledTrackColor                           #282828  #1e1e1e     1.1  !!!!!!
+Slider.trackColor                                   #323232  #1e1e1e     1.3  !!!!!!
+Slider.trackValueColor                              #007aff  #1e1e1e     4.2  !!!
+TabbedPane.contentAreaColor                         #343434  #1e1e1e     1.3  !!!!!!    #ffffff19  10%
+ToolBar.separatorColor                              #343434  #1e1e1e     1.3  !!!!!!    #ffffff19  10%

--- a/flatlaf-testing/dumps/uidefaults/FlatMacDarkLaf_1.8.0.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatMacDarkLaf_1.8.0.txt
@@ -1640,3 +1640,124 @@ textText                       #dddddd  HSL   0   0  87    javax.swing.plaf.Colo
 window                         #1e1e1e  HSL   0   0  12    javax.swing.plaf.ColorUIResource [UI]
 windowBorder                   #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 windowText                     #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+
+
+#-------- Contrast Ratios --------
+
+# WCAG 2 Contrast Requirements: minimum 4.5; enhanced 7.0
+# https://webaim.org/articles/contrast/#sc143
+
+
+#-- activeTitleForeground --
+InternalFrame.activeTitleForeground                 #dddddd  #040404    15.1
+
+#-- disabledForeground --
+ComboBox.disabledForeground                         #9a9a9a  #232323     5.6  !!
+Label.disabledForeground                            #9a9a9a  #1e1e1e     5.9  !!
+Spinner.disabledForeground                          #9a9a9a  #232323     5.6  !!
+
+#-- disabledText --
+Button.disabledText                                 #9a9a9a  #3d3d3d     3.9  !!!!
+CheckBox.disabledText                               #9a9a9a  #1e1e1e     5.9  !!
+RadioButton.disabledText                            #9a9a9a  #1e1e1e     5.9  !!
+ToggleButton.disabledText                           #9a9a9a  #3d3d3d     3.9  !!!!
+
+#-- dropCellForeground --
+List.dropCellForeground                             #ffffff  #003f99     9.7
+Table.dropCellForeground                            #ffffff  #003f99     9.7
+Tree.dropCellForeground                             #ffffff  #003f99     9.7
+
+#-- focusCellForeground --
+Table.focusCellForeground                           #dddddd  #282828    10.9
+
+#-- foreground --
+Button.foreground                                   #dddddd  #565656     5.4  !!
+Button.default.foreground                           #dddddd  #007aff     3.0  !!!!
+CheckBox.foreground                                 #dddddd  #1e1e1e    12.3
+CheckBoxMenuItem.foreground                         #dddddd  #323232     9.4
+ColorChooser.foreground                             #dddddd  #1e1e1e    12.3
+ComboBox.foreground                                 #dddddd  #565656     5.4  !!
+DesktopIcon.foreground                              #dddddd  #555c68     5.0  !!
+EditorPane.foreground                               #dddddd  #282828    10.9
+FormattedTextField.foreground                       #dddddd  #282828    10.9
+JideButton.foreground                               #dddddd  #565656     5.4  !!
+JideLabel.foreground                                #dddddd  #1e1e1e    12.3
+JideSplitButton.foreground                          #dddddd  #565656     5.4  !!
+JideTabbedPane.foreground                           #dddddd  #1e1e1e    12.3
+Label.foreground                                    #dddddd  #1e1e1e    12.3
+List.foreground                                     #dddddd  #282828    10.9
+Menu.foreground                                     #dddddd  #323232     9.4
+MenuBar.foreground                                  #dddddd  #323232     9.4
+MenuItem.foreground                                 #dddddd  #323232     9.4
+OptionPane.foreground                               #dddddd  #1e1e1e    12.3
+Panel.foreground                                    #dddddd  #1e1e1e    12.3
+PasswordField.foreground                            #dddddd  #282828    10.9
+PopupMenu.foreground                                #dddddd  #323232     9.4
+RadioButton.foreground                              #dddddd  #1e1e1e    12.3
+RadioButtonMenuItem.foreground                      #dddddd  #323232     9.4
+RootPane.foreground                                 #dddddd  #1e1e1e    12.3
+Spinner.foreground                                  #dddddd  #282828    10.9
+TabbedPane.foreground                               #dddddd  #1e1e1e    12.3
+Table.foreground                                    #dddddd  #282828    10.9
+TableHeader.foreground                              #dddddd  #282828    10.9
+TextArea.foreground                                 #dddddd  #282828    10.9
+TextField.foreground                                #dddddd  #282828    10.9
+TextPane.foreground                                 #dddddd  #282828    10.9
+TitlePane.foreground                                #dddddd  #323232     9.4
+ToggleButton.foreground                             #dddddd  #565656     5.4  !!
+ToolTip.foreground                                  #dddddd  #0f0f0f    14.1
+Tree.foreground                                     #dddddd  #282828    10.9
+
+#-- inactiveForeground --
+EditorPane.inactiveForeground                       #9a9a9a  #232323     5.6  !!
+FormattedTextField.inactiveForeground               #9a9a9a  #232323     5.6  !!
+PasswordField.inactiveForeground                    #9a9a9a  #232323     5.6  !!
+TextArea.inactiveForeground                         #9a9a9a  #232323     5.6  !!
+TextField.inactiveForeground                        #9a9a9a  #232323     5.6  !!
+TextPane.inactiveForeground                         #9a9a9a  #232323     5.6  !!
+TitlePane.inactiveForeground                        #9a9a9a  #323232     4.6  !!!
+
+#-- inactiveTitleForeground --
+InternalFrame.inactiveTitleForeground               #9a9a9a  #111111     6.7  !
+
+#-- monthStringForeground --
+JXMonthView.monthStringForeground                   #dddddd  #4c5052     6.0  !
+
+#-- selectedForeground --
+Button.selectedForeground                           #dddddd  #707070     3.6  !!!!
+ToggleButton.selectedForeground                     #dddddd  #898989     2.6  !!!!!
+
+#-- selectionBackground --
+ProgressBar.selectionBackground                     #dddddd  #323232     9.4
+
+#-- selectionForeground --
+CheckBoxMenuItem.selectionForeground                #ffffff  #1458b8     6.7  !
+ComboBox.selectionForeground                        #ffffff  #1458b8     6.7  !
+EditorPane.selectionForeground                      #ffffff  #3d6490     6.1  !
+FormattedTextField.selectionForeground              #ffffff  #3d6490     6.1  !
+List.selectionForeground                            #ffffff  #0054cc     6.7  !
+Menu.selectionForeground                            #ffffff  #1458b8     6.7  !
+MenuBar.selectionForeground                         #dddddd  #585858     5.2  !!
+MenuItem.selectionForeground                        #ffffff  #1458b8     6.7  !
+PasswordField.selectionForeground                   #ffffff  #3d6490     6.1  !
+ProgressBar.selectionForeground                     #dddddd  #007aff     3.0  !!!!
+RadioButtonMenuItem.selectionForeground             #ffffff  #1458b8     6.7  !
+Table.selectionForeground                           #ffffff  #0054cc     6.7  !
+TextArea.selectionForeground                        #ffffff  #3d6490     6.1  !
+TextField.selectionForeground                       #ffffff  #3d6490     6.1  !
+TextPane.selectionForeground                        #ffffff  #3d6490     6.1  !
+Tree.selectionForeground                            #ffffff  #0054cc     6.7  !
+
+#-- selectionInactiveForeground --
+List.selectionInactiveForeground                    #dddddd  #464646     6.9  !
+Table.selectionInactiveForeground                   #dddddd  #464646     6.9  !
+Tree.selectionInactiveForeground                    #dddddd  #464646     6.9  !
+
+#-- specialTitleForeground --
+TaskPane.specialTitleForeground                     #222222  #afafaf     7.3
+
+#-- textForeground --
+Tree.textForeground                                 #dddddd  #282828    10.9
+
+#-- titleForeground --
+JXTitledPanel.titleForeground                       #dddddd  #4c5052     6.0  !

--- a/flatlaf-testing/dumps/uidefaults/FlatMacDarkLaf_1.8.0.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatMacDarkLaf_1.8.0.txt
@@ -73,7 +73,7 @@ Button.default.borderColor     #268eff  HSL 211 100  57    javax.swing.plaf.Colo
 Button.default.borderWidth     0
 Button.default.focusColor      #29acff80  50%  HSLA 203 100  58 50    javax.swing.plaf.ColorUIResource [UI]
 Button.default.focusedBorderColor #2e92ff  HSL 211 100  59    javax.swing.plaf.ColorUIResource [UI]
-Button.default.foreground      #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+Button.default.foreground      #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
 Button.default.hoverBackground #0f82ff  HSL 211 100  53    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(3% autoInverse)
 Button.default.hoverBorderColor #2e92ff  HSL 211 100  59    javax.swing.plaf.ColorUIResource [UI]
 Button.default.pressedBackground #1f8aff  HSL 211 100  56    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(6% autoInverse)
@@ -794,7 +794,7 @@ ProgressBar.foreground         #007aff  HSL 211 100  50    javax.swing.plaf.Colo
 ProgressBar.horizontalSize     146,4    javax.swing.plaf.DimensionUIResource [UI]
 ProgressBar.repaintInterval    15
 ProgressBar.selectionBackground #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
-ProgressBar.selectionForeground #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+ProgressBar.selectionForeground #eeeeee  HSL   0   0  93    javax.swing.plaf.ColorUIResource [UI]
 ProgressBar.verticalSize       4,146    javax.swing.plaf.DimensionUIResource [UI]
 ProgressBarUI                  com.formdev.flatlaf.ui.FlatProgressBarUI
 
@@ -1326,7 +1326,7 @@ ToggleButton.margin            2,14,2,14    javax.swing.plaf.InsetsUIResource [U
 ToggleButton.pressedBackground #656565  HSL   0   0  40    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(6% autoInverse)
 ToggleButton.rollover          true
 ToggleButton.selectedBackground #898989  HSL   0   0  54    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(20% autoInverse)
-ToggleButton.selectedForeground #dddddd  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
+ToggleButton.selectedForeground #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
 ToggleButton.shadow            #ffffff19  10%  HSLA   0   0 100 10    javax.swing.plaf.ColorUIResource [UI]
 ToggleButton.tab.disabledUnderlineColor #595959  HSL   0   0  35    javax.swing.plaf.ColorUIResource [UI]
 ToggleButton.tab.focusBackground #172c4a  HSL 215  53  19    javax.swing.plaf.ColorUIResource [UI]
@@ -1672,7 +1672,7 @@ Table.focusCellForeground                           #dddddd  #282828    10.9
 
 #-- foreground --
 Button.foreground                                   #dddddd  #565656     5.4  !!
-Button.default.foreground                           #dddddd  #007aff     3.0  !!!!
+Button.default.foreground                           #ffffff  #007aff     4.0  !!!
 CheckBox.foreground                                 #dddddd  #1e1e1e    12.3
 CheckBoxMenuItem.foreground                         #dddddd  #323232     9.4
 ColorChooser.foreground                             #dddddd  #1e1e1e    12.3
@@ -1725,7 +1725,7 @@ JXMonthView.monthStringForeground                   #dddddd  #4c5052     6.0  !
 
 #-- selectedForeground --
 Button.selectedForeground                           #dddddd  #707070     3.6  !!!!
-ToggleButton.selectedForeground                     #dddddd  #898989     2.6  !!!!!
+ToggleButton.selectedForeground                     #ffffff  #898989     3.5  !!!!
 
 #-- selectionBackground --
 ProgressBar.selectionBackground                     #dddddd  #323232     9.4
@@ -1740,7 +1740,7 @@ Menu.selectionForeground                            #ffffff  #1458b8     6.7  !
 MenuBar.selectionForeground                         #dddddd  #585858     5.2  !!
 MenuItem.selectionForeground                        #ffffff  #1458b8     6.7  !
 PasswordField.selectionForeground                   #ffffff  #3d6490     6.1  !
-ProgressBar.selectionForeground                     #dddddd  #007aff     3.0  !!!!
+ProgressBar.selectionForeground                     #eeeeee  #007aff     3.5  !!!!
 RadioButtonMenuItem.selectionForeground             #ffffff  #1458b8     6.7  !
 Table.selectionForeground                           #ffffff  #0054cc     6.7  !
 TextArea.selectionForeground                        #ffffff  #3d6490     6.1  !

--- a/flatlaf-testing/dumps/uidefaults/FlatMacLightLaf_1.8.0.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatMacLightLaf_1.8.0.txt
@@ -1644,3 +1644,124 @@ textText                       #262626  HSL   0   0  15    javax.swing.plaf.Colo
 window                         #f6f6f6  HSL   0   0  96    javax.swing.plaf.ColorUIResource [UI]
 windowBorder                   #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
 windowText                     #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
+
+
+#-------- Contrast Ratios --------
+
+# WCAG 2 Contrast Requirements: minimum 4.5; enhanced 7.0
+# https://webaim.org/articles/contrast/#sc143
+
+
+#-- activeTitleForeground --
+InternalFrame.activeTitleForeground                 #262626  #ffffff    15.1
+
+#-- disabledForeground --
+ComboBox.disabledForeground                         #b6b6b6  #fafafa     1.9  !!!!!!
+Label.disabledForeground                            #b6b6b6  #f6f6f6     1.9  !!!!!!
+Spinner.disabledForeground                          #b6b6b6  #fafafa     1.9  !!!!!!
+
+#-- disabledText --
+Button.disabledText                                 #b6b6b6  #fafafa     1.9  !!!!!!
+CheckBox.disabledText                               #b6b6b6  #f6f6f6     1.9  !!!!!!
+RadioButton.disabledText                            #b6b6b6  #f6f6f6     1.9  !!!!!!
+ToggleButton.disabledText                           #b6b6b6  #fafafa     1.9  !!!!!!
+
+#-- dropCellForeground --
+List.dropCellForeground                             #ffffff  #1a79ff     4.0  !!!
+Table.dropCellForeground                            #ffffff  #1a79ff     4.0  !!!
+Tree.dropCellForeground                             #ffffff  #1a79ff     4.0  !!!
+
+#-- focusCellForeground --
+Table.focusCellForeground                           #262626  #ffffff    15.1
+
+#-- foreground --
+Button.foreground                                   #262626  #ffffff    15.1
+Button.default.foreground                           #f6f6f6  #007aff     3.7  !!!!
+CheckBox.foreground                                 #262626  #f6f6f6    14.0
+CheckBoxMenuItem.foreground                         #262626  #ececec    12.8
+ColorChooser.foreground                             #262626  #f6f6f6    14.0
+ComboBox.foreground                                 #262626  #ffffff    15.1
+DesktopIcon.foreground                              #262626  #c6d2dd     9.8
+EditorPane.foreground                               #262626  #ffffff    15.1
+FormattedTextField.foreground                       #262626  #ffffff    15.1
+JideButton.foreground                               #262626  #ffffff    15.1
+JideLabel.foreground                                #262626  #f6f6f6    14.0
+JideSplitButton.foreground                          #262626  #ffffff    15.1
+JideTabbedPane.foreground                           #262626  #f6f6f6    14.0
+Label.foreground                                    #262626  #f6f6f6    14.0
+List.foreground                                     #262626  #ffffff    15.1
+Menu.foreground                                     #262626  #ececec    12.8
+MenuBar.foreground                                  #262626  #ececec    12.8
+MenuItem.foreground                                 #262626  #ececec    12.8
+OptionPane.foreground                               #262626  #f6f6f6    14.0
+Panel.foreground                                    #262626  #f6f6f6    14.0
+PasswordField.foreground                            #262626  #ffffff    15.1
+PopupMenu.foreground                                #262626  #ececec    12.8
+RadioButton.foreground                              #262626  #f6f6f6    14.0
+RadioButtonMenuItem.foreground                      #262626  #ececec    12.8
+RootPane.foreground                                 #262626  #f6f6f6    14.0
+Spinner.foreground                                  #262626  #ffffff    15.1
+TabbedPane.foreground                               #262626  #f6f6f6    14.0
+Table.foreground                                    #262626  #ffffff    15.1
+TableHeader.foreground                              #262626  #ffffff    15.1
+TextArea.foreground                                 #262626  #ffffff    15.1
+TextField.foreground                                #262626  #ffffff    15.1
+TextPane.foreground                                 #262626  #ffffff    15.1
+TitlePane.foreground                                #262626  #ececec    12.8
+ToggleButton.foreground                             #262626  #ffffff    15.1
+ToolTip.foreground                                  #262626  #fefefe    15.0
+Tree.foreground                                     #262626  #ffffff    15.1
+
+#-- inactiveForeground --
+EditorPane.inactiveForeground                       #b6b6b6  #fafafa     1.9  !!!!!!
+FormattedTextField.inactiveForeground               #b6b6b6  #fafafa     1.9  !!!!!!
+PasswordField.inactiveForeground                    #b6b6b6  #fafafa     1.9  !!!!!!
+TextArea.inactiveForeground                         #b6b6b6  #fafafa     1.9  !!!!!!
+TextField.inactiveForeground                        #b6b6b6  #fafafa     1.9  !!!!!!
+TextPane.inactiveForeground                         #b6b6b6  #fafafa     1.9  !!!!!!
+TitlePane.inactiveForeground                        #b6b6b6  #ececec     1.7  !!!!!!
+
+#-- inactiveTitleForeground --
+InternalFrame.inactiveTitleForeground               #b6b6b6  #fafafa     1.9  !!!!!!
+
+#-- monthStringForeground --
+JXMonthView.monthStringForeground                   #262626  #dfdfdf    11.4
+
+#-- selectedForeground --
+Button.selectedForeground                           #262626  #cccccc     9.4
+ToggleButton.selectedForeground                     #262626  #cccccc     9.4
+
+#-- selectionBackground --
+ProgressBar.selectionBackground                     #262626  #e9e9e9    12.5
+
+#-- selectionForeground --
+CheckBoxMenuItem.selectionForeground                #ffffff  #3d9aff     2.9  !!!!!
+ComboBox.selectionForeground                        #ffffff  #3d9aff     2.9  !!!!!
+EditorPane.selectionForeground                      #262626  #b3d7ff    10.1
+FormattedTextField.selectionForeground              #262626  #b3d7ff    10.1
+List.selectionForeground                            #ffffff  #005fe6     5.6  !!
+Menu.selectionForeground                            #ffffff  #3d9aff     2.9  !!!!!
+MenuBar.selectionForeground                         #262626  #c6c6c6     8.9
+MenuItem.selectionForeground                        #ffffff  #3d9aff     2.9  !!!!!
+PasswordField.selectionForeground                   #262626  #b3d7ff    10.1
+ProgressBar.selectionForeground                     #ffffff  #007aff     4.0  !!!
+RadioButtonMenuItem.selectionForeground             #ffffff  #3d9aff     2.9  !!!!!
+Table.selectionForeground                           #ffffff  #005fe6     5.6  !!
+TextArea.selectionForeground                        #262626  #b3d7ff    10.1
+TextField.selectionForeground                       #262626  #b3d7ff    10.1
+TextPane.selectionForeground                        #262626  #b3d7ff    10.1
+Tree.selectionForeground                            #ffffff  #005fe6     5.6  !!
+
+#-- selectionInactiveForeground --
+List.selectionInactiveForeground                    #262626  #dcdcdc    11.0
+Table.selectionInactiveForeground                   #262626  #dcdcdc    11.0
+Tree.selectionInactiveForeground                    #262626  #dcdcdc    11.0
+
+#-- specialTitleForeground --
+TaskPane.specialTitleForeground                     #222222  #afafaf     7.3
+
+#-- textForeground --
+Tree.textForeground                                 #262626  #ffffff    15.1
+
+#-- titleForeground --
+JXTitledPanel.titleForeground                       #222222  #dfdfdf    11.9

--- a/flatlaf-testing/dumps/uidefaults/FlatMacLightLaf_1.8.0.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatMacLightLaf_1.8.0.txt
@@ -80,9 +80,9 @@ Button.default.pressedBackground #0062cc  HSL 211 100  40    com.formdev.flatlaf
 Button.defaultButtonFollowsFocus false
 Button.disabledBackground      #fafafa  HSL   0   0  98    javax.swing.plaf.ColorUIResource [UI]
 Button.disabledBorderColor     #00000019  10%  HSLA   0   0   0 10    javax.swing.plaf.ColorUIResource [UI]
-Button.disabledForeground      #b6b6b6  HSL   0   0  71    javax.swing.plaf.ColorUIResource [UI]
+Button.disabledForeground      #7b7b7b  HSL   0   0  48    javax.swing.plaf.ColorUIResource [UI]
 Button.disabledSelectedBackground #dedede  HSL   0   0  87    com.formdev.flatlaf.util.DerivedColor [UI]    darken(13% autoInverse)
-Button.disabledText            #b6b6b6  HSL   0   0  71    javax.swing.plaf.ColorUIResource [UI]
+Button.disabledText            #7b7b7b  HSL   0   0  48    javax.swing.plaf.ColorUIResource [UI]
 Button.focusedBorderColor      #005fe68d  55%  HSLA 215 100  45 55    javax.swing.plaf.ColorUIResource [UI]
 Button.font                    [active] $defaultFont [UI]
 Button.foreground              #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
@@ -119,7 +119,7 @@ Caret.width                    [active] 1
 CheckBox.arc                   7
 CheckBox.background            #f6f6f6  HSL   0   0  96    javax.swing.plaf.ColorUIResource [UI]
 CheckBox.border                [lazy] 0,0,0,0  false    com.formdev.flatlaf.ui.FlatMarginBorder [UI]
-CheckBox.disabledText          #b6b6b6  HSL   0   0  71    javax.swing.plaf.ColorUIResource [UI]
+CheckBox.disabledText          #7b7b7b  HSL   0   0  48    javax.swing.plaf.ColorUIResource [UI]
 CheckBox.font                  [active] $defaultFont [UI]
 CheckBox.foreground            #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
 CheckBox.icon.background       #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
@@ -169,7 +169,7 @@ CheckBoxMenuItem.background    #ececec  HSL   0   0  93    javax.swing.plaf.Colo
 CheckBoxMenuItem.border        [lazy] 0,0,0,0  false    com.formdev.flatlaf.ui.FlatMenuItemBorder [UI]
 CheckBoxMenuItem.borderPainted true
 CheckBoxMenuItem.checkIcon     [lazy] 15,15    com.formdev.flatlaf.icons.FlatCheckBoxMenuItemIcon [UI]
-CheckBoxMenuItem.disabledForeground #b6b6b6  HSL   0   0  71    javax.swing.plaf.ColorUIResource [UI]
+CheckBoxMenuItem.disabledForeground #7b7b7b  HSL   0   0  48    javax.swing.plaf.ColorUIResource [UI]
 CheckBoxMenuItem.font          [active] $defaultFont [UI]
 CheckBoxMenuItem.foreground    #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
 CheckBoxMenuItem.icon.checkmarkColor #007aff  HSL 211 100  50    javax.swing.plaf.ColorUIResource [UI]
@@ -221,7 +221,7 @@ ComboBox.buttonSeparatorColor  #00000026  15%  HSLA   0   0   0 15    javax.swin
 ComboBox.buttonShadow          #00000026  15%  HSLA   0   0   0 15    javax.swing.plaf.ColorUIResource [UI]
 ComboBox.buttonStyle           mac
 ComboBox.disabledBackground    #fafafa  HSL   0   0  98    javax.swing.plaf.ColorUIResource [UI]
-ComboBox.disabledForeground    #b6b6b6  HSL   0   0  71    javax.swing.plaf.ColorUIResource [UI]
+ComboBox.disabledForeground    #7b7b7b  HSL   0   0  48    javax.swing.plaf.ColorUIResource [UI]
 ComboBox.editorColumns         0
 ComboBox.font                  [active] $defaultFont [UI]
 ComboBox.foreground            #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
@@ -301,7 +301,7 @@ EditorPane.disabledBackground  #fafafa  HSL   0   0  98    javax.swing.plaf.Colo
 EditorPane.font                [active] $defaultFont [UI]
 EditorPane.foreground          #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
 EditorPane.inactiveBackground  #f6f6f6  HSL   0   0  96    javax.swing.plaf.ColorUIResource [UI]
-EditorPane.inactiveForeground  #b6b6b6  HSL   0   0  71    javax.swing.plaf.ColorUIResource [UI]
+EditorPane.inactiveForeground  #7b7b7b  HSL   0   0  48    javax.swing.plaf.ColorUIResource [UI]
 EditorPane.margin              2,6,2,6    javax.swing.plaf.InsetsUIResource [UI]
 EditorPane.selectionBackground #b3d7ff  HSL 212 100  85    javax.swing.plaf.ColorUIResource [UI]
 EditorPane.selectionForeground #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
@@ -342,9 +342,9 @@ FormattedTextField.font        [active] $defaultFont [UI]
 FormattedTextField.foreground  #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
 FormattedTextField.iconTextGap 4
 FormattedTextField.inactiveBackground #f6f6f6  HSL   0   0  96    javax.swing.plaf.ColorUIResource [UI]
-FormattedTextField.inactiveForeground #b6b6b6  HSL   0   0  71    javax.swing.plaf.ColorUIResource [UI]
+FormattedTextField.inactiveForeground #7b7b7b  HSL   0   0  48    javax.swing.plaf.ColorUIResource [UI]
 FormattedTextField.margin      2,6,2,6    javax.swing.plaf.InsetsUIResource [UI]
-FormattedTextField.placeholderForeground #b6b6b6  HSL   0   0  71    javax.swing.plaf.ColorUIResource [UI]
+FormattedTextField.placeholderForeground #7b7b7b  HSL   0   0  48    javax.swing.plaf.ColorUIResource [UI]
 FormattedTextField.selectionBackground #b3d7ff  HSL 212 100  85    javax.swing.plaf.ColorUIResource [UI]
 FormattedTextField.selectionForeground #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
 FormattedTextFieldUI           com.formdev.flatlaf.ui.FlatFormattedTextFieldUI
@@ -374,7 +374,7 @@ HelpButton.questionMarkColor   #007aff  HSL 211 100  50    javax.swing.plaf.Colo
 
 #---- Hyperlink ----
 
-Hyperlink.disabledText         #b6b6b6  HSL   0   0  71    javax.swing.plaf.ColorUIResource [UI]
+Hyperlink.disabledText         #7b7b7b  HSL   0   0  48    javax.swing.plaf.ColorUIResource [UI]
 Hyperlink.linkColor            #007aff  HSL 211 100  50    javax.swing.plaf.ColorUIResource [UI]
 Hyperlink.visitedColor         #007aff  HSL 211 100  50    javax.swing.plaf.ColorUIResource [UI]
 HyperlinkUI                    com.formdev.flatlaf.swingx.ui.FlatHyperlinkUI
@@ -410,7 +410,7 @@ InternalFrame.inactiveBorderColor #c5c5c5  HSL   0   0  77    javax.swing.plaf.C
 InternalFrame.inactiveDropShadowInsets 3,3,4,4    javax.swing.plaf.InsetsUIResource [UI]
 InternalFrame.inactiveDropShadowOpacity 0.5
 InternalFrame.inactiveTitleBackground #fafafa  HSL   0   0  98    javax.swing.plaf.ColorUIResource [UI]
-InternalFrame.inactiveTitleForeground #b6b6b6  HSL   0   0  71    javax.swing.plaf.ColorUIResource [UI]
+InternalFrame.inactiveTitleForeground #7b7b7b  HSL   0   0  48    javax.swing.plaf.ColorUIResource [UI]
 InternalFrame.maximizeIcon     [lazy] 24,24    com.formdev.flatlaf.icons.FlatInternalFrameMaximizeIcon [UI]
 InternalFrame.minimizeIcon     [lazy] 24,24    com.formdev.flatlaf.icons.FlatInternalFrameRestoreIcon [UI]
 InternalFrame.titleFont        [active] $defaultFont [UI]
@@ -453,17 +453,17 @@ JXHeader.titleFont             [active] Segoe UI bold 12    javax.swing.plaf.Fon
 JXMonthView.arrowColor         #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
 JXMonthView.background         #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
 JXMonthView.daysOfTheWeekForeground #444444  HSL   0   0  27    javax.swing.plaf.ColorUIResource [UI]
-JXMonthView.disabledArrowColor #b6b6b6  HSL   0   0  71    javax.swing.plaf.ColorUIResource [UI]
+JXMonthView.disabledArrowColor #7b7b7b  HSL   0   0  48    javax.swing.plaf.ColorUIResource [UI]
 JXMonthView.flaggedDayForeground #e02222  HSL   0  75  51    javax.swing.plaf.ColorUIResource [UI]
 JXMonthView.font               [active] $defaultFont [UI]
-JXMonthView.leadingDayForeground #b6b6b6  HSL   0   0  71    javax.swing.plaf.ColorUIResource [UI]
+JXMonthView.leadingDayForeground #7b7b7b  HSL   0   0  48    javax.swing.plaf.ColorUIResource [UI]
 JXMonthView.monthDownFileName  [lazy] 20,20    com.formdev.flatlaf.swingx.ui.FlatMonthDownIcon [UI]
 JXMonthView.monthStringBackground #dfdfdf  HSL   0   0  87    javax.swing.plaf.ColorUIResource [UI]
 JXMonthView.monthStringForeground #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
 JXMonthView.monthUpFileName    [lazy] 20,20    com.formdev.flatlaf.swingx.ui.FlatMonthUpIcon [UI]
 JXMonthView.selectedBackground #b3d2ff  HSL 216 100  85    javax.swing.plaf.ColorUIResource [UI]
 JXMonthView.todayColor         #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
-JXMonthView.trailingDayForeground #b6b6b6  HSL   0   0  71    javax.swing.plaf.ColorUIResource [UI]
+JXMonthView.trailingDayForeground #7b7b7b  HSL   0   0  48    javax.swing.plaf.ColorUIResource [UI]
 JXMonthView.unselectableDayForeground #e02222  HSL   0  75  51    javax.swing.plaf.ColorUIResource [UI]
 JXMonthView.weekOfTheYearForeground #666666  HSL   0   0  40    javax.swing.plaf.ColorUIResource [UI]
 
@@ -498,7 +498,7 @@ JideButtonUI                   com.formdev.flatlaf.jideoss.ui.FlatJideButtonUI
 #---- JideLabel ----
 
 JideLabel.background           #f6f6f6  HSL   0   0  96    javax.swing.plaf.ColorUIResource [UI]
-JideLabel.disabledForeground   #b6b6b6  HSL   0   0  71    javax.swing.plaf.ColorUIResource [UI]
+JideLabel.disabledForeground   #7b7b7b  HSL   0   0  48    javax.swing.plaf.ColorUIResource [UI]
 JideLabel.foreground           #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
 JideLabelUI                    com.formdev.flatlaf.jideoss.ui.FlatJideLabelUI
 
@@ -541,7 +541,7 @@ JideTabbedPaneUI               com.formdev.flatlaf.jideoss.ui.FlatJideTabbedPane
 #---- Label ----
 
 Label.background               #f6f6f6  HSL   0   0  96    javax.swing.plaf.ColorUIResource [UI]
-Label.disabledForeground       #b6b6b6  HSL   0   0  71    javax.swing.plaf.ColorUIResource [UI]
+Label.disabledForeground       #7b7b7b  HSL   0   0  48    javax.swing.plaf.ColorUIResource [UI]
 Label.disabledShadow           #00000026  15%  HSLA   0   0   0 15    javax.swing.plaf.ColorUIResource [UI]
 Label.font                     [active] $defaultFont [UI]
 Label.foreground               #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
@@ -586,7 +586,7 @@ Menu.border                    [lazy] 0,0,0,0  false    com.formdev.flatlaf.ui.F
 Menu.borderPainted             true
 Menu.cancelMode                hideLastSubmenu
 Menu.crossMenuMnemonic         true
-Menu.disabledForeground        #b6b6b6  HSL   0   0  71    javax.swing.plaf.ColorUIResource [UI]
+Menu.disabledForeground        #7b7b7b  HSL   0   0  48    javax.swing.plaf.ColorUIResource [UI]
 Menu.font                      [active] $defaultFont [UI]
 Menu.foreground                #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
 Menu.icon.arrowColor           #7d7d7d  HSL   0   0  49    javax.swing.plaf.ColorUIResource [UI]
@@ -639,7 +639,7 @@ MenuItem.border                [lazy] 0,0,0,0  false    com.formdev.flatlaf.ui.F
 MenuItem.borderPainted         true
 MenuItem.checkBackground       #bddcff  HSL 212 100  87    com.formdev.flatlaf.util.DerivedColor [UI]    lighten(25%)
 MenuItem.checkMargins          2,2,2,2    javax.swing.plaf.InsetsUIResource [UI]
-MenuItem.disabledForeground    #b6b6b6  HSL   0   0  71    javax.swing.plaf.ColorUIResource [UI]
+MenuItem.disabledForeground    #7b7b7b  HSL   0   0  48    javax.swing.plaf.ColorUIResource [UI]
 MenuItem.font                  [active] $defaultFont [UI]
 MenuItem.foreground            #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
 MenuItem.iconTextGap           6
@@ -737,9 +737,9 @@ PasswordField.font             [active] $defaultFont [UI]
 PasswordField.foreground       #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
 PasswordField.iconTextGap      4
 PasswordField.inactiveBackground #f6f6f6  HSL   0   0  96    javax.swing.plaf.ColorUIResource [UI]
-PasswordField.inactiveForeground #b6b6b6  HSL   0   0  71    javax.swing.plaf.ColorUIResource [UI]
+PasswordField.inactiveForeground #7b7b7b  HSL   0   0  48    javax.swing.plaf.ColorUIResource [UI]
 PasswordField.margin           2,6,2,6    javax.swing.plaf.InsetsUIResource [UI]
-PasswordField.placeholderForeground #b6b6b6  HSL   0   0  71    javax.swing.plaf.ColorUIResource [UI]
+PasswordField.placeholderForeground #7b7b7b  HSL   0   0  48    javax.swing.plaf.ColorUIResource [UI]
 PasswordField.revealIcon       [lazy] 16,16    com.formdev.flatlaf.icons.FlatRevealIcon [UI]
 PasswordField.revealIconColor  #7d7d7d  HSL   0   0  49    javax.swing.plaf.ColorUIResource [UI]
 PasswordField.selectionBackground #b3d7ff  HSL 212 100  85    javax.swing.plaf.ColorUIResource [UI]
@@ -808,7 +808,7 @@ ProgressBarUI                  com.formdev.flatlaf.ui.FlatProgressBarUI
 RadioButton.background         #f6f6f6  HSL   0   0  96    javax.swing.plaf.ColorUIResource [UI]
 RadioButton.border             [lazy] 0,0,0,0  false    com.formdev.flatlaf.ui.FlatMarginBorder [UI]
 RadioButton.darkShadow         #00000026  15%  HSLA   0   0   0 15    javax.swing.plaf.ColorUIResource [UI]
-RadioButton.disabledText       #b6b6b6  HSL   0   0  71    javax.swing.plaf.ColorUIResource [UI]
+RadioButton.disabledText       #7b7b7b  HSL   0   0  48    javax.swing.plaf.ColorUIResource [UI]
 RadioButton.font               [active] $defaultFont [UI]
 RadioButton.foreground         #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
 RadioButton.highlight          #40404026  15%  HSLA   0   0  25 15    javax.swing.plaf.ColorUIResource [UI]
@@ -835,7 +835,7 @@ RadioButtonMenuItem.background #ececec  HSL   0   0  93    javax.swing.plaf.Colo
 RadioButtonMenuItem.border     [lazy] 0,0,0,0  false    com.formdev.flatlaf.ui.FlatMenuItemBorder [UI]
 RadioButtonMenuItem.borderPainted true
 RadioButtonMenuItem.checkIcon  [lazy] 15,15    com.formdev.flatlaf.icons.FlatRadioButtonMenuItemIcon [UI]
-RadioButtonMenuItem.disabledForeground #b6b6b6  HSL   0   0  71    javax.swing.plaf.ColorUIResource [UI]
+RadioButtonMenuItem.disabledForeground #7b7b7b  HSL   0   0  48    javax.swing.plaf.ColorUIResource [UI]
 RadioButtonMenuItem.font       [active] $defaultFont [UI]
 RadioButtonMenuItem.foreground #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
 RadioButtonMenuItem.margin     3,11,3,11    javax.swing.plaf.InsetsUIResource [UI]
@@ -982,7 +982,7 @@ Slider.shadow                  #00000026  15%  HSLA   0   0   0 15    javax.swin
 Slider.thumbBorderColor        #00000026  15%  HSLA   0   0   0 15    javax.swing.plaf.ColorUIResource [UI]
 Slider.thumbColor              #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
 Slider.thumbSize               14,14    javax.swing.plaf.DimensionUIResource [UI]
-Slider.tickColor               #b6b6b6  HSL   0   0  71    javax.swing.plaf.ColorUIResource [UI]
+Slider.tickColor               #7b7b7b  HSL   0   0  48    javax.swing.plaf.ColorUIResource [UI]
 Slider.trackColor              #e4e4e4  HSL   0   0  89    javax.swing.plaf.ColorUIResource [UI]
 Slider.trackValueColor         #007aff  HSL 211 100  50    javax.swing.plaf.ColorUIResource [UI]
 Slider.trackWidth              3
@@ -1004,7 +1004,7 @@ Spinner.buttonPressedArrowColor #737373  HSL   0   0  45    com.formdev.flatlaf.
 Spinner.buttonSeparatorColor   #00000026  15%  HSLA   0   0   0 15    javax.swing.plaf.ColorUIResource [UI]
 Spinner.buttonStyle            mac
 Spinner.disabledBackground     #fafafa  HSL   0   0  98    javax.swing.plaf.ColorUIResource [UI]
-Spinner.disabledForeground     #b6b6b6  HSL   0   0  71    javax.swing.plaf.ColorUIResource [UI]
+Spinner.disabledForeground     #7b7b7b  HSL   0   0  48    javax.swing.plaf.ColorUIResource [UI]
 Spinner.editorAlignment        11
 Spinner.editorBorderPainted    false
 Spinner.font                   [active] $defaultFont [UI]
@@ -1058,7 +1058,7 @@ TabbedPane.closeArc            4
 TabbedPane.closeCrossFilledSize 7.5
 TabbedPane.closeCrossLineWidth 1
 TabbedPane.closeCrossPlainSize 7.5
-TabbedPane.closeForeground     #b6b6b6  HSL   0   0  71    javax.swing.plaf.ColorUIResource [UI]
+TabbedPane.closeForeground     #7b7b7b  HSL   0   0  48    javax.swing.plaf.ColorUIResource [UI]
 TabbedPane.closeHoverBackground #c3c3c3  HSL   0   0  76    com.formdev.flatlaf.util.DerivedColor [UI]    darken(20% autoInverse)
 TabbedPane.closeHoverForeground #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
 TabbedPane.closeIcon           [lazy] 16,16    com.formdev.flatlaf.icons.FlatTabbedPaneCloseIcon [UI]
@@ -1069,7 +1069,7 @@ TabbedPane.contentAreaColor    #00000026  15%  HSLA   0   0   0 15    javax.swin
 TabbedPane.contentOpaque       true
 TabbedPane.contentSeparatorHeight 1
 TabbedPane.darkShadow          #00000026  15%  HSLA   0   0   0 15    javax.swing.plaf.ColorUIResource [UI]
-TabbedPane.disabledForeground  #b6b6b6  HSL   0   0  71    javax.swing.plaf.ColorUIResource [UI]
+TabbedPane.disabledForeground  #7b7b7b  HSL   0   0  48    javax.swing.plaf.ColorUIResource [UI]
 TabbedPane.disabledUnderlineColor #afafaf  HSL   0   0  69    javax.swing.plaf.ColorUIResource [UI]
 TabbedPane.focus               #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
 TabbedPane.focusColor          #dde7f4  HSL 214  51  91    javax.swing.plaf.ColorUIResource [UI]
@@ -1199,7 +1199,7 @@ TextArea.disabledBackground    #fafafa  HSL   0   0  98    javax.swing.plaf.Colo
 TextArea.font                  [active] $defaultFont [UI]
 TextArea.foreground            #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
 TextArea.inactiveBackground    #f6f6f6  HSL   0   0  96    javax.swing.plaf.ColorUIResource [UI]
-TextArea.inactiveForeground    #b6b6b6  HSL   0   0  71    javax.swing.plaf.ColorUIResource [UI]
+TextArea.inactiveForeground    #7b7b7b  HSL   0   0  48    javax.swing.plaf.ColorUIResource [UI]
 TextArea.margin                2,6,2,6    javax.swing.plaf.InsetsUIResource [UI]
 TextArea.selectionBackground   #b3d7ff  HSL 212 100  85    javax.swing.plaf.ColorUIResource [UI]
 TextArea.selectionForeground   #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
@@ -1226,10 +1226,10 @@ TextField.foreground           #262626  HSL   0   0  15    javax.swing.plaf.Colo
 TextField.highlight            #40404026  15%  HSLA   0   0  25 15    javax.swing.plaf.ColorUIResource [UI]
 TextField.iconTextGap          4
 TextField.inactiveBackground   #f6f6f6  HSL   0   0  96    javax.swing.plaf.ColorUIResource [UI]
-TextField.inactiveForeground   #b6b6b6  HSL   0   0  71    javax.swing.plaf.ColorUIResource [UI]
+TextField.inactiveForeground   #7b7b7b  HSL   0   0  48    javax.swing.plaf.ColorUIResource [UI]
 TextField.light                #1f1f1f26  15%  HSLA   0   0  12 15    javax.swing.plaf.ColorUIResource [UI]
 TextField.margin               2,6,2,6    javax.swing.plaf.InsetsUIResource [UI]
-TextField.placeholderForeground #b6b6b6  HSL   0   0  71    javax.swing.plaf.ColorUIResource [UI]
+TextField.placeholderForeground #7b7b7b  HSL   0   0  48    javax.swing.plaf.ColorUIResource [UI]
 TextField.selectionBackground  #b3d7ff  HSL 212 100  85    javax.swing.plaf.ColorUIResource [UI]
 TextField.selectionForeground  #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
 TextField.shadow               #00000026  15%  HSLA   0   0   0 15    javax.swing.plaf.ColorUIResource [UI]
@@ -1246,7 +1246,7 @@ TextPane.disabledBackground    #fafafa  HSL   0   0  98    javax.swing.plaf.Colo
 TextPane.font                  [active] $defaultFont [UI]
 TextPane.foreground            #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
 TextPane.inactiveBackground    #f6f6f6  HSL   0   0  96    javax.swing.plaf.ColorUIResource [UI]
-TextPane.inactiveForeground    #b6b6b6  HSL   0   0  71    javax.swing.plaf.ColorUIResource [UI]
+TextPane.inactiveForeground    #7b7b7b  HSL   0   0  48    javax.swing.plaf.ColorUIResource [UI]
 TextPane.margin                2,6,2,6    javax.swing.plaf.InsetsUIResource [UI]
 TextPane.selectionBackground   #b3d7ff  HSL 212 100  85    javax.swing.plaf.ColorUIResource [UI]
 TextPane.selectionForeground   #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
@@ -1277,7 +1277,7 @@ TitlePane.iconMargins          3,8,3,8    javax.swing.plaf.InsetsUIResource [UI]
 TitlePane.iconSize             16,16    javax.swing.plaf.DimensionUIResource [UI]
 TitlePane.iconifyIcon          [lazy] 44,30    com.formdev.flatlaf.icons.FlatWindowIconifyIcon [UI]
 TitlePane.inactiveBackground   #ececec  HSL   0   0  93    javax.swing.plaf.ColorUIResource [UI]
-TitlePane.inactiveForeground   #b6b6b6  HSL   0   0  71    javax.swing.plaf.ColorUIResource [UI]
+TitlePane.inactiveForeground   #7b7b7b  HSL   0   0  48    javax.swing.plaf.ColorUIResource [UI]
 TitlePane.maximizeIcon         [lazy] 44,30    com.formdev.flatlaf.icons.FlatWindowMaximizeIcon [UI]
 TitlePane.menuBarEmbedded      true
 TitlePane.menuBarTitleGap      40
@@ -1320,7 +1320,7 @@ ToggleButton.border            [lazy] 3,3,3,3  false    com.formdev.flatlaf.ui.F
 ToggleButton.darkShadow        #00000026  15%  HSLA   0   0   0 15    javax.swing.plaf.ColorUIResource [UI]
 ToggleButton.disabledBackground #fafafa  HSL   0   0  98    javax.swing.plaf.ColorUIResource [UI]
 ToggleButton.disabledSelectedBackground #dedede  HSL   0   0  87    com.formdev.flatlaf.util.DerivedColor [UI]    darken(13% autoInverse)
-ToggleButton.disabledText      #b6b6b6  HSL   0   0  71    javax.swing.plaf.ColorUIResource [UI]
+ToggleButton.disabledText      #7b7b7b  HSL   0   0  48    javax.swing.plaf.ColorUIResource [UI]
 ToggleButton.font              [active] $defaultFont [UI]
 ToggleButton.foreground        #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
 ToggleButton.highlight         #40404026  15%  HSLA   0   0  25 15    javax.swing.plaf.ColorUIResource [UI]
@@ -1639,7 +1639,7 @@ swingx/TaskPaneUI              com.formdev.flatlaf.swingx.ui.FlatTaskPaneUI
 text                           #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
 textHighlight                  #005fe6  HSL 215 100  45    javax.swing.plaf.ColorUIResource [UI]
 textHighlightText              #ffffff  HSL   0   0 100    javax.swing.plaf.ColorUIResource [UI]
-textInactiveText               #b6b6b6  HSL   0   0  71    javax.swing.plaf.ColorUIResource [UI]
+textInactiveText               #7b7b7b  HSL   0   0  48    javax.swing.plaf.ColorUIResource [UI]
 textText                       #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
 window                         #f6f6f6  HSL   0   0  96    javax.swing.plaf.ColorUIResource [UI]
 windowBorder                   #262626  HSL   0   0  15    javax.swing.plaf.ColorUIResource [UI]
@@ -1656,15 +1656,15 @@ windowText                     #262626  HSL   0   0  15    javax.swing.plaf.Colo
 InternalFrame.activeTitleForeground                 #262626  #ffffff    15.1
 
 #-- disabledForeground --
-ComboBox.disabledForeground                         #b6b6b6  #fafafa     1.9  !!!!!!
-Label.disabledForeground                            #b6b6b6  #f6f6f6     1.9  !!!!!!
-Spinner.disabledForeground                          #b6b6b6  #fafafa     1.9  !!!!!!
+ComboBox.disabledForeground                         #7b7b7b  #fafafa     4.1  !!!
+Label.disabledForeground                            #7b7b7b  #f6f6f6     3.9  !!!!
+Spinner.disabledForeground                          #7b7b7b  #fafafa     4.1  !!!
 
 #-- disabledText --
-Button.disabledText                                 #b6b6b6  #fafafa     1.9  !!!!!!
-CheckBox.disabledText                               #b6b6b6  #f6f6f6     1.9  !!!!!!
-RadioButton.disabledText                            #b6b6b6  #f6f6f6     1.9  !!!!!!
-ToggleButton.disabledText                           #b6b6b6  #fafafa     1.9  !!!!!!
+Button.disabledText                                 #7b7b7b  #fafafa     4.1  !!!
+CheckBox.disabledText                               #7b7b7b  #f6f6f6     3.9  !!!!
+RadioButton.disabledText                            #7b7b7b  #f6f6f6     3.9  !!!!
+ToggleButton.disabledText                           #7b7b7b  #fafafa     4.1  !!!
 
 #-- dropCellForeground --
 List.dropCellForeground                             #ffffff  #1a79ff     4.0  !!!
@@ -1713,16 +1713,16 @@ ToolTip.foreground                                  #262626  #fefefe    15.0
 Tree.foreground                                     #262626  #ffffff    15.1
 
 #-- inactiveForeground --
-EditorPane.inactiveForeground                       #b6b6b6  #fafafa     1.9  !!!!!!
-FormattedTextField.inactiveForeground               #b6b6b6  #fafafa     1.9  !!!!!!
-PasswordField.inactiveForeground                    #b6b6b6  #fafafa     1.9  !!!!!!
-TextArea.inactiveForeground                         #b6b6b6  #fafafa     1.9  !!!!!!
-TextField.inactiveForeground                        #b6b6b6  #fafafa     1.9  !!!!!!
-TextPane.inactiveForeground                         #b6b6b6  #fafafa     1.9  !!!!!!
-TitlePane.inactiveForeground                        #b6b6b6  #ececec     1.7  !!!!!!
+EditorPane.inactiveForeground                       #7b7b7b  #fafafa     4.1  !!!
+FormattedTextField.inactiveForeground               #7b7b7b  #fafafa     4.1  !!!
+PasswordField.inactiveForeground                    #7b7b7b  #fafafa     4.1  !!!
+TextArea.inactiveForeground                         #7b7b7b  #fafafa     4.1  !!!
+TextField.inactiveForeground                        #7b7b7b  #fafafa     4.1  !!!
+TextPane.inactiveForeground                         #7b7b7b  #fafafa     4.1  !!!
+TitlePane.inactiveForeground                        #7b7b7b  #ececec     3.6  !!!!
 
 #-- inactiveTitleForeground --
-InternalFrame.inactiveTitleForeground               #b6b6b6  #fafafa     1.9  !!!!!!
+InternalFrame.inactiveTitleForeground               #7b7b7b  #fafafa     4.1  !!!
 
 #-- monthStringForeground --
 JXMonthView.monthStringForeground                   #262626  #dfdfdf    11.4

--- a/flatlaf-testing/dumps/uidefaults/FlatMacLightLaf_1.8.0.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatMacLightLaf_1.8.0.txt
@@ -1765,3 +1765,17 @@ Tree.textForeground                                 #262626  #ffffff    15.1
 
 #-- titleForeground --
 JXTitledPanel.titleForeground                       #222222  #dfdfdf    11.9
+
+#-- non-text --
+CheckBoxMenuItem.icon.checkmarkColor                #007aff  #f6f6f6     3.7  !!!!
+CheckBoxMenuItem.icon.disabledCheckmarkColor        #bdbdbd  #f6f6f6     1.7  !!!!!!
+Menu.icon.arrowColor                                #7d7d7d  #f6f6f6     3.8  !!!!
+Menu.icon.disabledArrowColor                        #bdbdbd  #f6f6f6     1.7  !!!!!!
+ProgressBar.background                              #e9e9e9  #f6f6f6     1.1  !!!!!!
+ProgressBar.foreground                              #007aff  #f6f6f6     3.7  !!!!
+Separator.foreground                                #dedede  #f6f6f6     1.2  !!!!!!    #00000019  10%
+Slider.disabledTrackColor                           #ececec  #f6f6f6     1.1  !!!!!!
+Slider.trackColor                                   #e4e4e4  #f6f6f6     1.2  !!!!!!
+Slider.trackValueColor                              #007aff  #f6f6f6     3.7  !!!!
+TabbedPane.contentAreaColor                         #d1d1d1  #f6f6f6     1.4  !!!!!!    #00000026  15%
+ToolBar.separatorColor                              #dedede  #f6f6f6     1.2  !!!!!!    #00000019  10%

--- a/flatlaf-testing/dumps/uidefaults/FlatTestLaf_1.8.0.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatTestLaf_1.8.0.txt
@@ -1844,3 +1844,16 @@ Tree.textForeground                                 #ff0000  #fff0ff     3.6  !!
 
 #-- titleForeground --
 JXTitledPanel.titleForeground                       #ff00ff  #ffff00     2.9  !!!!!
+
+#-- non-text --
+CheckBoxMenuItem.icon.checkmarkColor                #4d89c9  #ccffcc     3.3  !!!!
+CheckBoxMenuItem.icon.disabledCheckmarkColor        #ababab  #ccffcc     2.0  !!!!!
+Menu.icon.arrowColor                                #4d89c9  #ccffcc     3.3  !!!!
+Menu.icon.disabledArrowColor                        #ababab  #ccffcc     2.0  !!!!!
+ProgressBar.background                              #88ff88  #ccffcc     1.1  !!!!!!
+ProgressBar.foreground                              #bae3ba  #ccffcc     1.3  !!!!!!    #73737333  20%
+Separator.foreground                                #00bb00  #ccffcc     2.3  !!!!!
+Slider.disabledTrackColor                           #ffff88  #ccffcc     1.1  !!!!!!
+Slider.trackColor                                   #88ff88  #ccffcc     1.1  !!!!!!
+TabbedPane.contentAreaColor                         #ff0000  #ccffcc     3.6  !!!!
+ToolBar.separatorColor                              #00bb00  #ccffcc     2.3  !!!!!

--- a/flatlaf-testing/dumps/uidefaults/FlatTestLaf_1.8.0.txt
+++ b/flatlaf-testing/dumps/uidefaults/FlatTestLaf_1.8.0.txt
@@ -1689,3 +1689,158 @@ textText                       #ff0000  HSL   0 100  50    javax.swing.plaf.Colo
 window                         #ccffcc  HSL 120 100  90    javax.swing.plaf.ColorUIResource [UI]
 windowBorder                   #ff0000  HSL   0 100  50    javax.swing.plaf.ColorUIResource [UI]
 windowText                     #ff0000  HSL   0 100  50    javax.swing.plaf.ColorUIResource [UI]
+
+
+#-------- Contrast Ratios --------
+
+# WCAG 2 Contrast Requirements: minimum 4.5; enhanced 7.0
+# https://webaim.org/articles/contrast/#sc143
+
+
+#-- activeTitleForeground --
+InternalFrame.activeTitleForeground                 #ffaaaa  #880000     5.7  !!
+
+#-- disabledForeground --
+ComboBox.disabledForeground                         #000088  #e0e0e0    11.7
+Label.disabledForeground                            #000088  #ccffcc    13.8
+Spinner.disabledForeground                          #000088  #e0e0e0    11.7
+
+#-- disabledSelectedForeground --
+Button.disabledSelectedForeground                   #ffcccc  #112233    11.4
+Button.toolbar.disabledSelectedForeground           #886666  #cccccc     3.2  !!!!
+ToggleButton.disabledSelectedForeground             #ffffff  #44dd44     1.8  !!!!!!
+ToggleButton.toolbar.disabledSelectedForeground     #886666  #cccccc     3.2  !!!!
+
+#-- disabledText --
+Button.disabledText                                 #000088  #e0e0e0    11.7
+CheckBox.disabledText                               #000088  #ccffcc    13.8
+RadioButton.disabledText                            #000088  #ccffcc    13.8
+ToggleButton.disabledText                           #000088  #e0e0e0    11.7
+
+#-- dropCellForeground --
+List.dropCellForeground                             #00ff00  #ff0000     2.9  !!!!!
+Table.dropCellForeground                            #00ff00  #ff0000     2.9  !!!!!
+Tree.dropCellForeground                             #00ff00  #ff0000     2.9  !!!!!
+
+#-- focusCellForeground --
+Table.focusCellForeground                           #ff0000  #fffff0     4.0  !!!
+
+#-- focusForeground --
+ToggleButton.tab.focusForeground                    #008800  #dddddd     3.4  !!!!
+
+#-- focusedForeground --
+Button.focusedForeground                            #0000ff  #00ffff     6.9  !
+Button.default.focusedForeground                    #0000ff  #00ffff     6.9  !
+ToggleButton.focusedForeground                      #0000ff  #00ffff     6.9  !
+
+#-- foreground --
+Button.foreground                                   #ff0000  #ccffcc     3.6  !!!!
+CheckBox.foreground                                 #ff0000  #ccffcc     3.6  !!!!
+CheckBoxMenuItem.foreground                         #ff0000  #ffffff     4.0  !!!
+ColorChooser.foreground                             #ff0000  #ccffcc     3.6  !!!!
+ComboBox.foreground                                 #ff0000  #ffffff     4.0  !!!
+DesktopIcon.foreground                              #ff0000  #44ffda     3.2  !!!!
+EditorPane.foreground                               #ff0000  #ffffff     4.0  !!!
+FormattedTextField.foreground                       #ff0000  #ffffff     4.0  !!!
+JideButton.foreground                               #ff0000  #ccffcc     3.6  !!!!
+JideLabel.foreground                                #008800  #ccffcc     4.1  !!!
+JideSplitButton.foreground                          #ff0000  #ccffcc     3.6  !!!!
+JideTabbedPane.foreground                           #ff0000  #ccffcc     3.6  !!!!
+Label.foreground                                    #008800  #ccffcc     4.1  !!!
+List.foreground                                     #ff0000  #f0ffff     3.9  !!!!
+Menu.foreground                                     #ff0000  #ffffff     4.0  !!!
+MenuBar.foreground                                  #ff0000  #ffffff     4.0  !!!
+MenuItem.foreground                                 #ff0000  #ffffff     4.0  !!!
+OptionPane.foreground                               #ff0000  #ffdddd     3.2  !!!!
+Panel.foreground                                    #ff0000  #ccffcc     3.6  !!!!
+PasswordField.foreground                            #ff0000  #ffffff     4.0  !!!
+PopupMenu.foreground                                #ff0000  #ffffff     4.0  !!!
+RadioButton.foreground                              #ff0000  #ccffcc     3.6  !!!!
+RadioButtonMenuItem.foreground                      #ff0000  #ffffff     4.0  !!!
+RootPane.foreground                                 #ff0000  #ccffcc     3.6  !!!!
+Spinner.foreground                                  #ff0000  #ffffff     4.0  !!!
+TabbedPane.foreground                               #ff0000  #ccffcc     3.6  !!!!
+Table.foreground                                    #ff0000  #fffff0     4.0  !!!
+TableHeader.foreground                              #ffffff  #4444ff     6.0  !
+TextArea.foreground                                 #ff0000  #ffffff     4.0  !!!
+TextField.foreground                                #ff0000  #ffffff     4.0  !!!
+TextPane.foreground                                 #ff0000  #ffffff     4.0  !!!
+TitlePane.foreground                                #0000ff  #00ff00     6.3  !
+ToggleButton.foreground                             #ff0000  #ddddff     3.0  !!!!
+ToolTip.foreground                                  #ff0000  #eeeeff     3.5  !!!!
+Tree.foreground                                     #ff0000  #fff0ff     3.6  !!!!
+
+#-- hoverForeground --
+Button.hoverForeground                              #0000ff  #ffff00     8.0
+Button.default.hoverForeground                      #0000ff  #ffff00     8.0
+Button.toolbar.hoverForeground                      #000000  #ffffff    21.0
+TableHeader.hoverForeground                         #e6e6e6  #1111ff     6.6  !
+ToggleButton.hoverForeground                        #0000ff  #ffff00     8.0
+ToggleButton.tab.hoverForeground                    #0000ff  #eeeeee     7.4
+ToggleButton.toolbar.hoverForeground                #000000  #ffffff    21.0
+
+#-- inactiveForeground --
+EditorPane.inactiveForeground                       #000088  #e0e0e0    11.7
+FormattedTextField.inactiveForeground               #000088  #e0e0e0    11.7
+PasswordField.inactiveForeground                    #000088  #e0e0e0    11.7
+TextArea.inactiveForeground                         #000088  #e0e0e0    11.7
+TextField.inactiveForeground                        #000088  #e0e0e0    11.7
+TextPane.inactiveForeground                         #000088  #e0e0e0    11.7
+TitlePane.inactiveForeground                        #ffffff  #008800     4.6  !!!
+
+#-- inactiveTitleForeground --
+InternalFrame.inactiveTitleForeground               #aaffaa  #008800     3.9  !!!!
+
+#-- monthStringForeground --
+JXMonthView.monthStringForeground                   #0000ff  #00ff00     6.3  !
+
+#-- pressedForeground --
+Button.pressedForeground                            #0080ff  #ffc800     2.4  !!!!!
+Button.default.pressedForeground                    #0080ff  #ffc800     2.4  !!!!!
+Button.toolbar.pressedForeground                    #666666  #eeeeee     4.9  !!!
+TableHeader.pressedForeground                       #cccccc  #0000dd     6.4  !
+ToggleButton.pressedForeground                      #0080ff  #ffc800     2.4  !!!!!
+ToggleButton.toolbar.pressedForeground              #666666  #eeeeee     4.9  !!!
+
+#-- selectedForeground --
+Button.selectedForeground                           #332211  #ffbbbb     9.5
+Button.toolbar.selectedForeground                   #880000  #dddddd     7.6
+TabbedPane.selectedForeground                       #0000ff  #00ff00     6.3  !
+ToggleButton.selectedForeground                     #000000  #44ff44    15.6
+ToggleButton.tab.selectedForeground                 #ffffff  #008800     4.6  !!!
+ToggleButton.toolbar.selectedForeground             #880000  #dddddd     7.6
+
+#-- selectionBackground --
+ProgressBar.selectionBackground                     #000088  #88ff88    12.3
+
+#-- selectionForeground --
+CheckBoxMenuItem.selectionForeground                #ffff00  #00aa00     2.9  !!!!!
+ComboBox.selectionForeground                        #ffff00  #00aa00     2.9  !!!!!
+EditorPane.selectionForeground                      #ffff00  #00aa00     2.9  !!!!!
+FormattedTextField.selectionForeground              #ffff00  #00aa00     2.9  !!!!!
+List.selectionForeground                            #ffff00  #00aa00     2.9  !!!!!
+Menu.selectionForeground                            #ffff00  #00aa00     2.9  !!!!!
+MenuBar.selectionForeground                         #00ff00  #ff0000     2.9  !!!!!
+MenuItem.selectionForeground                        #ffff00  #00aa00     2.9  !!!!!
+PasswordField.selectionForeground                   #ffff00  #00aa00     2.9  !!!!!
+ProgressBar.selectionForeground                     #ff0000  #737373     1.2  !!!!!!
+RadioButtonMenuItem.selectionForeground             #ffff00  #00aa00     2.9  !!!!!
+Table.selectionForeground                           #ffff00  #00aa00     2.9  !!!!!
+TextArea.selectionForeground                        #ffff00  #00aa00     2.9  !!!!!
+TextField.selectionForeground                       #ffff00  #00aa00     2.9  !!!!!
+TextPane.selectionForeground                        #ffff00  #00aa00     2.9  !!!!!
+Tree.selectionForeground                            #ffff00  #00aa00     2.9  !!!!!
+
+#-- selectionInactiveForeground --
+List.selectionInactiveForeground                    #ffffff  #888888     3.5  !!!!
+Table.selectionInactiveForeground                   #ffffff  #888888     3.5  !!!!
+Tree.selectionInactiveForeground                    #ffffff  #888888     3.5  !!!!
+
+#-- specialTitleForeground --
+TaskPane.specialTitleForeground                     #444444  #00ffff     7.8
+
+#-- textForeground --
+Tree.textForeground                                 #ff0000  #fff0ff     3.6  !!!!
+
+#-- titleForeground --
+JXTitledPanel.titleForeground                       #ff00ff  #ffff00     2.9  !!!!!

--- a/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/uidefaults/UIDefaultsDump.java
+++ b/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/uidefaults/UIDefaultsDump.java
@@ -38,6 +38,7 @@ import java.lang.reflect.Field;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
@@ -45,6 +46,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
 import java.util.TreeSet;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
 import javax.swing.*;
 import javax.swing.UIDefaults.ActiveValue;
@@ -63,6 +65,7 @@ import com.formdev.flatlaf.testing.FlatTestLaf;
 import com.formdev.flatlaf.themes.*;
 import com.formdev.flatlaf.ui.FlatLineBorder;
 import com.formdev.flatlaf.ui.FlatUIUtils;
+import com.formdev.flatlaf.util.ColorFunctions;
 import com.formdev.flatlaf.util.ColorFunctions.ColorFunction;
 import com.jidesoft.plaf.LookAndFeelFactory;
 import com.formdev.flatlaf.util.DerivedColor;
@@ -181,20 +184,20 @@ public class UIDefaultsDump
 		// the lazy color InternalFrame.closeHoverBackground is resolved)
 		defaults = (UIDefaults) defaults.clone();
 
-		dump( dir, "", lookAndFeel, defaults, key -> !key.contains( "InputMap" ) );
+		dump( dir, "", lookAndFeel, defaults, key -> !key.contains( "InputMap" ), true );
 
 		if( lookAndFeel.getClass() == FlatLightLaf.class || !(lookAndFeel instanceof FlatLaf) ) {
-			dump( dir, "_InputMap", lookAndFeel, defaults, key -> key.contains( "InputMap" ) );
+			dump( dir, "_InputMap", lookAndFeel, defaults, key -> key.contains( "InputMap" ), false );
 			dumpActionMaps( dir, "_ActionMap", lookAndFeel, defaults );
 		}
 	}
 
 	private static void dump( File dir, String nameSuffix,
-		LookAndFeel lookAndFeel, UIDefaults defaults, Predicate<String> keyFilter )
+		LookAndFeel lookAndFeel, UIDefaults defaults, Predicate<String> keyFilter, boolean contrastRatios )
 	{
 		// dump to string
 		StringWriter stringWriter = new StringWriter( 100000 );
-		new UIDefaultsDump( lookAndFeel, defaults ).dump( new PrintWriter( stringWriter ), keyFilter );
+		new UIDefaultsDump( lookAndFeel, defaults ).dump( new PrintWriter( stringWriter ), keyFilter, contrastRatios );
 
 		String name = lookAndFeel instanceof MyBasicLookAndFeel
 			? BasicLookAndFeel.class.getSimpleName()
@@ -354,12 +357,15 @@ public class UIDefaultsDump
 		Map<String, String> defaults = new LinkedHashMap<>();
 		try( BufferedReader reader = new BufferedReader( in ) ) {
 			String lastKey = null;
+			boolean inContrastRatios = false;
 
 			String line;
 			while( (line = reader.readLine()) != null ) {
 				String trimmedLine = line.trim();
 				if( trimmedLine.isEmpty() || trimmedLine.startsWith( "#" ) ) {
 					lastKey = null;
+					if( trimmedLine.contains( "#-------- Contrast Ratios --------" ) )
+						inContrastRatios = true;
 					continue;
 				}
 
@@ -374,6 +380,8 @@ public class UIDefaultsDump
 
 					String key = line.substring( 0, sep );
 					String value = line.substring( sep );
+					if( inContrastRatios )
+						key = "contrast ratio: " + key;
 					defaults.put( key, value );
 
 					lastKey = key;
@@ -403,7 +411,7 @@ public class UIDefaultsDump
 		out.printf( "OS     %s%n", System.getProperty( "os.name" ) );
 	}
 
-	private void dump( PrintWriter out, Predicate<String> keyFilter ) {
+	private void dump( PrintWriter out, Predicate<String> keyFilter, boolean contrastRatios ) {
 		dumpHeader( out );
 
 		defaults.entrySet().stream()
@@ -428,6 +436,9 @@ public class UIDefaultsDump
 				dumpValue( out, strKey, value );
 				out.println();
 			} );
+
+		if( contrastRatios )
+			dumpContrastRatios( out );
 	}
 
 	private void dumpActionMaps( PrintWriter out ) {
@@ -827,6 +838,124 @@ public class UIDefaultsDump
 		// creating a new color instance to drop Color.frgbvalue from newColor
 		// and avoid rounding issues/differences
 		return new Color( newColor.getRGB(), true );
+	}
+
+	private void dumpContrastRatios( PrintWriter out ) {
+		out.printf( "%n%n#-------- Contrast Ratios --------%n%n" );
+		out.println( "# WCAG 2 Contrast Requirements: minimum 4.5; enhanced 7.0" );
+		out.println( "# https://webaim.org/articles/contrast/#sc143" );
+		out.println();
+
+		HashMap<String, String> fg2bgMap = new HashMap<>();
+		defaults.keySet().stream()
+			.filter( key -> key instanceof String && ((String)key).endsWith( "ackground" ) )
+			.map( key -> (String) key )
+			.forEach( bgKey -> {
+				String fgKey = bgKey.replace( "Background", "Foreground" ).replace( "background", "foreground" );
+				fg2bgMap.put( fgKey, bgKey );
+			} );
+
+		// special cases
+		fg2bgMap.remove( "Button.disabledForeground" );
+		fg2bgMap.put( "Button.disabledText", "Button.disabledBackground" );
+		fg2bgMap.remove( "ToggleButton.disabledForeground" );
+		fg2bgMap.put( "ToggleButton.disabledText", "ToggleButton.disabledBackground" );
+		fg2bgMap.put( "CheckBox.foreground", "Panel.background" );
+		fg2bgMap.put( "CheckBox.disabledText", "Panel.background" );
+		fg2bgMap.put( "Label.foreground", "Panel.background" );
+		fg2bgMap.put( "Label.disabledForeground", "Panel.background" );
+		fg2bgMap.remove( "ProgressBar.foreground" );
+		fg2bgMap.put( "ProgressBar.selectionForeground", "ProgressBar.foreground" );
+		fg2bgMap.put( "ProgressBar.selectionBackground", "ProgressBar.background" );
+		fg2bgMap.put( "RadioButton.foreground", "Panel.background" );
+		fg2bgMap.put( "RadioButton.disabledText", "Panel.background" );
+		fg2bgMap.remove( "ScrollBar.foreground" );
+		fg2bgMap.remove( "ScrollBar.hoverButtonForeground" );
+		fg2bgMap.remove( "ScrollBar.pressedButtonForeground" );
+		fg2bgMap.remove( "ScrollPane.foreground" );
+		fg2bgMap.remove( "Separator.foreground" );
+		fg2bgMap.remove( "Slider.foreground" );
+		fg2bgMap.remove( "SplitPane.foreground" );
+		fg2bgMap.remove( "TextArea.disabledForeground" );
+		fg2bgMap.put( "TextArea.inactiveForeground", "TextArea.disabledBackground" );
+		fg2bgMap.remove( "TextPane.disabledForeground" );
+		fg2bgMap.put( "TextPane.inactiveForeground", "TextPane.disabledBackground" );
+		fg2bgMap.remove( "EditorPane.disabledForeground" );
+		fg2bgMap.put( "EditorPane.inactiveForeground", "EditorPane.disabledBackground" );
+		fg2bgMap.remove( "TextField.disabledForeground" );
+		fg2bgMap.put( "TextField.inactiveForeground", "TextField.disabledBackground" );
+		fg2bgMap.remove( "FormattedTextField.disabledForeground" );
+		fg2bgMap.put( "FormattedTextField.inactiveForeground", "FormattedTextField.disabledBackground" );
+		fg2bgMap.remove( "PasswordField.disabledForeground" );
+		fg2bgMap.put( "PasswordField.inactiveForeground", "PasswordField.disabledBackground" );
+		fg2bgMap.remove( "ToolBar.dockingForeground" );
+		fg2bgMap.remove( "ToolBar.floatingForeground" );
+		fg2bgMap.remove( "ToolBar.foreground" );
+		fg2bgMap.remove( "ToolBar.hoverButtonGroupForeground" );
+		fg2bgMap.remove( "Viewport.foreground" );
+
+		fg2bgMap.remove( "InternalFrame.closeHoverForeground" );
+		fg2bgMap.remove( "InternalFrame.closePressedForeground" );
+		fg2bgMap.remove( "TabbedPane.closeHoverForeground" );
+		fg2bgMap.remove( "TabbedPane.closePressedForeground" );
+		fg2bgMap.remove( "TitlePane.closeHoverForeground" );
+		fg2bgMap.remove( "TitlePane.closePressedForeground" );
+
+//		out.println();
+//		fg2bgMap.entrySet().stream()
+//			.sorted( (e1, e2) -> e1.getKey().compareTo( e2.getKey() ) )
+//			.forEach( e -> {
+//				out.printf( "%-50s  %s%n", e.getKey(), e.getValue() );
+//			} );
+//		out.println();
+
+		AtomicReference<String> lastSubkey = new AtomicReference<>();
+
+		fg2bgMap.entrySet().stream()
+			.sorted( (e1, e2) -> {
+				String key1 = e1.getKey();
+				String key2 = e2.getKey();
+				int dot1 = key1.lastIndexOf( '.' );
+				int dot2 = key2.lastIndexOf( '.' );
+				if( dot1 < 0 || dot2 < 0 )
+					return key1.compareTo( key2 );
+				int r = key1.substring( dot1 + 1 ).compareTo( key2.substring( dot2 + 1 ) );
+				if( r != 0 )
+					return r;
+				return key1.substring( 0, dot1 ).compareTo( key2.substring( 0, dot2 ) );
+			} )
+			.forEach( e -> {
+				String fgKey = e.getKey();
+				String bgKey = e.getValue();
+				Color background = defaults.getColor( bgKey );
+				Color foreground = defaults.getColor( fgKey );
+				if( background != null && foreground != null ) {
+					float luma1 = ColorFunctions.luma( background );
+					float luma2 = ColorFunctions.luma( foreground );
+					float contrastRatio = (luma1 > luma2)
+						? (luma1 + 0.05f) / (luma2 + 0.05f)
+						: (luma2 + 0.05f) / (luma1 + 0.05f);
+					String rateing =
+						contrastRatio < 1.95f ? "  !!!!!!" :
+						contrastRatio < 2.95f ? "  !!!!!" :
+						contrastRatio < 3.95f ? "  !!!!" :
+						contrastRatio < 4.95f ? "  !!!" :
+						contrastRatio < 5.95f ? "  !!" :
+						contrastRatio < 6.95f ? "  !" :
+						"";
+
+					String subkey = fgKey.substring( fgKey.lastIndexOf( '.' ) + 1 );
+					if( !subkey.equals( lastSubkey.get() ) ) {
+						lastSubkey.set( subkey );
+						out.println();
+						out.println( "#-- " + subkey + " --" );
+					}
+
+					out.printf( "%-50s  #%06x  #%06x    %4.1f%s%n", fgKey,
+						foreground.getRGB() & 0xffffff, background.getRGB() & 0xffffff,
+						contrastRatio, rateing );
+				}
+			} );
 	}
 
 	//---- class MyBasicLookAndFeel -------------------------------------------


### PR DESCRIPTION
This PR increases contrast of text for better readability: (issue #762)

  - In **FlatLaf Dark**, **FlatLaf Darcula** and many dark IntelliJ themes made all text colors brighter.
  - In **FlatLaf Light**, **FlatLaf IntelliJ** and many light IntelliJ themes made disabled text colors slightly darker.
  - In **FlatLaf macOS Light** made disabled text colors darker.
  - In **FlatLaf macOS Dark** made text colors of "default" button and selected ToggleButton lighter.

**FlatLaf Dark** theme (left is old, right is new):

![image](https://github.com/user-attachments/assets/326b98dd-c63c-4086-9f18-1f288d27c2c7)

**FlatLaf Light** theme with slightly (only 5%) darker **disabled text** colors (left is old, right is new):

![image](https://github.com/user-attachments/assets/428b60fb-8993-4db8-8bc5-19f3b9ed2e14)

**FlatLaf macOS Light** theme with darker **disabled text** colors (left is old, right is new):

![image](https://github.com/user-attachments/assets/f5becf5d-c882-485c-9425-667eb3ac3607)

**FlatLaf macOS Dark** theme with lighter text in "default" button (left is old, right is new):

![image](https://github.com/user-attachments/assets/49007e74-d376-49da-8d8f-3a104183a618)
