### PR TITLE
Recalculate geometry after styling in FlatSliderUI

### DIFF
--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatSliderUI.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatSliderUI.java
@@ -227,7 +227,11 @@ public class FlatSliderUI
 
 	/** @since 2 */
 	protected void applyStyle( Object style ) {
+	    boolean recalc = ( oldStyleValues != null && !oldStyleValues.isEmpty() );
 		oldStyleValues = FlatStylingSupport.parseAndApply( oldStyleValues, style, this::applyStyleProperty );
+        recalc |= ( oldStyleValues != null && !oldStyleValues.isEmpty() );
+		if( recalc )
+            calculateGeometry();
 	}
 
 	/** @since 2 */


### PR DESCRIPTION
The parent class BasicSliderUI caches it's calculated geometry for the layout of the track, thumb, ticks, etc.
So it is necessary to recalculate the geometry in FlatSliderUI if the slider is styled to have a correct preferred size.
It's a simple solution without checking what exactly is changed, the track width, the thumb size or only a color.
But at least it checks the internal oldStyleValues map, so if it is empty before and after the styling no recalculation is done.
