### PR TITLE
JTable empty header size (too high) fix

### DIFF
--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatTableHeaderUI.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatTableHeaderUI.java
@@ -300,7 +300,7 @@ public class FlatTableHeaderUI
 	public Dimension getPreferredSize( JComponent c ) {
 		Dimension size = super.getPreferredSize( c );
 		if( size.height > 0 )
-			size.height = Math.max( size.height, UIScale.scale( height ) );
+			size.height = Math.max( size.height, UIScale.scale( size.height ) );
 		return size;
 	}
 

--- a/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatEmptyTableHeaderTest.java
+++ b/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatEmptyTableHeaderTest.java
@@ -1,0 +1,32 @@
+package com.formdev.flatlaf.testing;
+
+import javax.swing.BoxLayout;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.JTable;
+import javax.swing.SwingUtilities;
+import javax.swing.table.DefaultTableModel;
+
+public class FlatEmptyTableHeaderTest
+	extends JScrollPane
+{
+
+	public static void main( String[] args ) {
+		SwingUtilities.invokeLater( () -> {
+			FlatTestFrame frame = FlatTestFrame.create( args, "FlatEmptyTableHeaderTest" );
+			frame.showFrame( FlatEmptyTableHeaderTest::new );
+		} );
+	}
+
+	FlatEmptyTableHeaderTest() {
+		JPanel panel = new JPanel();
+		panel.setLayout( new BoxLayout( panel, BoxLayout.X_AXIS ) );
+		panel.add( new JScrollPane( new JTable( new DefaultTableModel(
+			new Object[][] { { "row1" }, { "row2" }, { "row3" }, { "row4" }, { "row5" } }, new Object[] { "" } ) ) ) );
+		panel.add( new JScrollPane( new JTable(
+			new DefaultTableModel( new Object[][] { { "row1" }, { "row2" }, { "row3" }, { "row4" }, { "row5" } },
+				new Object[] { "classic header table" } ) ) ) );
+		setViewportView( panel );
+	}
+
+}


### PR DESCRIPTION
The issue: https://github.com/JFormDesigner/FlatLaf/issues/1006
I just modified the method **com.formdev.flatlaf.ui.FlatTableHeaderUI.getPreferredSize(JComponent)**.
After debugging, I found that the header height (size.height) was correctly calculated by super.getPreferredSize(c). I thought getPreferredSize(JComponent c) had been overridden solely to adapt the header height to the flatlaf.uiScale property. 
Can you confirm this?

I then deduced that this was a typo and that simply replacing "UIScale.scale(height)" with "UIScale.scale(size.height)" would fix this small issue.

I also added: flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatEmptyTableHeaderTest.java to verify the fix. But I'm not sure if this is really useful.