### PR TITLE
Window decorations: added events to move or resize window

### DIFF
--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatWindowsNativeWindowBorder.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatWindowsNativeWindowBorder.java
@@ -31,9 +31,7 @@ import java.util.Collections;
 import java.util.IdentityHashMap;
 import java.util.Map;
 import java.util.function.Predicate;
-import javax.swing.JDialog;
-import javax.swing.JFrame;
-import javax.swing.Timer;
+import javax.swing.*;
 import javax.swing.event.ChangeEvent;
 import javax.swing.event.ChangeListener;
 import javax.swing.event.EventListenerList;
@@ -80,6 +78,7 @@ class FlatWindowsNativeWindowBorder
 	private boolean colorizationColorAffectsBorders;
 	private Color colorizationColor;
 	private int colorizationColorBalance;
+	private boolean isMovingOrSizing;
 
 	private static FlatWindowsNativeWindowBorder instance;
 
@@ -221,6 +220,19 @@ class FlatWindowsNativeWindowBorder
 		colorizationColor = (value != -1) ? new Color( value ) : null;
 
 		colorizationColorBalance = registryGetIntValue( subKey, "ColorizationColorBalance", -1 );
+	}
+
+	protected void updateIsMovingOrSizingValue( boolean isMovingOrSizing ) {
+		boolean oldValue = this.isMovingOrSizing;
+		this.isMovingOrSizing = isMovingOrSizing;
+
+		if(oldValue != isMovingOrSizing){
+			fireStateChanged();
+		}
+	}
+
+	public boolean isMovingOrSizing() {
+		return isMovingOrSizing;
 	}
 
 	private native static int registryGetIntValue( String key, String valueName, int defaultValue );
@@ -434,6 +446,12 @@ class FlatWindowsNativeWindowBorder
 		// invoked from native code
 		private void fireStateChangedLaterOnce() {
 			FlatWindowsNativeWindowBorder.this.fireStateChangedLaterOnce();
+		}
+
+		private void setIsMovingOrSizing( boolean isMovingOrSizing ) {
+			EventQueue.invokeLater(() ->
+				FlatWindowsNativeWindowBorder.this.updateIsMovingOrSizingValue( isMovingOrSizing )
+			);
 		}
 	}
 }

--- a/flatlaf-natives/flatlaf-natives-windows/src/main/cpp/FlatWndProc.cpp
+++ b/flatlaf-natives/flatlaf-natives-windows/src/main/cpp/FlatWndProc.cpp
@@ -75,6 +75,7 @@ int FlatWndProc::initialized = 0;
 jmethodID FlatWndProc::onNcHitTestMID;
 jmethodID FlatWndProc::isFullscreenMID;
 jmethodID FlatWndProc::fireStateChangedLaterOnceMID;
+jmethodID FlatWndProc::setIsMovingOrSizingMID;
 
 HWNDMap* FlatWndProc::hwndMap;
 DWORD FlatWndProc::osBuildNumber = 0;
@@ -175,11 +176,13 @@ void FlatWndProc::initIDs( JNIEnv *env, jobject obj ) {
 	onNcHitTestMID = env->GetMethodID( cls, "onNcHitTest", "(IIZ)I" );
 	isFullscreenMID = env->GetMethodID( cls, "isFullscreen", "()Z" );
 	fireStateChangedLaterOnceMID = env->GetMethodID( cls, "fireStateChangedLaterOnce", "()V" );
+	setIsMovingOrSizingMID = env->GetMethodID( cls, "setIsMovingOrSizing", "(Z)V" );
 
 	// check whether all IDs were found
 	if( onNcHitTestMID != NULL &&
 		isFullscreenMID != NULL &&
-		fireStateChangedLaterOnceMID != NULL )
+		fireStateChangedLaterOnceMID != NULL &&
+		setIsMovingOrSizingMID != NULL )
 	  initialized = 1;
 }
 
@@ -276,10 +279,12 @@ LRESULT CALLBACK FlatWndProc::WindowProc( HWND hwnd, UINT uMsg, WPARAM wParam, L
 
 		case WM_ENTERSIZEMOVE:
 			isMovingOrSizing = true;
+			setIsMovingOrSizing ( true );
 			break;
 
 		case WM_EXITSIZEMOVE:
 			isMovingOrSizing = isMoving = false;
+			setIsMovingOrSizing ( false );
 			break;
 
 		case WM_MOVE:
@@ -520,6 +525,14 @@ void FlatWndProc::fireStateChangedLaterOnce() {
 		return;
 
 	env->CallVoidMethod( obj, fireStateChangedLaterOnceMID );
+}
+
+void FlatWndProc::setIsMovingOrSizing( boolean isMovingOrSizing ) {
+	JNIEnv* env = getEnv();
+	if( env == NULL )
+		return;
+
+	env->CallIntMethod( obj, setIsMovingOrSizingMID, (jboolean) isMovingOrSizing );
 }
 
 // similar to JNU_GetEnv() in jni_util.c

--- a/flatlaf-natives/flatlaf-natives-windows/src/main/cpp/FlatWndProc.h
+++ b/flatlaf-natives/flatlaf-natives-windows/src/main/cpp/FlatWndProc.h
@@ -33,6 +33,7 @@ private:
 	static jmethodID onNcHitTestMID;
 	static jmethodID isFullscreenMID;
 	static jmethodID fireStateChangedLaterOnceMID;
+	static jmethodID setIsMovingOrSizingMID;
 
 	static HWNDMap* hwndMap;
 	static DWORD osBuildNumber;
@@ -63,6 +64,7 @@ private:
 	BOOL isFullscreen();
 	int onNcHitTest( int x, int y, boolean isOnResizeBorder );
 	void fireStateChangedLaterOnce();
+	void setIsMovingOrSizing( boolean isMovingOrSizing );
 	JNIEnv* getEnv();
 
 	void sendMessageToClientArea( HWND hwnd, int uMsg, LPARAM lParam );


### PR DESCRIPTION
Hi,

As mentioned in my previous issues #960 , I'd like to add an event that lets you know when a Windows user starts and finishes moving or resizing a window.

I've made the necessary changes to make this feature as lightweight as possible, while remaining consistent with the other existing features.

In the pull request, I did not include the new dll files.

Best regards