### PR TITLE
Fix NPE in FlatUIDefaultsInspector when color is null

### DIFF
--- a/flatlaf-extras/src/main/java/com/formdev/flatlaf/extras/FlatUIDefaultsInspector.java
+++ b/flatlaf-extras/src/main/java/com/formdev/flatlaf/extras/FlatUIDefaultsInspector.java
@@ -777,6 +777,9 @@ public class FlatUIDefaultsInspector
 
 		@SuppressWarnings( "FormatString" ) // Error Prone
 		private static String color2hex( Color color ) {
+
+			if ( color == null ) return "#none";
+
 			int rgb = color.getRGB();
 			boolean hasAlpha = color.getAlpha() != 255;
 
@@ -1019,7 +1022,7 @@ public class FlatUIDefaultsInspector
 			init( table, item.key, isSelected, row );
 
 			// reset background, foreground and icon
-			if( !(item.value instanceof Color) ) {
+			if( !isTargetClass() ) {
 				setBackground( null );
 				setForeground( null );
 			}
@@ -1033,12 +1036,19 @@ public class FlatUIDefaultsInspector
 
 			if( item.value instanceof Color ) {
 				Color color = (item.info instanceof Color[]) ? ((Color[])item.info)[0] : (Color) item.value;
-				boolean isDark = new HSLColor( color ).getLuminance() < 70 && color.getAlpha() >= 128;
 				valueColor = color;
-				setForeground( isDark ? Color.white : Color.black );
+				setForeground( fgColor( color ) );
 			} else if( item.value instanceof Icon ) {
 				Icon icon = (Icon) item.value;
 				setIcon( new SafeIcon( icon ) );
+			} else if ( item.value instanceof FlatLineBorder ) {
+				Color lineColor = ((FlatLineBorder)item.value).getLineColor();
+				valueColor = lineColor == null
+					? (isSelected ? table.getSelectionBackground() : table.getBackground())
+					: lineColor;
+				setForeground( lineColor == null
+					? (isSelected ? table.getSelectionForeground() : table.getForeground())
+					: fgColor( lineColor ) );
 			}
 
 			// set tooltip
@@ -1054,9 +1064,18 @@ public class FlatUIDefaultsInspector
 			return this;
 		}
 
+		private boolean isTargetClass() {
+			return item.value instanceof Color || item.value instanceof FlatLineBorder;
+		}
+
+		private Color fgColor( Color color ) {
+			boolean isDark = new HSLColor( color ).getLuminance() < 70 && color.getAlpha() >= 128;
+			return isDark ? Color.white : Color.black;
+		}
+
 		@Override
 		protected void paintComponent( Graphics g ) {
-			if( item.value instanceof Color ) {
+			if( isTargetClass() ) {
 				int width = getWidth();
 				int height = getHeight();
 				Color background = valueColor;


### PR DESCRIPTION
The UI Defaults Inspector renders color values by painting the table cell background with the corresponding color, which makes color identification immediate and visual.

However, when listing `FlatLineBorder` values, although the border properties `(insets`, `color hex value` and `line thickness`) are displayed, the value cell background was not painted using the border color. This made it difficult to visually identify the actual color used by the border.

This change extends the existing behavior so that, when a `FlatLineBorder` is displayed, the value cell background is painted using the border’s line color, providing the same visual feedback already available for plain color values.

According to the FlatLaf documentation, borders defined using the
`top,left,bottom,right[,lineColor[,lineThickness[,arc]]] `format allow `lineColor`, `lineThickness`, and `arc` to be optional.

This means definitions such as `5,5,5,5,,,15`, specified in theme `.properties` files, are valid and supported, resulting in a rounded border without a line color, which works correctly when applied to Swing components.

When such a border is encountered by the UI Defaults Inspector, the absence of a `lineColor` results in a null value, which previously caused a `NullPointerException` during rendering.

This change ensures that the inspector handles this documented and valid configuration gracefully, avoiding runtime exceptions and improving robustness and usability when inspecting theme-defined borders.

The implementation is minimal and does not affect existing rendering behavior for other value types.