### PR TITLE
TextField: fixed preferred size when leading/trailing component or icon are present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ FlatLaf Change Log
   - macOS: `Cmd+A` (**Select All**) did not work in file dialog. (issue #1084)
 - macOS: Fixed missing close/iconify/maximize buttons on inactive window, if
   system appearance is dark, but application appearance is light. (issue #1032)
-
+- TextComponents: Fixed preferred width when leading/trailing components or
+  icons are present. (issue #1110)
 
 ## 3.7.1
 

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatTextFieldUI.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatTextFieldUI.java
@@ -540,41 +540,44 @@ debug*/
 
 	@Override
 	public Dimension getPreferredSize( JComponent c ) {
-		return applyMinimumWidth( c, applyExtraSize( super.getPreferredSize( c ), true ), minimumWidth );
+		return applyMinimumWidth( c, applyExtraSize( super.getPreferredSize( c ) ), minimumWidth );
 	}
 
 	@Override
 	public Dimension getMinimumSize( JComponent c ) {
-		return applyMinimumWidth( c, applyExtraSize( super.getMinimumSize( c ), false ), minimumWidth );
+		return applyMinimumWidth( c, applyExtraSize( super.getMinimumSize( c ) ), minimumWidth );
 	}
 
-	private Dimension applyExtraSize( Dimension size, boolean reduceInset ) {
+	private Dimension applyExtraSize( Dimension size ) {
 		// add width of leading and trailing icons
 		size.width += getLeadingIconWidth() + getTrailingIconWidth();
 
 		// add width of leading and trailing components
-		boolean leftVisible = false;
-		boolean rightVisible = false;
+		boolean leftCompVisible = false;
+		boolean rightCompVisible = false;
 		for( JComponent comp : getLeadingComponents() ) {
 			if( comp != null && comp.isVisible() ) {
 				size.width += comp.getPreferredSize().width;
-				leftVisible = true;
+				leftCompVisible = true;
 			}
 		}
 		for( JComponent comp : getTrailingComponents() ) {
 			if( comp != null && comp.isVisible() ) {
 				size.width += comp.getPreferredSize().width;
-				rightVisible = true;
+				rightCompVisible = true;
 			}
 		}
-		if( reduceInset ) {
-			boolean ltr = isLeftToRight();
-			HorizontalInsets diffInsets = getDiffInsets( leftVisible, rightVisible, ltr );
-			if( diffInsets.left > 0 )
-				size.width -= diffInsets.left;
-			if( diffInsets.right > 0 )
-				size.width -= diffInsets.right;
-		}
+
+		// if leading/trailing icons or components are shown,
+		// then the left/right insets are reduced to the top inset,
+		// which places the icon nicely centered on left/right side
+		// --> reduce width if necessary
+		Insets diffInsets = getDiffInsets( leftCompVisible, rightCompVisible );
+		if( diffInsets.left > 0 )
+			size.width -= diffInsets.left;
+		if( diffInsets.right > 0 )
+			size.width -= diffInsets.right;
+
 		return size;
 	}
 
@@ -598,23 +601,6 @@ debug*/
 		float focusWidth = FlatUIUtils.getBorderFocusWidth( c );
 		size.width = Math.max( size.width, scale( minimumWidth ) + Math.round( focusWidth * 2 ) );
 		return size;
-	}
-
-	private HorizontalInsets getDiffInsets( boolean leftVisible, boolean rightVisible, boolean ltr ) {
-		int left = 0;
-		int right = 0;
-		Insets insets = getComponent().getInsets();
-		if( leftVisible || (ltr ? hasLeadingIcon() : hasTrailingIcon()) ) {
-			int newLeftInset = Math.min( insets.left, insets.top );
-			if( newLeftInset < insets.left )
-				left = insets.left - newLeftInset;
-		}
-		if( rightVisible || (ltr ? hasTrailingIcon() : hasLeadingIcon()) ) {
-			int newRightInset = Math.min( insets.right, insets.top );
-			if( newRightInset < insets.right )
-				right = insets.right - newRightInset;
-		}
-		return new HorizontalInsets( left, right );
 	}
 
 	static boolean hasDefaultMargins( JComponent c, Insets defaultMargin ) {
@@ -673,26 +659,27 @@ debug*/
 		// remove width of leading/trailing components
 		JComponent[] leftComponents = ltr ? getLeadingComponents() : getTrailingComponents();
 		JComponent[] rightComponents = ltr ? getTrailingComponents() : getLeadingComponents();
-		boolean leftVisible = false;
-		boolean rightVisible = false;
+		boolean leftCompVisible = false;
+		boolean rightCompVisible = false;
 		for( JComponent leftComponent : leftComponents ) {
 			if( leftComponent != null && leftComponent.isVisible() ) {
 				int w = leftComponent.getPreferredSize().width;
 				r.x += w;
 				r.width -= w;
-				leftVisible = true;
+				leftCompVisible = true;
 			}
 		}
 		for( JComponent rightComponent : rightComponents ) {
 			if( rightComponent != null && rightComponent.isVisible() ) {
 				r.width -= rightComponent.getPreferredSize().width;
-				rightVisible = true;
+				rightCompVisible = true;
 			}
 		}
 
-		// if a leading/trailing icons (or components) are shown, then the left/right insets are reduced
-		// to the top inset, which places the icon nicely centered on left/right side
-		HorizontalInsets diffInsets = getDiffInsets( leftVisible, rightVisible, ltr );
+		// if leading/trailing icons or components are shown,
+		// then the left/right insets are reduced to the top inset,
+		// which places the icon nicely centered on left/right side
+		Insets diffInsets = getDiffInsets( leftCompVisible, rightCompVisible );
 		if( diffInsets.left > 0 ) {
 			r.x -= diffInsets.left;
 			r.width += diffInsets.left;
@@ -705,6 +692,27 @@ debug*/
 		r.height = Math.max( r.height, 0 );
 
 		return r;
+	}
+
+	private Insets getDiffInsets( boolean leftCompVisible, boolean rightCompVisible ) {
+		int left = 0;
+		int right = 0;
+		boolean ltr = isLeftToRight();
+		if( leftCompVisible || (ltr ? hasLeadingIcon() : hasTrailingIcon()) ) {
+			// reduce left inset
+			Insets insets = getComponent().getInsets();
+			int newLeftInset = Math.min( insets.left, insets.top );
+			if( newLeftInset < insets.left )
+				left = insets.left - newLeftInset;
+		}
+		if( rightCompVisible || (ltr ? hasTrailingIcon() : hasLeadingIcon()) ) {
+			// reduce right inset
+			Insets insets = getComponent().getInsets();
+			int newRightInset = Math.min( insets.right, insets.top );
+			if( newRightInset < insets.right )
+				right = insets.right - newRightInset;
+		}
+		return new Insets( 0, left, 0, right );
 	}
 
 	/** @since 2 */
@@ -1002,19 +1010,6 @@ debug*/
 		@Override
 		public void changedUpdate( DocumentEvent e ) {
 			documentChanged( e );
-		}
-	}
-
-	//---- class HorizontalInsets ---------------------------------------------
-
-	private static class HorizontalInsets
-	{
-		int left;
-		int right;
-
-		HorizontalInsets( int left, int right ) {
-			this.left = left;
-			this.right = right;
 		}
 	}
 }

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatTextFieldUI.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatTextFieldUI.java
@@ -540,28 +540,41 @@ debug*/
 
 	@Override
 	public Dimension getPreferredSize( JComponent c ) {
-		return applyMinimumWidth( c, applyExtraSize( super.getPreferredSize( c ) ), minimumWidth );
+		return applyMinimumWidth( c, applyExtraSize( super.getPreferredSize( c ), true ), minimumWidth );
 	}
 
 	@Override
 	public Dimension getMinimumSize( JComponent c ) {
-		return applyMinimumWidth( c, applyExtraSize( super.getMinimumSize( c ) ), minimumWidth );
+		return applyMinimumWidth( c, applyExtraSize( super.getMinimumSize( c ), false ), minimumWidth );
 	}
 
-	private Dimension applyExtraSize( Dimension size ) {
+	private Dimension applyExtraSize( Dimension size, boolean reduceInset ) {
 		// add width of leading and trailing icons
 		size.width += getLeadingIconWidth() + getTrailingIconWidth();
 
 		// add width of leading and trailing components
+		boolean leftVisible = false;
+		boolean rightVisible = false;
 		for( JComponent comp : getLeadingComponents() ) {
-			if( comp != null && comp.isVisible() )
+			if( comp != null && comp.isVisible() ) {
 				size.width += comp.getPreferredSize().width;
+				leftVisible = true;
+			}
 		}
 		for( JComponent comp : getTrailingComponents() ) {
-			if( comp != null && comp.isVisible() )
+			if( comp != null && comp.isVisible() ) {
 				size.width += comp.getPreferredSize().width;
+				rightVisible = true;
+			}
 		}
-
+		if( reduceInset ) {
+			boolean ltr = isLeftToRight();
+			HorizontalInsets diffInsets = getDiffInsets( leftVisible, rightVisible, ltr );
+			if( diffInsets.left > 0 )
+				size.width -= diffInsets.left;
+			if( diffInsets.right > 0 )
+				size.width -= diffInsets.right;
+		}
 		return size;
 	}
 
@@ -585,6 +598,23 @@ debug*/
 		float focusWidth = FlatUIUtils.getBorderFocusWidth( c );
 		size.width = Math.max( size.width, scale( minimumWidth ) + Math.round( focusWidth * 2 ) );
 		return size;
+	}
+
+	private HorizontalInsets getDiffInsets( boolean leftVisible, boolean rightVisible, boolean ltr ) {
+		int left = 0;
+		int right = 0;
+		Insets insets = getComponent().getInsets();
+		if( leftVisible || (ltr ? hasLeadingIcon() : hasTrailingIcon()) ) {
+			int newLeftInset = Math.min( insets.left, insets.top );
+			if( newLeftInset < insets.left )
+				left = insets.left - newLeftInset;
+		}
+		if( rightVisible || (ltr ? hasTrailingIcon() : hasLeadingIcon()) ) {
+			int newRightInset = Math.min( insets.right, insets.top );
+			if( newRightInset < insets.right )
+				right = insets.right - newRightInset;
+		}
+		return new HorizontalInsets( left, right );
 	}
 
 	static boolean hasDefaultMargins( JComponent c, Insets defaultMargin ) {
@@ -662,23 +692,13 @@ debug*/
 
 		// if a leading/trailing icons (or components) are shown, then the left/right insets are reduced
 		// to the top inset, which places the icon nicely centered on left/right side
-		if( leftVisible || (ltr ? hasLeadingIcon() : hasTrailingIcon()) ) {
-			// reduce left inset
-			Insets insets = getComponent().getInsets();
-			int newLeftInset = Math.min( insets.left, insets.top );
-			if( newLeftInset < insets.left ) {
-				int diff = insets.left - newLeftInset;
-				r.x -= diff;
-				r.width += diff;
-			}
+		HorizontalInsets diffInsets = getDiffInsets( leftVisible, rightVisible, ltr );
+		if( diffInsets.left > 0 ) {
+			r.x -= diffInsets.left;
+			r.width += diffInsets.left;
 		}
-		if( rightVisible || (ltr ? hasTrailingIcon() : hasLeadingIcon()) ) {
-			// reduce right inset
-			Insets insets = getComponent().getInsets();
-			int newRightInset = Math.min( insets.right, insets.top );
-			if( newRightInset < insets.left )
-				r.width += insets.right - newRightInset;
-		}
+		if( diffInsets.right > 0 )
+			r.width += diffInsets.right;
 
 		// make sure that width and height are not negative
 		r.width = Math.max( r.width, 0 );
@@ -982,6 +1002,19 @@ debug*/
 		@Override
 		public void changedUpdate( DocumentEvent e ) {
 			documentChanged( e );
+		}
+	}
+
+	//---- class HorizontalInsets ---------------------------------------------
+
+	private static class HorizontalInsets
+	{
+		int left;
+		int right;
+
+		HorizontalInsets( int left, int right ) {
+			this.left = left;
+			this.right = right;
 		}
 	}
 }


### PR DESCRIPTION
This PR fixes an issue with TextField margins when using leading/trailing components or icons.

When no layout constraint is set and the JTextField column is 0, the layout uses the component’s preferred size. In this case, an extra horizontal margin becomes visible.

From reviewing the existing implementation, the left and right insets are reduced when leading/trailing components are present, but this is not reflected in the preferred size calculation.

This PR resolves the issue by updating `getPreferredSize(JComponent c)` to adjusted insets.

Before Fix

![no-fix](https://github.com/user-attachments/assets/d75ab3d6-d58d-4d4c-8fca-3ff97a3c46be)

After Fix

![fix](https://github.com/user-attachments/assets/b59bc2ff-0844-44ba-b13b-b3da99c99563)

