### PR TITLE
Fix: Improve JTabbedPane tab title rendering

### DIFF
--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatTabbedPaneUI.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatTabbedPaneUI.java
@@ -18,6 +18,7 @@ package com.formdev.flatlaf.ui;
 
 import static com.formdev.flatlaf.util.UIScale.scale;
 import static com.formdev.flatlaf.FlatClientProperties.*;
+import java.awt.BasicStroke;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Component;
@@ -33,6 +34,7 @@ import java.awt.KeyboardFocusManager;
 import java.awt.LayoutManager;
 import java.awt.Point;
 import java.awt.Rectangle;
+import java.awt.RenderingHints;
 import java.awt.Shape;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
@@ -49,8 +51,12 @@ import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
 import java.awt.event.MouseMotionListener;
 import java.awt.event.MouseWheelEvent;
+import java.awt.font.FontRenderContext;
+import java.awt.font.TextHitInfo;
+import java.awt.font.TextLayout;
 import java.awt.geom.AffineTransform;
 import java.awt.geom.Area;
+import java.awt.geom.Line2D;
 import java.awt.geom.Path2D;
 import java.awt.geom.Rectangle2D;
 import java.beans.PropertyChangeEvent;
@@ -1294,38 +1300,77 @@ debug*/
 
 	@Override
 	protected void paintText( Graphics g, int tabPlacement, Font font, FontMetrics metrics,
-		int tabIndex, String title, Rectangle textRect, boolean isSelected )
-	{
+		int tabIndex, String title, Rectangle textRect, boolean isSelected ) {
+
 		g.setFont( font );
 
-		FlatUIUtils.runWithoutRenderingHints( g, oldRenderingHints, () -> {
+		Graphics2D g2 = (Graphics2D)g.create();
+
+		try {
 			// html
 			View view = getTextViewForTab( tabIndex );
+
 			if( view != null ) {
-				AffineTransform oldTransform = rotateGraphics( g, tabPlacement, textRect );
+
+				AffineTransform oldTransform = rotateGraphics( g2, tabPlacement, textRect );
 				Rectangle textRect2 = (oldTransform != null)
 					? new Rectangle( textRect.x, textRect.y, textRect.height, textRect.width )
 					: textRect;
 
-				view.paint( g, textRect2 );
+				view.paint( g2, textRect2 );
 
-				if( oldTransform != null )
-					((Graphics2D)g).setTransform( oldTransform );
+				return;
+
+			}
+
+			if( title == null || title.isEmpty() )
+				return;
+
+			AffineTransform oldTransform = rotateGraphics( g2, tabPlacement, textRect );
+			g2.setColor( getTabForeground( tabPlacement, tabIndex, isSelected ) );
+
+			int ni = FlatLaf.isShowMnemonics()
+				? tabPane.getDisplayedMnemonicIndexAt( tabIndex )
+				: -1;
+
+			// horizontal
+			if( oldTransform == null ) {
+				FlatUIUtils.drawStringUnderlineCharAt( tabPane, g2, title, ni, textRect.x,
+					textRect.y + metrics.getAscent() );
 				return;
 			}
 
-			// rotate text if necessary
-			AffineTransform oldTransform = rotateGraphics( g, tabPlacement, textRect );
+			// vertical
+			FontRenderContext frc = g2.getFontRenderContext();
+			TextLayout layout = new TextLayout( title, font, frc );
 
-			// plain text
-			int mnemIndex = FlatLaf.isShowMnemonics() ? tabPane.getDisplayedMnemonicIndexAt( tabIndex ) : -1;
-			g.setColor( getTabForeground( tabPlacement, tabIndex, isSelected ) );
-			FlatUIUtils.drawStringUnderlineCharAt( tabPane, g, title, mnemIndex,
-				textRect.x, textRect.y + metrics.getAscent() );
+			float xPos = (float) textRect.x;
+			float yPos = (float) textRect.y + metrics.getAscent();
 
-			if( oldTransform != null )
-				((Graphics2D)g).setTransform( oldTransform );
-		} );
+			Shape outline = layout.getOutline( AffineTransform.getTranslateInstance( xPos, yPos ) );
+			g2.fill( outline );
+
+			// underline vertical
+			if( ni >= 0 && ni < title.length() ) {
+
+				Shape charShape = layout.getVisualHighlightShape( TextHitInfo.leading( ni ), TextHitInfo.trailing( ni ) );
+				Rectangle2D charBounds = charShape.getBounds2D();
+
+				float thickness = 1.0f;
+				float yUnderline = yPos + thickness + 1.0f;
+
+				Line2D.Float underline = new Line2D.Float( (float) (xPos + charBounds.getX()), yUnderline,
+					(float) (xPos + charBounds.getX() + charBounds.getWidth()), yUnderline );
+
+				g2.setStroke( new BasicStroke( thickness ) );
+				g2.draw( underline );
+
+			}
+
+		} finally {
+			g2.dispose();
+		}
+
 	}
 
 	@Override


### PR DESCRIPTION
This PR improves the rendering of tab titles in `JTabbedPane,` specifically when tabs are placed vertically (Left/Right). Previously, rotated text often exhibited minor visual distortions and aliasing issues. Vertical text rendering is now much closer in quality to horizontal rendering, providing a more professional and consistent UI look across all tab placements

**Scale 125%**
<img width="442" height="214" alt="scale125" src="https://github.com/user-attachments/assets/4c9c4f1e-2252-4067-bc4f-a3393a40dabb" />


**Scale 150%**
<img width="514" height="246" alt="scale150" src="https://github.com/user-attachments/assets/8c7563aa-4d7a-402c-8c35-ee75b198354f" />

**Vector-based Rendering:** For rotated text, the implementation now uses `TextLayout.getOutline()` to render the title as a `Shape.` This ensures high-quality vector-based rendering, eliminating the "blurred" or "jagged" look that sometimes occurred with standard string drawing during rotation.

**Horizontal Rendering:** Kept the original `drawStringUnderlineCharAt` for horizontal tabs to maintain peak performance and native font rendering consistency.

**Mnemonic Support:** Manually implemented the underline logic for vertical text using `TextHitInfo,` ensuring the `mnemonic` remains perfectly aligned with the vector-based title.

_Important Notes_:
This improvement applies only to plain text titles. For tabs using **HTML** content, the original `View.paint()` logic is preserved, and the rendering remains unchanged.