### PR TITLE
Fix exception when SVG icon name has no file extension

### DIFF
--- a/flatlaf-extras/src/main/java/com/formdev/flatlaf/extras/FlatSVGIcon.java
+++ b/flatlaf-extras/src/main/java/com/formdev/flatlaf/extras/FlatSVGIcon.java
@@ -524,7 +524,8 @@ public class FlatSVGIcon
 	private URL getIconURL( String name, boolean dark ) {
 		if( dark ) {
 			int dotIndex = name.lastIndexOf( '.' );
-			name = name.substring( 0, dotIndex ) + "_dark" + name.substring( dotIndex );
+			if ( dotIndex > 0 )
+				name = name.substring( 0, dotIndex ) + "_dark" + name.substring( dotIndex );
 		}
 
 		ClassLoader cl = (classLoader != null) ? classLoader : FlatSVGIcon.class.getClassLoader();


### PR DESCRIPTION
When using dark themes, FlatSVGIcon attempts to insert `_dark` before the file
extension. If the icon name does not contain a dot, this results in a
`StringIndexOutOfBoundsException.`

This situation can easily occur if the SVG file path is provided without the
`.svg` extension by mistake, since the API does not enforce or validate the
file name format.

This change adds a simple guard to avoid invalid substring operations when
no file extension is present, preventing runtime exceptions while preserving
existing behavior.
