### PR TITLE
Enhance FlatUIUtils.getBorderArc to support FlatLineBorder Arc value

### DIFF
--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatUIUtils.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatUIUtils.java
@@ -461,9 +461,13 @@ public class FlatUIUtils
 	 * Returns the scaled arc diameter of the border for the given component.
 	 */
 	public static float getBorderArc( JComponent c ) {
-		FlatBorder border = getOutsideFlatBorder( c );
-		return (border != null)
-			? UIScale.scale( (float) border.getArc( c ) )
+		Border border = c.getBorder();
+		if( border instanceof FlatLineBorder )
+			return UIScale.scale( ((FlatLineBorder)border).getArc() );
+		
+		FlatBorder outsideBorder = getOutsideFlatBorder( c );
+		return (outsideBorder != null)
+			? UIScale.scale( (float) outsideBorder.getArc( c ) )
 			: 0;
 	}
 


### PR DESCRIPTION
### Description
This PR addresses an issue where `FlatUIUtils.getBorderArc()` returns `0` when a `JComponent` uses `FlatLineBorder`, causing the background painting in `FlatButtonUI` to ignore the specified arc value. As a result, the background spills outside the rounded corners when a background color is set (e.g., `button.setBackground(Color.RED)`), which doesn’t happen with the default `FlatBorder`.

![immagine](https://github.com/user-attachments/assets/12017170-0610-4e5c-b431-820270130351)

### Changes
- Updated `FlatUIUtils.getBorderArc()` to check if the component’s border is an instance of `FlatLineBorder`.
- If it is, retrieve the arc value using `FlatLineBorder.getArc()` and apply `UIScale.scale()` to ensure consistency with `FlatBorder` handling.
- Retained the original logic for `FlatBorder` as a fallback.


--