### PR TITLE
TabbedPaneUI: When the mouse wheel event is not in the viewport, propagate the event to the nearest parent

### DIFF
--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatTabbedPaneUI.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatTabbedPaneUI.java
@@ -2708,19 +2708,10 @@ debug*/
 			// because this listener receives mouse events for the whole tabbed pane,
 			// we have to check whether the mouse is located over the viewport
 			if( !isInViewport( e.getX(), e.getY() ) ) {
-				// if it is not in the viewport, retarget the even to a parent container
+				// if it is not in the viewport, retarget the event to a parent container
 				// which might support scrolling (e.g. a surrounding ScrollPane)
-				Container parent = getParent();
-      			while (parent != null) {
-					// informing the first parent with a mouse wheel listener should be sufficient.
-					if (parent.getMouseWheelListeners().length > 0) {
-						for (MouseWheelListener parentListener : parent.getMouseWheelListeners()) {
-							parentListener.mouseWheelMoved(e);
-						}
-						return;
-					}
-					parent = parent.getContainer();
-				}
+				Container parent = tabPane.getParent();
+				parent.dispatchEvent( SwingUtilities.convertMouseEvent( tabPane, e, parent ) );
 				return;
 			}
 


### PR DESCRIPTION
Hello,

I would like to propose a change to the handling of mouse wheel events in the TabbedPane when the event did not occur in the viewport.

The scenario is the following: A JTabbedPane with tab layout policy = SCROLL placed inside a JScrollPane.
If the content of the open tab or of the scroll pane itself are too large to show, the expected behavior is that mouse wheel events cause the outer ScrollPane to scroll - unless the mouse wheel event occurred within the viewport of the TabbedView, in which case the tabs may scroll.

However, the event dispatching retargets the event only to the nearest surrounding component that can handle mouse wheel events, which in case of FlatLaF is the TabbedPane since it brings its own mouse wheel listener. That listener checks if the event is within the viewport, and if it is not, does nothing. The event is also dispatched to the ancestor (Window), which does nothing with it as well. The outer ScrollPane never receives the event.

The proposed fix redirects events outside of the viewport to the nearest parent container that has a mouse listener.
I have not actually compiled it into FlatLaf, but I have tested it by implementing my own MouseWheelListener on a JTabbedPane (with a hacky workaround that removes and adds the additional listener in order to be able to trigger the FlatTabbedPaneUI implementation when needed).

The condition might also need to be refined to ignore other ScrollPanes with FlatTabbedPaneUI found among the parent containers.

with best regards