### PR TITLE
Color Spaces for mixing colors

### DIFF
--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/UIDefaultsLoader.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/UIDefaultsLoader.java
@@ -1074,13 +1074,13 @@ class UIDefaultsLoader
 
 		if( params.size() > 2 ) {
 			String options = params.get( 2 );
-			relative = options.contains( "relative" );
-			autoInverse = options.contains( "autoInverse" );
-			derived = options.contains( "derived" );
-			lazy = options.contains( "lazy" );
+			relative = hasOption( options, "relative" );
+			autoInverse = hasOption( options, "autoInverse" );
+			derived = hasOption( options, "derived" );
+			lazy = hasOption( options, "lazy" );
 
 			// use autoInverse by default for derived colors, except if noAutoInverse is set
-			if( derived && !options.contains( "noAutoInverse" ) )
+			if( derived && !hasOption( options, "noAutoInverse" ) )
 				autoInverse = true;
 		}
 
@@ -1111,8 +1111,8 @@ class UIDefaultsLoader
 
 		if( params.size() > 2 ) {
 			String options = params.get( 2 );
-			derived = options.contains( "derived" );
-			lazy = options.contains( "lazy" );
+			derived = hasOption( options, "derived" );
+			lazy = hasOption( options, "lazy" );
 		}
 
 		// create function
@@ -1141,8 +1141,8 @@ class UIDefaultsLoader
 
 		if( params.size() > 2 ) {
 			String options = params.get( 2 );
-			derived = options.contains( "derived" );
-			lazy = options.contains( "lazy" );
+			derived = hasOption( options, "derived" );
+			lazy = hasOption( options, "lazy" );
 		}
 
 		// create function
@@ -1177,8 +1177,8 @@ class UIDefaultsLoader
 
 		if( params.size() > 2 ) {
 			String options = params.get( 2 );
-			derived = options.contains( "derived" );
-			lazy = options.contains( "lazy" );
+			derived = hasOption( options, "derived" );
+			lazy = hasOption( options, "lazy" );
 		}
 
 		// create function
@@ -1199,7 +1199,7 @@ class UIDefaultsLoader
 	 *   - color2: a color (e.g. #f00) or a color function
 	 *   - weight: the weight (in range 0-100%) to mix the two colors
 	 *             larger weight uses more of first color, smaller weight more of second color
-	 *   - options: [derived] [lazy]
+	 *   - options: [rgb|lrgb|oklab] [derived] [lazy]
 	 */
 	private static Object parseColorMix( String color1Str, List<String> params, Function<String, String> resolver )
 		throws IllegalArgumentException
@@ -1211,6 +1211,7 @@ class UIDefaultsLoader
 		int weight = 50;
 		boolean derived = false;
 		boolean lazy = false;
+		int method = ColorFunctions.RGB;
 
 		if( params.size() > i ) {
 			String weightStr = params.get( i );
@@ -1221,8 +1222,14 @@ class UIDefaultsLoader
 		}
 		if( params.size() > i ) {
 			String options = params.get( i );
-			derived = options.contains( "derived" );
-			lazy = options.contains( "lazy" );
+			if( hasOption( options, "rgb" ) )
+				method = ColorFunctions.RGB;
+			else if( hasOption( options, "lrgb" ) )
+				method = ColorFunctions.LRGB;
+			else if( hasOption( options, "oklab" ) )
+				method = ColorFunctions.OKLAB;
+			derived = hasOption( options, "derived" );
+			lazy = hasOption( options, "lazy" );
 		}
 
 		// parse second color
@@ -1231,7 +1238,7 @@ class UIDefaultsLoader
 			return null;
 
 		// create function
-		ColorFunction function = new ColorFunctions.Mix2( color1, weight );
+		ColorFunction function = new ColorFunctions.Mix2( color1, weight, method );
 
 		if( lazy )
 			return newLazyColorFunction( color2Str, function );
@@ -1607,6 +1614,14 @@ class UIDefaultsLoader
 			strs.add( s );
 
 		return strs;
+	}
+
+	static boolean hasOption( String options, String option ) {
+		int index = options.indexOf( option );
+		int endIndex = index + option.length();
+		return index >= 0 &&
+			(index == 0 || Character.isWhitespace( options.charAt( index - 1 ) )) &&
+			(endIndex == options.length() || Character.isWhitespace( options.charAt( endIndex ) ));
 	}
 
 	private static Object invokeConstructorOrStaticMethod( Executable[] constructorsOrMethods,

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/UIDefaultsLoader.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/UIDefaultsLoader.java
@@ -1450,7 +1450,7 @@ class UIDefaultsLoader
 		return font;
 	}
 
-	private static int parsePercentage( String value )
+	static int parsePercentage( String value )
 		throws IllegalArgumentException, NumberFormatException
 	{
 		if( !value.endsWith( "%" ) )
@@ -1500,7 +1500,7 @@ class UIDefaultsLoader
 		return integer;
 	}
 
-	private static Integer parseInteger( String value )
+	static Integer parseInteger( String value )
 		throws NumberFormatException
 	{
 		try {
@@ -1591,7 +1591,7 @@ class UIDefaultsLoader
 	 * Splits function parameters and allows using functions as parameters.
 	 * In other words: Delimiters surrounded by '(' and ')' are ignored.
 	 */
-	private static List<String> splitFunctionParams( String str, char delim ) {
+	static List<String> splitFunctionParams( String str, char delim ) {
 		ArrayList<String> strs = new ArrayList<>();
 		int nestLevel = 0;
 		int start = 0;

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/util/ColorFunctions.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/util/ColorFunctions.java
@@ -26,6 +26,27 @@ import java.awt.Color;
 public class ColorFunctions
 {
 	/**
+	 * sRGB color space.
+	 *
+	 * @since 3.8
+	 */
+	public static final int RGB = 0;
+
+	/**
+	 * Linear-light sRGB color space.
+	 *
+	 * @since 3.8
+	 */
+	public static final int LRGB = 1;
+
+	/**
+	 * <a href="https://bottosson.github.io/posts/oklab/">Oklab</a> color space.
+	 *
+	 * @since 3.8
+	 */
+	public static final int OKLAB = 2;
+
+	/**
 	 * Increase the lightness of a color in HSL color space by an absolute amount.
 	 * <p>
 	 * Consider using {@link #tint(Color, float)} as alternative.
@@ -120,6 +141,8 @@ public class ColorFunctions
 
 	/**
 	 * Returns a color that is a mixture of two colors.
+	 * Uses {@link #RGB} interpolation method.
+	 * For better results use {@link #OKLAB} or {@link #LRGB} and {@link #mix(Color, Color, float, int)}.
 	 * <p>
 	 * This can be used to animate a color change from {@code color1} to {@code color2}
 	 * by invoking this method multiple times with decreasing {@code weight} (from 1 to 0).
@@ -132,6 +155,27 @@ public class ColorFunctions
 	 * @return mixture of colors
 	 */
 	public static Color mix( Color color1, Color color2, float weight ) {
+		return mix( color1, color2, weight, RGB );
+	}
+
+	/**
+	 * Returns a color that is a mixture of two colors, using give interpolation method.
+	 * For best results use {@link #OKLAB} or {@link #LRGB}.
+	 * <p>
+	 * This can be used to animate a color change from {@code color1} to {@code color2}
+	 * by invoking this method multiple times with decreasing {@code weight} (from 1 to 0).
+	 *
+	 * @param color1 first color
+	 * @param color2 second color
+	 * @param weight the weight of first color (in range 0-1), used to mix the two colors.
+	 *               Weight of second color is {@code 1-weight}.
+	 *               Larger weight uses more of first color, smaller weight more of second color.
+	 * @param method interpolation method used to mix the colors:
+	 *               {@link #RGB}, {@link #LRGB} or {@link #OKLAB}
+	 * @return mixture of colors
+	 * @since 3.8
+	 */
+	public static Color mix( Color color1, Color color2, float weight, int method ) {
 		if( weight >= 1 )
 			return color1;
 		if( weight <= 0 )
@@ -139,30 +183,60 @@ public class ColorFunctions
 		if( color1.equals( color2 ) )
 			return color1;
 
-		int r1 = color1.getRed();
-		int g1 = color1.getGreen();
-		int b1 = color1.getBlue();
-		int a1 = color1.getAlpha();
+		switch( method ) {
+			case RGB:			return mixRGB( color1, color2, weight );
+			case LRGB:			return mixLinearRGB( color1, color2, weight );
+			case OKLAB:			return mixOklab( color1, color2, weight );
+			default:			throw new IllegalArgumentException();
+		}
+	}
 
-		int r2 = color2.getRed();
-		int g2 = color2.getGreen();
-		int b2 = color2.getBlue();
-		int a2 = color2.getAlpha();
-
+	private static Color mixRGB( Color color1, Color color2, float weight ) {
 		return new Color(
-			Math.round( r2 + ((r1 - r2) * weight) ),
-			Math.round( g2 + ((g1 - g2) * weight) ),
-			Math.round( b2 + ((b1 - b2) * weight) ),
-			Math.round( a2 + ((a1 - a2) * weight) ) );
+			Math.round( lerp( color1.getRed(),   color2.getRed(),   weight ) ),
+			Math.round( lerp( color1.getGreen(), color2.getGreen(), weight ) ),
+			Math.round( lerp( color1.getBlue(),  color2.getBlue(),  weight ) ),
+			Math.round( lerp( color1.getAlpha(), color2.getAlpha(), weight ) ) );
+	}
+
+	private static Color mixLinearRGB( Color color1, Color color2, float weight ) {
+		float[] lrgb1 = toLinearRGB( color1 );
+		float[] lrgb2 = toLinearRGB( color2 );
+
+		return fromLinearRGB( new float[] {
+			lerp( lrgb1[0], lrgb2[0], weight ),
+			lerp( lrgb1[1], lrgb2[1], weight ),
+			lerp( lrgb1[2], lrgb2[2], weight ),
+			lerp( lrgb1[3], lrgb2[3], weight ),
+		} );
+	}
+
+	private static Color mixOklab( Color color1, Color color2, float weight ) {
+		float[] oklab1 = toOklab( color1 );
+		float[] oklab2 = toOklab( color2 );
+
+		return fromOklab( new float[] {
+			lerp( oklab1[0], oklab2[0], weight ),
+			lerp( oklab1[1], oklab2[1], weight ),
+			lerp( oklab1[2], oklab2[2], weight ),
+			lerp( oklab1[3], oklab2[3], weight ),
+		} );
+	}
+
+	private static float lerp( float value1, float value2, float weight ) {
+		return value2 + ((value1 - value2) * weight);
 	}
 
 	/**
-	 * Mix color with white, which makes the color brighter.
+	 * Mix color with white, which makes the color lighter.
 	 * This is the same as {@link #mix}{@code (Color.white, color, weight)}.
+	 * Uses {@link #RGB} interpolation method.
+	 * For better results use {@link #OKLAB} or {@link #LRGB} and {@link #tint(Color, float, int)}.
 	 *
-	 * @param color second color
-	 * @param weight the weight (in range 0-1) to mix the two colors.
-	 *               Larger weight uses more of first color, smaller weight more of second color.
+	 * @param color color to mix with white
+	 * @param weight the weight of white (in range 0-1), used to mix the two colors.
+	 *               Weight of given color is {@code 1-weight}.
+	 *               Larger weight uses more of white, smaller weight more of given color.
 	 * @return mixture of colors
 	 * @since 2
 	 */
@@ -171,17 +245,56 @@ public class ColorFunctions
 	}
 
 	/**
+	 * Mix color with white, which makes the color lighter.
+	 * This is the same as {@link #mix}{@code (Color.white, color, weight)}.
+	 * For best results use {@link #OKLAB} or {@link #LRGB}.
+	 *
+	 * @param color color to mix with white
+	 * @param weight the weight of white (in range 0-1), used to mix the two colors.
+	 *               Weight of given color is {@code 1-weight}.
+	 *               Larger weight uses more of white, smaller weight more of given color.
+	 * @param method interpolation method used to mix the colors:
+	 *               {@link #RGB}, {@link #LRGB} or {@link #OKLAB}
+	 * @return mixture of colors
+	 * @since 3.8
+	 */
+	public static Color tint( Color color, float weight, int method ) {
+		return mix( Color.white, color, weight, method );
+	}
+
+	/**
 	 * Mix color with black, which makes the color darker.
 	 * This is the same as {@link #mix}{@code (Color.black, color, weight)}.
+	 * Uses {@link #RGB} interpolation method.
+	 * For better results use {@link #OKLAB} or {@link #LRGB} and {@link #shade(Color, float, int)}.
 	 *
-	 * @param color second color
-	 * @param weight the weight (in range 0-1) to mix the two colors.
-	 *               Larger weight uses more of first color, smaller weight more of second color.
+	 * @param color color to mix with black
+	 * @param weight the weight of black (in range 0-1), used to mix the two colors.
+	 *               Weight of given color is {@code 1-weight}.
+	 *               Larger weight uses more of black, smaller weight more of given color.
 	 * @return mixture of colors
 	 * @since 2
 	 */
 	public static Color shade( Color color, float weight ) {
 		return mix( Color.black, color, weight );
+	}
+
+	/**
+	 * Mix color with black, which makes the color darker.
+	 * This is the same as {@link #mix}{@code (Color.black, color, weight)}.
+	 * For best results use {@link #OKLAB} or {@link #LRGB}.
+	 *
+	 * @param color color to mix with black
+	 * @param weight the weight of black (in range 0-1), used to mix the two colors.
+	 *               Weight of given color is {@code 1-weight}.
+	 *               Larger weight uses more of black, smaller weight more of given color.
+	 * @param method interpolation method used to mix the colors:
+	 *               {@link #RGB}, {@link #LRGB} or {@link #OKLAB}
+	 * @return mixture of colors
+	 * @since 3.8
+	 */
+	public static Color shade( Color color, float weight, int method ) {
+		return mix( Color.black, color, weight, method );
 	}
 
 	/**
@@ -199,7 +312,7 @@ public class ColorFunctions
 	public static float luma( Color color ) {
 		// see https://en.wikipedia.org/wiki/Luma_(video)
 		// see https://www.w3.org/TR/2008/REC-WCAG20-20081211/#relativeluminancedef
-		// see https://github.com/less/less.js/blob/master/packages/less/src/less/tree/color.js
+		// see https://github.com/less/less.js/blob/master/packages/less/lib/less/tree/color.js
 		float r = gammaCorrection( color.getRed() / 255f );
 		float g = gammaCorrection( color.getGreen() / 255f );
 		float b = gammaCorrection( color.getBlue() / 255f );
@@ -227,7 +340,7 @@ public class ColorFunctions
 			return mix( color, mixFunction.color2, mixFunction.weight / 100 );
 		} else if( functions.length == 1 && functions[0] instanceof Mix2 ) {
 			Mix2 mixFunction = (Mix2) functions[0];
-			return mix( mixFunction.color1, color, mixFunction.weight / 100 );
+			return mix( mixFunction.color1, color, mixFunction.weight / 100, mixFunction.method );
 		}
 
 		// convert RGB to HSL
@@ -247,11 +360,14 @@ public class ColorFunctions
 	 * Clamps the given value between 0 and 100.
 	 */
 	public static float clamp( float value ) {
-		return (value < 0)
-			? 0
-			: ((value > 100)
-				? 100
-				: value);
+		return (value < 0) ? 0 : ((value > 100) ? 100 : value);
+	}
+
+	/**
+	 * Clamps the given value between 0 and 1.
+	 */
+	private static float clamp1( float value ) {
+		return (value < 0) ? 0 : ((value > 1) ? 1 : value);
 	}
 
 	//---- interface ColorFunction --------------------------------------------
@@ -443,10 +559,17 @@ public class ColorFunctions
 	{
 		public final Color color1;
 		public final float weight;
+		/** @since 3.8 */ public final int method;
 
 		public Mix2( Color color1, float weight ) {
+			this( color1, weight, RGB );
+		}
+
+		/** @since 3.8 */
+		public Mix2( Color color1, float weight, int method ) {
 			this.color1 = color1;
 			this.weight = weight;
+			this.method = method;
 		}
 
 		@Override
@@ -455,7 +578,7 @@ public class ColorFunctions
 			Color color2 = HSLColor.toRGB( hsla[0], hsla[1], hsla[2], hsla[3] / 100 );
 
 			// mix
-			Color color = mix( color1, color2, weight / 100 );
+			Color color = mix( color1, color2, weight / 100, method );
 
 			// convert RGB to HSL
 			float[] hsl = HSLColor.fromRGB( color );
@@ -467,5 +590,90 @@ public class ColorFunctions
 		public String toString() {
 			return String.format( "mix2(#%08x,%.0f%%)", color1.getRGB(), weight );
 		}
+	}
+
+	//---- linear RGB ---------------------------------------------------------
+
+	static float[] toLinearRGB( Color color ) {
+		float[] rgb = color.getRGBComponents( null );
+		return new float[] {
+			toLinearRGB( rgb[0] ),
+			toLinearRGB( rgb[1] ),
+			toLinearRGB( rgb[2] ),
+			rgb[3],
+		};
+	}
+
+	static Color fromLinearRGB( float[] lrgb ) {
+		return new Color(
+			clamp1( fromLinearRGB( lrgb[0] ) ),
+			clamp1( fromLinearRGB( lrgb[1] ) ),
+			clamp1( fromLinearRGB( lrgb[2] ) ),
+			lrgb[3] );
+	}
+
+	// source https://bottosson.github.io/posts/colorwrong/#what-can-we-do%3F
+
+	private static float fromLinearRGB( float x ) {
+		if( x >= 0.0031308f )
+			return (float) (1.055 * Math.pow( x, 1.0 / 2.4 ) - 0.055f);
+		else
+			return 12.92f * x;
+	}
+
+	private static float toLinearRGB( float x ) {
+		if( x >= 0.04045f )
+			return (float) Math.pow( (x + 0.055) / (1 + 0.055), 2.4 );
+		else
+			return x / 12.92f;
+	}
+
+	//---- Oklab --------------------------------------------------------------
+
+	// source https://bottosson.github.io/posts/oklab/
+
+	@SuppressWarnings( "FloatingPointLiteralPrecision" ) // Error Prone
+	static float[] toOklab( Color color ) {
+		float[] lrgb = toLinearRGB( color );
+		float r = lrgb[0];
+		float g = lrgb[1];
+		float b = lrgb[2];
+
+		float l = 0.4122214708f * r + 0.5363325363f * g + 0.0514459929f * b;
+		float m = 0.2119034982f * r + 0.6806995451f * g + 0.1073969566f * b;
+		float s = 0.0883024619f * r + 0.2817188376f * g + 0.6299787005f * b;
+
+		float l_ = (float) Math.cbrt( l );
+		float m_ = (float) Math.cbrt( m );
+		float s_ = (float) Math.cbrt( s );
+
+		return new float[] {
+			0.2104542553f * l_ + 0.7936177850f * m_ - 0.0040720468f * s_,
+			1.9779984951f * l_ - 2.4285922050f * m_ + 0.4505937099f * s_,
+			0.0259040371f * l_ + 0.7827717662f * m_ - 0.8086757660f * s_,
+			lrgb[3]
+		};
+	}
+
+	@SuppressWarnings( "FloatingPointLiteralPrecision" ) // Error Prone
+	static Color fromOklab( float[] oklab ) {
+		float L = oklab[0];
+		float a = oklab[1];
+		float b = oklab[2];
+
+		float l_ = L + 0.3963377774f * a + 0.2158037573f * b;
+		float m_ = L - 0.1055613458f * a - 0.0638541728f * b;
+		float s_ = L - 0.0894841775f * a - 1.2914855480f * b;
+
+		float l = l_*l_*l_;
+		float m = m_*m_*m_;
+		float s = s_*s_*s_;
+
+		return fromLinearRGB( new float[] {
+			+4.0767416621f * l - 3.3077115913f * m + 0.2309699292f * s,
+			-1.2684380046f * l + 2.6097574011f * m - 0.3413193965f * s,
+			-0.0041960863f * l - 0.7034186147f * m + 1.7076147010f * s,
+			oklab[3]
+		} );
 	}
 }

--- a/flatlaf-core/src/test/java/com/formdev/flatlaf/TestUIDefaultsLoader.java
+++ b/flatlaf-core/src/test/java/com/formdev/flatlaf/TestUIDefaultsLoader.java
@@ -17,6 +17,7 @@
 package com.formdev.flatlaf;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -246,14 +247,32 @@ public class TestUIDefaultsLoader
 		// mix
 		assertEquals( new Color( 0x808000 ), parseColor( "mix(#f00, #0f0)" ) );
 		assertEquals( new Color( 0xbf4000 ), parseColor( "mix(#f00, #0f0, 75%)" ) );
+		assertEquals( new Color( 0x808000 ), parseColor( "mix(#f00, #0f0, rgb)" ) );
+		assertEquals( new Color( 0xbcbc00 ), parseColor( "mix(#f00, #0f0, lrgb)" ) );
+		assertEquals( new Color( 0xd0a800 ), parseColor( "mix(#f00, #0f0, oklab)" ) );
+		assertEquals( new Color( 0xbf4000 ), parseColor( "mix(#f00, #0f0, 75%, rgb)" ) );
+		assertEquals( new Color( 0xe18900 ), parseColor( "mix(#f00, #0f0, 75%, lrgb)" ) );
+		assertEquals( new Color( 0xed7300 ), parseColor( "mix(#f00, #0f0, 75%, oklab)" ) );
 
 		// tint
 		assertEquals( new Color( 0xff80ff ), parseColor( "tint(#f0f)" ) );
 		assertEquals( new Color( 0xffbfff ), parseColor( "tint(#f0f, 75%)" ) );
+		assertEquals( new Color( 0xff80ff ), parseColor( "tint(#f0f, rgb)" ) );
+		assertEquals( new Color( 0xffbcff ), parseColor( "tint(#f0f, lrgb)" ) );
+		assertEquals( new Color( 0xffa6ff ), parseColor( "tint(#f0f, oklab)" ) );
+		assertEquals( new Color( 0xffbfff ), parseColor( "tint(#f0f, 75%, rgb)" ) );
+		assertEquals( new Color( 0xffe1ff ), parseColor( "tint(#f0f, 75%, lrgb)" ) );
+		assertEquals( new Color( 0xffd4ff ), parseColor( "tint(#f0f, 75%, oklab)" ) );
 
 		// shade
 		assertEquals( new Color( 0x800080 ), parseColor( "shade(#f0f)" ) );
 		assertEquals( new Color( 0x400040 ), parseColor( "shade(#f0f, 75%)" ) );
+		assertEquals( new Color( 0x800080 ), parseColor( "shade(#f0f, rgb)" ) );
+		assertEquals( new Color( 0xbc00bc ), parseColor( "shade(#f0f, lrgb)" ) );
+		assertEquals( new Color( 0x630063 ), parseColor( "shade(#f0f, oklab)" ) );
+		assertEquals( new Color( 0x400040 ), parseColor( "shade(#f0f, 75%, rgb)" ) );
+		assertEquals( new Color( 0x890089 ), parseColor( "shade(#f0f, 75%, lrgb)" ) );
+		assertEquals( new Color( 0x220022 ), parseColor( "shade(#f0f, 75%, oklab)" ) );
 
 		// contrast
 		assertEquals( new Color( 0x0000ff ), parseColor( "contrast(#bbb, #00f, #0f0)" ) );
@@ -322,19 +341,6 @@ public class TestUIDefaultsLoader
 
 	@Test
 	void parseDerivedColorFunctions() {
-		// mix
-		assertDerivedColorEquals( new Color( 0x808000 ), "mix(#f00, #0f0, derived)", new Mix2( Color.red, 50 ) );
-		assertDerivedColorEquals( new Color( 0xbf4000 ), "mix(#f00, #0f0, 75%, derived)", new Mix2( Color.red, 75 ) );
-
-		// tint
-		assertDerivedColorEquals( new Color( 0xff80ff ), "tint(#f0f, derived)", new Mix2( Color.white, 50 ) );
-		assertDerivedColorEquals( new Color( 0xffbfff ), "tint(#f0f, 75%, derived)", new Mix2( Color.white, 75 ) );
-
-		// shade
-		assertDerivedColorEquals( new Color( 0x800080 ), "shade(#f0f, derived)", new Mix2( Color.black, 50 ) );
-		assertDerivedColorEquals( new Color( 0x400040 ), "shade(#f0f, 75%, derived)", new Mix2( Color.black, 75 ) );
-
-
 		// lighten
 		assertDerivedColorEquals( new Color( 0xff6666 ), "lighten(#f00, 20%, derived)",                                 new HSLIncreaseDecrease( 2, true,  20, false, true  ) );
 		assertDerivedColorEquals( new Color( 0xff3333 ), "lighten(#f00, 20%, derived relative)",                        new HSLIncreaseDecrease( 2, true,  20, true,  true  ) );
@@ -396,6 +402,18 @@ public class TestUIDefaultsLoader
 		// shade
 		assertDerivedColorEquals( new Color( 0x800080 ), "shade(#f0f, derived)",          new Mix2( new Color( 0x000000 ), 50 ) );
 		assertDerivedColorEquals( new Color( 0x400040 ), "shade(#f0f, 75%, derived)",     new Mix2( new Color( 0x000000 ), 75 ) );
+	}
+
+	@Test
+	void options() {
+		assertTrue( UIDefaultsLoader.hasOption( "derived", "derived" ) );
+		assertTrue( UIDefaultsLoader.hasOption( "derived ", "derived" ) );
+		assertTrue( UIDefaultsLoader.hasOption( " derived", "derived" ) );
+		assertTrue( UIDefaultsLoader.hasOption( "derived lazy", "derived" ) );
+		assertTrue( UIDefaultsLoader.hasOption( "lazy derived", "derived" ) );
+
+		assertFalse( UIDefaultsLoader.hasOption( "no-lazy", "lazy" ) );
+		assertFalse( UIDefaultsLoader.hasOption( "lazy-no", "lazy" ) );
 	}
 
 	private void assertDerivedColorEquals( Color expectedColor, String actualStyle, ColorFunction... expectedFunctions ) {

--- a/flatlaf-core/src/test/java/com/formdev/flatlaf/util/TestColorFunctions.java
+++ b/flatlaf-core/src/test/java/com/formdev/flatlaf/util/TestColorFunctions.java
@@ -16,6 +16,7 @@
 
 package com.formdev.flatlaf.util;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.awt.Color;
 import org.junit.jupiter.api.Test;
@@ -25,6 +26,8 @@ import org.junit.jupiter.api.Test;
  */
 public class TestColorFunctions
 {
+	private static final float DELTA = 0.0001f;
+
 	@Test
 	void colorFunctions() {
 		// lighten, darken
@@ -63,6 +66,33 @@ public class TestColorFunctions
 	}
 
 	@Test
+	void colorFunctionsWithColorSpaces() {
+		// mix
+		assertEquals( new Color( 0x808000 ), ColorFunctions.mix( Color.red, Color.green, 0.5f, ColorFunctions.RGB ) );
+		assertEquals( new Color( 0xbcbc00 ), ColorFunctions.mix( Color.red, Color.green, 0.5f, ColorFunctions.LRGB ) );
+		assertEquals( new Color( 0xd0a800 ), ColorFunctions.mix( Color.red, Color.green, 0.5f, ColorFunctions.OKLAB ) );
+		assertEquals( new Color( 0xbf4000 ), ColorFunctions.mix( Color.red, Color.green, 0.75f, ColorFunctions.RGB ) );
+		assertEquals( new Color( 0xe18900 ), ColorFunctions.mix( Color.red, Color.green, 0.75f, ColorFunctions.LRGB ) );
+		assertEquals( new Color( 0xed7300 ), ColorFunctions.mix( Color.red, Color.green, 0.75f, ColorFunctions.OKLAB ) );
+
+		// tint
+		assertEquals( new Color( 0xff80ff ), ColorFunctions.tint( Color.magenta, 0.5f, ColorFunctions.RGB ) );
+		assertEquals( new Color( 0xffbcff ), ColorFunctions.tint( Color.magenta, 0.5f, ColorFunctions.LRGB ) );
+		assertEquals( new Color( 0xffa6ff ), ColorFunctions.tint( Color.magenta, 0.5f, ColorFunctions.OKLAB ) );
+		assertEquals( new Color( 0xffbfff ), ColorFunctions.tint( Color.magenta, 0.75f, ColorFunctions.RGB ) );
+		assertEquals( new Color( 0xffe1ff ), ColorFunctions.tint( Color.magenta, 0.75f, ColorFunctions.LRGB ) );
+		assertEquals( new Color( 0xffd4ff ), ColorFunctions.tint( Color.magenta, 0.75f, ColorFunctions.OKLAB ) );
+
+		// shade
+		assertEquals( new Color( 0x800080 ), ColorFunctions.shade( Color.magenta, 0.5f, ColorFunctions.RGB ) );
+		assertEquals( new Color( 0xbc00bc ), ColorFunctions.shade( Color.magenta, 0.5f, ColorFunctions.LRGB ) );
+		assertEquals( new Color( 0x630063 ), ColorFunctions.shade( Color.magenta, 0.5f, ColorFunctions.OKLAB ) );
+		assertEquals( new Color( 0x400040 ), ColorFunctions.shade( Color.magenta, 0.75f, ColorFunctions.RGB ) );
+		assertEquals( new Color( 0x890089 ), ColorFunctions.shade( Color.magenta, 0.75f, ColorFunctions.LRGB ) );
+		assertEquals( new Color( 0x220022 ), ColorFunctions.shade( Color.magenta, 0.75f, ColorFunctions.OKLAB ) );
+	}
+
+	@Test
 	void luma() {
 		assertEquals( 0, ColorFunctions.luma( Color.black ) );
 		assertEquals( 1, ColorFunctions.luma( Color.white ) );
@@ -77,5 +107,62 @@ public class TestColorFunctions
 		assertEquals( 0.051269464f, ColorFunctions.luma( Color.darkGray ) );
 		assertEquals( 0.21586052f, ColorFunctions.luma( Color.gray ) );
 		assertEquals( 0.52711517f, ColorFunctions.luma( Color.lightGray ) );
+	}
+
+	@Test
+	void linearRGB() {
+		// common 8-bit values
+		assertArrayEquals( new float[] { 0, 0.000304f, 0.002428f, 1 }, ColorFunctions.toLinearRGB( new Color( 0, 1, 8 ) ), DELTA );
+		assertArrayEquals( new float[] { 0.003035f, 0.003347f, 0.051269f, 1 }, ColorFunctions.toLinearRGB( new Color( 10, 11, 64 ) ), DELTA );
+		assertArrayEquals( new float[] { 0.215861f, 0.527115f, 1, 1 }, ColorFunctions.toLinearRGB( new Color( 128, 192, 255 ) ), DELTA );
+
+		// alpha must not change
+		assertArrayEquals( new float[] { 0, 0, 0, 0.5f }, ColorFunctions.toLinearRGB( new Color( 0, 0, 0, 0.5f ) ) );
+		assertEquals( new Color( 0, 0, 0, 0.5f ), ColorFunctions.fromLinearRGB( ColorFunctions.toLinearRGB( new Color( 0, 0, 0, 0.5f ) ) ) );
+
+		// all 256 8-bit values
+		for( int i = 0; i < 255; i += 3 ) {
+			Color c = new Color( i, i + 1, i + 2 );
+			assertEquals( c, ColorFunctions.fromLinearRGB( ColorFunctions.toLinearRGB( c ) ) );
+			assertEquals(
+				ColorFunctions.mix( c, Color.green, 0.3f, ColorFunctions.LRGB ),
+				ColorFunctions.mix( Color.green, c, 1 - 0.3f, ColorFunctions.LRGB ) );
+		}
+	}
+
+	@Test
+	void oklab() {
+		// known reference values
+		assertArrayEquals( new float[] { 0, 0, 0, 1 }, ColorFunctions.toOklab( Color.black ) );
+		assertArrayEquals( new float[] { 1, 0, 0, 1 }, ColorFunctions.toOklab( Color.white ), DELTA );
+		assertArrayEquals( new float[] { 0.6280f, 0.2249f, 0.1258f, 1 }, ColorFunctions.toOklab( Color.red ), DELTA );
+		assertArrayEquals( new float[] { 0.8664f, -0.2339f, 0.1795f, 1 }, ColorFunctions.toOklab( Color.green ), DELTA );
+		assertArrayEquals( new float[] { 0.4520f, -0.0324f, -0.3116f, 1 }, ColorFunctions.toOklab( Color.blue ), DELTA );
+
+		// gray
+		assertArrayEquals( new float[] { 0.8077962f, 0, 0, 1 }, ColorFunctions.toOklab( Color.lightGray ), DELTA );
+		assertArrayEquals( new float[] { 0.5998708f, 0, 0, 1 }, ColorFunctions.toOklab( Color.gray ), DELTA );
+
+		// round trip
+		oklabRoundTrip( Color.white );
+		oklabRoundTrip( Color.lightGray );
+		oklabRoundTrip( Color.gray );
+		oklabRoundTrip( Color.darkGray );
+		oklabRoundTrip( Color.black );
+		oklabRoundTrip( Color.red );
+		oklabRoundTrip( Color.pink );
+		oklabRoundTrip( Color.orange );
+		oklabRoundTrip( Color.yellow );
+		oklabRoundTrip( Color.green );
+		oklabRoundTrip( Color.magenta );
+		oklabRoundTrip( Color.cyan );
+		oklabRoundTrip( Color.blue );
+	}
+
+	private void oklabRoundTrip( Color c ) {
+		assertEquals( c.getRGB(), ColorFunctions.fromOklab( ColorFunctions.toOklab( c ) ).getRGB() );
+		assertEquals(
+			ColorFunctions.mix( c, Color.green, 0.3f, ColorFunctions.OKLAB ),
+			ColorFunctions.mix( Color.green, c, 1 - 0.3f, ColorFunctions.OKLAB ) );
 	}
 }

--- a/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatColorFunctionsTest.java
+++ b/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatColorFunctionsTest.java
@@ -1,0 +1,343 @@
+/*
+ * Copyright 2026 FormDev Software GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.formdev.flatlaf.testing;
+
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.awt.Graphics;
+import java.awt.image.BufferedImage;
+import java.util.Objects;
+import javax.swing.*;
+import com.formdev.flatlaf.util.ColorFunctions;
+import com.formdev.flatlaf.util.UIScale;
+import net.miginfocom.swing.*;
+
+/**
+ * @author Karl Tauber
+ */
+public class FlatColorFunctionsTest
+	extends FlatTestPanel
+{
+	public static void main( String[] args ) {
+		SwingUtilities.invokeLater( () -> {
+			FlatTestFrame frame = FlatTestFrame.create( args, "FlatColorFunctionsTest" );
+			frame.showFrame( FlatColorFunctionsTest::new );
+		} );
+	}
+
+	FlatColorFunctionsTest() {
+		initComponents();
+
+		mixRGBPreview.setColorMethod( (color1, color2, weight) ->
+			ColorFunctions.mix( color1, color2, 1f - weight, ColorFunctions.RGB ) );
+		mixLinearRGBPreview.setColorMethod( (color1, color2, weight) ->
+			ColorFunctions.mix( color1, color2, 1f - weight, ColorFunctions.LRGB ) );
+		mixOklabPreview.setColorMethod( (color1, color2, weight) ->
+			ColorFunctions.mix( color1, color2, 1f - weight, ColorFunctions.OKLAB ) );
+
+		tintRGBPreview.setColorMethod( (color1, color2, weight) ->
+			ColorFunctions.tint( color1, weight, ColorFunctions.RGB ) );
+		tintLinearRGBPreview.setColorMethod( (color1, color2, weight) ->
+			ColorFunctions.tint( color1, weight, ColorFunctions.LRGB ) );
+		tintOklabPreview.setColorMethod( (color1, color2, weight) ->
+			ColorFunctions.tint( color1, weight, ColorFunctions.OKLAB ) );
+
+		shadeRGBPreview.setColorMethod( (color1, color2, weight) ->
+			ColorFunctions.shade( color1, weight, ColorFunctions.RGB ) );
+		shadeLinearRGBPreview.setColorMethod( (color1, color2, weight) ->
+			ColorFunctions.shade( color1, weight, ColorFunctions.LRGB ) );
+		shadeOklabPreview.setColorMethod( (color1, color2, weight) ->
+			ColorFunctions.shade( color1, weight, ColorFunctions.OKLAB ) );
+
+		lightenPreview.setColorMethod( (color1, color2, weight) ->
+			ColorFunctions.lighten( color1, weight ) );
+		darkenPreview.setColorMethod( (color1, color2, weight) ->
+			ColorFunctions.darken( color1, weight ) );
+
+		saturatePreview.setColorMethod( (color1, color2, weight) ->
+			ColorFunctions.saturate( color1, weight ) );
+		desaturatePreview.setColorMethod( (color1, color2, weight) ->
+			ColorFunctions.desaturate( color1, weight ) );
+
+		spinPreview.setColorMethod( (color1, color2, weight) ->
+			ColorFunctions.spin( color1, weight * 360 ) );
+
+		color1Chooser.getSelectionModel().addChangeListener( e -> {
+			Color color1 = color1Chooser.getColor();
+			for( Component c : getComponents() ) {
+				if( c instanceof GradientPreview )
+					((GradientPreview)c).setColor1( color1 );
+			}
+		} );
+		color2Chooser.getSelectionModel().addChangeListener( e -> {
+			Color color2 = color2Chooser.getColor();
+			for( Component c : getComponents() ) {
+				if( c instanceof GradientPreview )
+					((GradientPreview)c).setColor2( color2 );
+			}
+		} );
+	}
+
+	private void initComponents() {
+		// JFormDesigner - Component initialization - DO NOT MODIFY  //GEN-BEGIN:initComponents
+		JLabel mixLabel = new JLabel();
+		JLabel label4 = new JLabel();
+		mixRGBPreview = new FlatColorFunctionsTest.GradientPreview();
+		JPanel panel1 = new JPanel();
+		color1Chooser = new JColorChooser();
+		color2Chooser = new JColorChooser();
+		JLabel label5 = new JLabel();
+		mixLinearRGBPreview = new FlatColorFunctionsTest.GradientPreview();
+		JLabel label6 = new JLabel();
+		mixOklabPreview = new FlatColorFunctionsTest.GradientPreview();
+		JLabel tintLabel = new JLabel();
+		JLabel label1 = new JLabel();
+		tintRGBPreview = new FlatColorFunctionsTest.GradientPreview();
+		JLabel label2 = new JLabel();
+		tintLinearRGBPreview = new FlatColorFunctionsTest.GradientPreview();
+		JLabel label3 = new JLabel();
+		tintOklabPreview = new FlatColorFunctionsTest.GradientPreview();
+		JLabel shadeLabel = new JLabel();
+		JLabel label7 = new JLabel();
+		shadeRGBPreview = new FlatColorFunctionsTest.GradientPreview();
+		JLabel label8 = new JLabel();
+		shadeLinearRGBPreview = new FlatColorFunctionsTest.GradientPreview();
+		JLabel label9 = new JLabel();
+		shadeOklabPreview = new FlatColorFunctionsTest.GradientPreview();
+		JLabel lightenLabel = new JLabel();
+		lightenPreview = new FlatColorFunctionsTest.GradientPreview();
+		JLabel darkenLabel = new JLabel();
+		darkenPreview = new FlatColorFunctionsTest.GradientPreview();
+		JLabel saturateLabel = new JLabel();
+		saturatePreview = new FlatColorFunctionsTest.GradientPreview();
+		JLabel desaturateLabel = new JLabel();
+		desaturatePreview = new FlatColorFunctionsTest.GradientPreview();
+		JLabel spinLabel = new JLabel();
+		spinPreview = new FlatColorFunctionsTest.GradientPreview();
+
+		//======== this ========
+		setLayout(new MigLayout(
+			"insets dialog,hidemode 3",
+			// columns
+			"[76,fill]" +
+			"[fill]" +
+			"[fill]",
+			// rows
+			"[]" +
+			"[]" +
+			"[]para" +
+			"[]" +
+			"[]" +
+			"[]para" +
+			"[]" +
+			"[]" +
+			"[]para" +
+			"[]" +
+			"[]para" +
+			"[]" +
+			"[]para" +
+			"[]"));
+
+		//---- mixLabel ----
+		mixLabel.setText("mix");
+		add(mixLabel, "cell 0 0");
+
+		//---- label4 ----
+		label4.setText("RGB");
+		add(label4, "cell 0 0,alignx right,growx 0");
+		add(mixRGBPreview, "cell 1 0");
+
+		//======== panel1 ========
+		{
+			panel1.setLayout(new MigLayout(
+				"hidemode 3",
+				// columns
+				"[fill]",
+				// rows
+				"[]" +
+				"[]"));
+			panel1.add(color1Chooser, "cell 0 0");
+			panel1.add(color2Chooser, "cell 0 1");
+		}
+		add(panel1, "cell 2 0 1 14");
+
+		//---- label5 ----
+		label5.setText("linear RGB");
+		add(label5, "cell 0 1,alignx right,growx 0");
+		add(mixLinearRGBPreview, "cell 1 1");
+
+		//---- label6 ----
+		label6.setText("Oklab");
+		add(label6, "cell 0 2,alignx right,growx 0");
+		add(mixOklabPreview, "cell 1 2");
+
+		//---- tintLabel ----
+		tintLabel.setText("tint");
+		add(tintLabel, "cell 0 3");
+
+		//---- label1 ----
+		label1.setText("RGB");
+		add(label1, "cell 0 3,alignx right,growx 0");
+		add(tintRGBPreview, "cell 1 3");
+
+		//---- label2 ----
+		label2.setText("linear RGB");
+		add(label2, "cell 0 4,alignx right,growx 0");
+		add(tintLinearRGBPreview, "cell 1 4");
+
+		//---- label3 ----
+		label3.setText("Oklab");
+		add(label3, "cell 0 5,alignx right,growx 0");
+		add(tintOklabPreview, "cell 1 5");
+
+		//---- shadeLabel ----
+		shadeLabel.setText("shade");
+		add(shadeLabel, "cell 0 6");
+
+		//---- label7 ----
+		label7.setText("RGB");
+		add(label7, "cell 0 6,alignx right,growx 0");
+		add(shadeRGBPreview, "cell 1 6");
+
+		//---- label8 ----
+		label8.setText("linear RGB");
+		add(label8, "cell 0 7,alignx right,growx 0");
+		add(shadeLinearRGBPreview, "cell 1 7");
+
+		//---- label9 ----
+		label9.setText("Oklab");
+		add(label9, "cell 0 8,alignx right,growx 0");
+		add(shadeOklabPreview, "cell 1 8");
+
+		//---- lightenLabel ----
+		lightenLabel.setText("lighten");
+		add(lightenLabel, "cell 0 9");
+		add(lightenPreview, "cell 1 9");
+
+		//---- darkenLabel ----
+		darkenLabel.setText("darken");
+		add(darkenLabel, "cell 0 10");
+		add(darkenPreview, "cell 1 10");
+
+		//---- saturateLabel ----
+		saturateLabel.setText("saturate");
+		add(saturateLabel, "cell 0 11");
+		add(saturatePreview, "cell 1 11");
+
+		//---- desaturateLabel ----
+		desaturateLabel.setText("desaturate");
+		add(desaturateLabel, "cell 0 12");
+		add(desaturatePreview, "cell 1 12");
+
+		//---- spinLabel ----
+		spinLabel.setText("spin");
+		add(spinLabel, "cell 0 13");
+		add(spinPreview, "cell 1 13");
+		// JFormDesigner - End of component initialization  //GEN-END:initComponents
+	}
+
+	// JFormDesigner - Variables declaration - DO NOT MODIFY  //GEN-BEGIN:variables
+	private FlatColorFunctionsTest.GradientPreview mixRGBPreview;
+	private JColorChooser color1Chooser;
+	private JColorChooser color2Chooser;
+	private FlatColorFunctionsTest.GradientPreview mixLinearRGBPreview;
+	private FlatColorFunctionsTest.GradientPreview mixOklabPreview;
+	private FlatColorFunctionsTest.GradientPreview tintRGBPreview;
+	private FlatColorFunctionsTest.GradientPreview tintLinearRGBPreview;
+	private FlatColorFunctionsTest.GradientPreview tintOklabPreview;
+	private FlatColorFunctionsTest.GradientPreview shadeRGBPreview;
+	private FlatColorFunctionsTest.GradientPreview shadeLinearRGBPreview;
+	private FlatColorFunctionsTest.GradientPreview shadeOklabPreview;
+	private FlatColorFunctionsTest.GradientPreview lightenPreview;
+	private FlatColorFunctionsTest.GradientPreview darkenPreview;
+	private FlatColorFunctionsTest.GradientPreview saturatePreview;
+	private FlatColorFunctionsTest.GradientPreview desaturatePreview;
+	private FlatColorFunctionsTest.GradientPreview spinPreview;
+	// JFormDesigner - End of variables declaration  //GEN-END:variables
+
+	//---- class GradientPreview ----------------------------------------------
+
+	private static class GradientPreview
+		extends JComponent
+	{
+		private Color color1 = Color.red;
+		private Color color2 = Color.green;
+		private ColorMethod colorMethod;
+
+		private BufferedImage image;
+
+		@Override
+		public Dimension getPreferredSize() {
+			return isPreferredSizeSet()
+				? super.getPreferredSize()
+				: UIScale.scale( new Dimension( 400, 40 ) );
+		}
+
+		void setColor1( Color color1 ) {
+			if( Objects.equals( this.color1, color1 ) )
+				return;
+
+			this.color1 = color1;
+			image = null;
+			repaint();
+		}
+
+		void setColor2( Color color2 ) {
+			if( Objects.equals( this.color2, color2 ) )
+				return;
+
+			this.color2 = color2;
+			image = null;
+			repaint();
+		}
+
+		void setColorMethod( ColorMethod colorMethod ) {
+			if( this.colorMethod == colorMethod )
+				return;
+
+			this.colorMethod = colorMethod;
+			image = null;
+			repaint();
+		}
+
+		@Override
+		protected void paintComponent( Graphics g ) {
+			int width = getWidth();
+
+			if( image == null || image.getWidth() != width ) {
+				image = new BufferedImage( width, 1, BufferedImage.TYPE_INT_RGB );
+
+				for( int i = 0; i < width; i++ ) {
+					float weight = (float) i / width;
+					Color result = (colorMethod != null)
+						? colorMethod.apply( color1, color2, weight )
+						: ColorFunctions.mix( color1, color2, 1f - weight );
+					image.setRGB( i, 0, result.getRGB() );
+				}
+			}
+
+			g.drawImage( image, 0, 0, width, getHeight(), null );
+		}
+	}
+
+	//---- interface ColorMethod ----------------------------------------------
+
+	private interface ColorMethod {
+		Color apply( Color color1, Color color2, float weight );
+	}
+}

--- a/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatColorFunctionsTest.jfd
+++ b/flatlaf-testing/src/main/java/com/formdev/flatlaf/testing/FlatColorFunctionsTest.jfd
@@ -1,0 +1,262 @@
+JFDML JFormDesigner: "8.3" encoding: "UTF-8"
+
+new FormModel {
+	contentType: "form/swing"
+	root: new FormRoot {
+		add( new FormContainer( "com.formdev.flatlaf.testing.FlatTestPanel", new FormLayoutManager( class net.miginfocom.swing.MigLayout ) {
+			"$layoutConstraints": "insets dialog,hidemode 3"
+			"$columnConstraints": "[76,fill][fill][fill]"
+			"$rowConstraints": "[][][]para[][][]para[][][]para[][]para[][]para[]"
+		} ) {
+			name: "this"
+			add( new FormComponent( "javax.swing.JLabel" ) {
+				name: "mixLabel"
+				"text": "mix"
+				auxiliary() {
+					"JavaCodeGenerator.variableLocal": true
+				}
+			}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+				"value": "cell 0 0"
+			} )
+			add( new FormComponent( "javax.swing.JLabel" ) {
+				name: "label4"
+				"text": "RGB"
+				auxiliary() {
+					"JavaCodeGenerator.variableLocal": true
+				}
+			}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+				"value": "cell 0 0,alignx right,growx 0"
+			} )
+			add( new FormComponent( "com.formdev.flatlaf.testing.FlatColorFunctionsTest$GradientPreview" ) {
+				name: "mixRGBPreview"
+			}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+				"value": "cell 1 0"
+			} )
+			add( new FormContainer( "javax.swing.JPanel", new FormLayoutManager( class net.miginfocom.swing.MigLayout ) {
+				"$layoutConstraints": "hidemode 3"
+				"$columnConstraints": "[fill]"
+				"$rowConstraints": "[][]"
+			} ) {
+				name: "panel1"
+				auxiliary() {
+					"JavaCodeGenerator.variableLocal": true
+				}
+				add( new FormComponent( "javax.swing.JColorChooser" ) {
+					name: "color1Chooser"
+				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+					"value": "cell 0 0"
+				} )
+				add( new FormComponent( "javax.swing.JColorChooser" ) {
+					name: "color2Chooser"
+				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+					"value": "cell 0 1"
+				} )
+			}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+				"value": "cell 2 0 1 14"
+			} )
+			add( new FormComponent( "javax.swing.JLabel" ) {
+				name: "label5"
+				"text": "linear RGB"
+				auxiliary() {
+					"JavaCodeGenerator.variableLocal": true
+				}
+			}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+				"value": "cell 0 1,alignx right,growx 0"
+			} )
+			add( new FormComponent( "com.formdev.flatlaf.testing.FlatColorFunctionsTest$GradientPreview" ) {
+				name: "mixLinearRGBPreview"
+			}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+				"value": "cell 1 1"
+			} )
+			add( new FormComponent( "javax.swing.JLabel" ) {
+				name: "label6"
+				"text": "Oklab"
+				auxiliary() {
+					"JavaCodeGenerator.variableLocal": true
+				}
+			}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+				"value": "cell 0 2,alignx right,growx 0"
+			} )
+			add( new FormComponent( "com.formdev.flatlaf.testing.FlatColorFunctionsTest$GradientPreview" ) {
+				name: "mixOklabPreview"
+			}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+				"value": "cell 1 2"
+			} )
+			add( new FormComponent( "javax.swing.JLabel" ) {
+				name: "tintLabel"
+				"text": "tint"
+				auxiliary() {
+					"JavaCodeGenerator.variableLocal": true
+				}
+			}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+				"value": "cell 0 3"
+			} )
+			add( new FormComponent( "javax.swing.JLabel" ) {
+				name: "label1"
+				"text": "RGB"
+				auxiliary() {
+					"JavaCodeGenerator.variableLocal": true
+				}
+			}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+				"value": "cell 0 3,alignx right,growx 0"
+			} )
+			add( new FormComponent( "com.formdev.flatlaf.testing.FlatColorFunctionsTest$GradientPreview" ) {
+				name: "tintRGBPreview"
+			}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+				"value": "cell 1 3"
+			} )
+			add( new FormComponent( "javax.swing.JLabel" ) {
+				name: "label2"
+				"text": "linear RGB"
+				auxiliary() {
+					"JavaCodeGenerator.variableLocal": true
+				}
+			}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+				"value": "cell 0 4,alignx right,growx 0"
+			} )
+			add( new FormComponent( "com.formdev.flatlaf.testing.FlatColorFunctionsTest$GradientPreview" ) {
+				name: "tintLinearRGBPreview"
+			}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+				"value": "cell 1 4"
+			} )
+			add( new FormComponent( "javax.swing.JLabel" ) {
+				name: "label3"
+				"text": "Oklab"
+				auxiliary() {
+					"JavaCodeGenerator.variableLocal": true
+				}
+			}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+				"value": "cell 0 5,alignx right,growx 0"
+			} )
+			add( new FormComponent( "com.formdev.flatlaf.testing.FlatColorFunctionsTest$GradientPreview" ) {
+				name: "tintOklabPreview"
+			}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+				"value": "cell 1 5"
+			} )
+			add( new FormComponent( "javax.swing.JLabel" ) {
+				name: "shadeLabel"
+				"text": "shade"
+				auxiliary() {
+					"JavaCodeGenerator.variableLocal": true
+				}
+			}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+				"value": "cell 0 6"
+			} )
+			add( new FormComponent( "javax.swing.JLabel" ) {
+				name: "label7"
+				"text": "RGB"
+				auxiliary() {
+					"JavaCodeGenerator.variableLocal": true
+				}
+			}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+				"value": "cell 0 6,alignx right,growx 0"
+			} )
+			add( new FormComponent( "com.formdev.flatlaf.testing.FlatColorFunctionsTest$GradientPreview" ) {
+				name: "shadeRGBPreview"
+			}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+				"value": "cell 1 6"
+			} )
+			add( new FormComponent( "javax.swing.JLabel" ) {
+				name: "label8"
+				"text": "linear RGB"
+				auxiliary() {
+					"JavaCodeGenerator.variableLocal": true
+				}
+			}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+				"value": "cell 0 7,alignx right,growx 0"
+			} )
+			add( new FormComponent( "com.formdev.flatlaf.testing.FlatColorFunctionsTest$GradientPreview" ) {
+				name: "shadeLinearRGBPreview"
+			}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+				"value": "cell 1 7"
+			} )
+			add( new FormComponent( "javax.swing.JLabel" ) {
+				name: "label9"
+				"text": "Oklab"
+				auxiliary() {
+					"JavaCodeGenerator.variableLocal": true
+				}
+			}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+				"value": "cell 0 8,alignx right,growx 0"
+			} )
+			add( new FormComponent( "com.formdev.flatlaf.testing.FlatColorFunctionsTest$GradientPreview" ) {
+				name: "shadeOklabPreview"
+			}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+				"value": "cell 1 8"
+			} )
+			add( new FormComponent( "javax.swing.JLabel" ) {
+				name: "lightenLabel"
+				"text": "lighten"
+				auxiliary() {
+					"JavaCodeGenerator.variableLocal": true
+				}
+			}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+				"value": "cell 0 9"
+			} )
+			add( new FormComponent( "com.formdev.flatlaf.testing.FlatColorFunctionsTest$GradientPreview" ) {
+				name: "lightenPreview"
+			}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+				"value": "cell 1 9"
+			} )
+			add( new FormComponent( "javax.swing.JLabel" ) {
+				name: "darkenLabel"
+				"text": "darken"
+				auxiliary() {
+					"JavaCodeGenerator.variableLocal": true
+				}
+			}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+				"value": "cell 0 10"
+			} )
+			add( new FormComponent( "com.formdev.flatlaf.testing.FlatColorFunctionsTest$GradientPreview" ) {
+				name: "darkenPreview"
+			}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+				"value": "cell 1 10"
+			} )
+			add( new FormComponent( "javax.swing.JLabel" ) {
+				name: "saturateLabel"
+				"text": "saturate"
+				auxiliary() {
+					"JavaCodeGenerator.variableLocal": true
+				}
+			}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+				"value": "cell 0 11"
+			} )
+			add( new FormComponent( "com.formdev.flatlaf.testing.FlatColorFunctionsTest$GradientPreview" ) {
+				name: "saturatePreview"
+			}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+				"value": "cell 1 11"
+			} )
+			add( new FormComponent( "javax.swing.JLabel" ) {
+				name: "desaturateLabel"
+				"text": "desaturate"
+				auxiliary() {
+					"JavaCodeGenerator.variableLocal": true
+				}
+			}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+				"value": "cell 0 12"
+			} )
+			add( new FormComponent( "com.formdev.flatlaf.testing.FlatColorFunctionsTest$GradientPreview" ) {
+				name: "desaturatePreview"
+			}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+				"value": "cell 1 12"
+			} )
+			add( new FormComponent( "javax.swing.JLabel" ) {
+				name: "spinLabel"
+				"text": "spin"
+				auxiliary() {
+					"JavaCodeGenerator.variableLocal": true
+				}
+			}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+				"value": "cell 0 13"
+			} )
+			add( new FormComponent( "com.formdev.flatlaf.testing.FlatColorFunctionsTest$GradientPreview" ) {
+				name: "spinPreview"
+			}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+				"value": "cell 1 13"
+			} )
+		}, new FormLayoutConstraints( null ) {
+			"location": new java.awt.Point( 0, 0 )
+			"size": new java.awt.Dimension( 1190, 790 )
+		} )
+	}
+}

--- a/flatlaf-theme-editor/src/main/java/com/formdev/flatlaf/UIDefaultsLoaderAccessor.java
+++ b/flatlaf-theme-editor/src/main/java/com/formdev/flatlaf/UIDefaultsLoaderAccessor.java
@@ -17,6 +17,7 @@
 package com.formdev.flatlaf;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
@@ -77,5 +78,29 @@ public class UIDefaultsLoaderAccessor
 
 	public static Properties newUIProperties( boolean dark ) {
 		return UIDefaultsLoader.newUIProperties( dark );
+	}
+
+	public static int parsePercentage( String value )
+		throws IllegalArgumentException, NumberFormatException
+	{
+		return UIDefaultsLoader.parsePercentage( value );
+	}
+
+	public static Integer parseInteger( String value )
+		throws NumberFormatException
+	{
+		return UIDefaultsLoader.parseInteger( value );
+	}
+
+	public static List<String> splitFunctionParams( String str, char delim ) {
+		return UIDefaultsLoader.splitFunctionParams( str, delim );
+	}
+
+	public static boolean hasOption( String options, String option ) {
+		return UIDefaultsLoader.hasOption( options, option );
+	}
+
+	public static Object lazyUIManagerGet( String uiKey ) {
+		return UIDefaultsLoader.lazyUIManagerGet( uiKey );
 	}
 }

--- a/flatlaf-theme-editor/src/main/java/com/formdev/flatlaf/themeeditor/FlatColorFunctionPreview.java
+++ b/flatlaf-theme-editor/src/main/java/com/formdev/flatlaf/themeeditor/FlatColorFunctionPreview.java
@@ -1,0 +1,743 @@
+/*
+ * Copyright 2026 FormDev Software GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.formdev.flatlaf.themeeditor;
+
+import java.awt.BasicStroke;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.EventQueue;
+import java.awt.FontMetrics;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.Shape;
+import java.awt.image.BufferedImage;
+import java.util.List;
+import java.util.function.DoubleFunction;
+import javax.swing.JComponent;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.SwingConstants;
+import javax.swing.UIManager;
+import javax.swing.text.BadLocationException;
+import com.formdev.flatlaf.FlatClientProperties;
+import com.formdev.flatlaf.FlatLaf;
+import com.formdev.flatlaf.UIDefaultsLoaderAccessor;
+import com.formdev.flatlaf.ui.FlatUIUtils;
+import com.formdev.flatlaf.util.ColorFunctions;
+import com.formdev.flatlaf.util.HSLColor;
+import com.formdev.flatlaf.util.StringUtils;
+import com.formdev.flatlaf.util.UIScale;
+import net.miginfocom.swing.MigLayout;
+
+/**
+ * @author Karl Tauber
+ */
+class FlatColorFunctionPreview
+	extends JPanel
+{
+	private final FlatSyntaxTextArea textArea;
+
+	FlatColorFunctionPreview( FlatSyntaxTextArea textArea ) {
+		this.textArea = textArea;
+
+		initComponents();
+
+		textArea.addCaretListener( e -> updateLater() );
+		updateLater();
+	}
+
+	@Override
+	public void addNotify() {
+		super.addNotify();
+		updateLater();
+	}
+
+	private void updateLater() {
+		EventQueue.invokeLater( this::update );
+	}
+
+	private void update() {
+		if( !isDisplayable() )
+			return;
+
+		boolean visible = false;
+		try {
+			int caretPosition = textArea.getCaretPosition();
+			int line = textArea.getLineOfOffset( caretPosition );
+			int startOffset = textArea.getLineStartOffset( line );
+			int endOffset = textArea.getLineEndOffset( line );
+			String text = textArea.getText( startOffset, endOffset - startOffset );
+			if( StringUtils.isTrimmedEmpty( text ) )
+				return;
+
+			// find function parameters start
+			int caretIndex = Math.min( caretPosition - startOffset, text.length() - 1 );
+			int paramsStart = findFunctionParamsStart( text, caretIndex );
+			if( paramsStart < 0 )
+				return;
+
+			// find function parameters end
+			int paramsEnd = findFunctionParamsEnd( text, paramsStart );
+			if( paramsEnd < 0 )
+				return;
+
+			// find function name start
+			int funNameStart = findFunctionNameStart( text, paramsStart );
+			if( funNameStart < 0 )
+				return;
+
+			try {
+				parseColorFunctions( text, funNameStart, paramsStart, paramsEnd );
+				visible = true;
+			} catch( IllegalArgumentException ex ) {
+				// ignore
+			}
+
+		} catch( BadLocationException ex ) {
+			ex.printStackTrace();
+		} finally {
+			setVisible( visible );
+		}
+	}
+
+	private int findFunctionNameStart( String text, int paramsStart ) {
+		int funNameEnd = paramsStart;
+		while( funNameEnd > 0 && Character.isWhitespace( text.charAt( funNameEnd - 1 ) ) )
+			funNameEnd--;
+		int funNameStart = funNameEnd;
+		while( funNameStart > 0 && Character.isLetter( text.charAt( funNameStart - 1 ) ) )
+			funNameStart--;
+		return (funNameStart < funNameEnd) ? funNameStart : -1;
+	}
+
+	private int findFunctionParamsStart( String text, int caretIndex ) {
+		char charAtCaret = text.charAt( caretIndex );
+		int textLength = text.length();
+
+		// if caret is at '(', use it
+		if( charAtCaret == '(' )
+			return caretIndex;
+
+		// if caret is at a letter, check whether it is a function name followed by '('
+		if( Character.isLetter( charAtCaret ) ) {
+			int index = skipLetter( text, caretIndex );
+			index = skipWhitespace( text, index );
+			if( index < textLength && text.charAt( index ) == '(' )
+				return index;
+		}
+
+		// if caret is at a whitespace, check whether it is followed by '('
+		if( Character.isWhitespace( charAtCaret ) ) {
+			int index = skipWhitespace( text, caretIndex );
+			if( index < textLength && text.charAt( index ) == '(' )
+				return index;
+		}
+
+		// find '(' left to caret, ignore nested '(' and ')'
+		int nestLevel = 0;
+		for( int i = caretIndex - 1; i >= 0; i-- ) {
+			char ch = text.charAt( i );
+			if( ch == ')' )
+				nestLevel++;
+			else if( ch == '(' ) {
+				if( nestLevel == 0 )
+					return i;
+				nestLevel--;
+			}
+		}
+
+		// find first '('
+		return text.indexOf( '(' );
+	}
+
+	private int findFunctionParamsEnd( String text, int paramsStart ) {
+		// find ')' right to opening '(', ignore nested '(' and ')'
+		int textLength = text.length();
+		int nestLevel = 0;
+		for( int i = paramsStart + 1; i < textLength; i++ ) {
+			char ch = text.charAt( i );
+			if( ch == '(' )
+				nestLevel++;
+			else if( ch == ')' ) {
+				if( nestLevel == 0 )
+					return i;
+				nestLevel--;
+			}
+		}
+		return -1;
+	}
+
+	private int skipLetter( String text, int fromIndex ) {
+		int textLength = text.length();
+		for( int i = fromIndex; i < textLength; i++ ) {
+			if( !Character.isLetter( text.charAt( i ) ) )
+				return i;
+		}
+		return textLength;
+	}
+
+	private int skipWhitespace( String text, int fromIndex ) {
+		int textLength = text.length();
+		for( int i = fromIndex; i < textLength; i++ ) {
+			if( !Character.isWhitespace( text.charAt( i ) ) )
+				return i;
+		}
+		return textLength;
+	}
+
+	private void parseColorFunctions( String text, int funNameStart, int paramsStart, int paramsEnd )
+		throws IllegalArgumentException
+	{
+		String function = StringUtils.substringTrimmed( text, funNameStart, paramsStart );
+		List<String> params = UIDefaultsLoaderAccessor.splitFunctionParams( text.substring( paramsStart + 1, paramsEnd ), ',' );
+		if( params.isEmpty() )
+			throw new IllegalArgumentException();
+
+		functionLabel.setText( function + text.substring( paramsStart, paramsEnd + 1 ) );
+
+		switch( function ) {
+			case "lighten":			parseColorHSLIncreaseDecrease( 2, true, params ); return;
+			case "darken":			parseColorHSLIncreaseDecrease( 2, false, params ); return;
+			case "saturate":		parseColorHSLIncreaseDecrease( 1, true, params ); return;
+			case "desaturate":		parseColorHSLIncreaseDecrease( 1, false, params ); return;
+			case "fadein":			parseColorHSLIncreaseDecrease( 3, true, params ); return;
+			case "fadeout":			parseColorHSLIncreaseDecrease( 3, false, params ); return;
+			case "fade":			parseColorFade( params ); return;
+			case "spin":			parseColorSpin( params ); return;
+			case "changeHue":		parseColorChange( 0, params ); return;
+			case "changeSaturation":parseColorChange( 1, params ); return;
+			case "changeLightness":	parseColorChange( 2, params ); return;
+			case "changeAlpha":		parseColorChange( 3, params ); return;
+			case "mix":				parseColorMix( false, null, params ); return;
+			case "tint":			parseColorMix( true, "#fff", params ); return;
+			case "shade":			parseColorMix( true, "#000", params ); return;
+		}
+
+		// unknown function
+		throw new IllegalArgumentException();
+	}
+
+	/**
+	 * Syntax: lighten(color,amount[,options]) or darken(color,amount[,options]) or
+	 *         saturate(color,amount[,options]) or desaturate(color,amount[,options]) or
+	 *         fadein(color,amount[,options]) or fadeout(color,amount[,options])
+	 *   - color: a color (e.g. #f00) or a color function
+	 *   - amount: percentage 0-100%
+	 *   - options: [relative] [autoInverse] [noAutoInverse] [derived] [lazy]
+	 */
+	private void parseColorHSLIncreaseDecrease( int hslIndex, boolean increase, List<String> params )
+		throws IllegalArgumentException
+	{
+		String colorStr = params.get( 0 );
+		String amountStr = params.get( 1 );
+		int amount = UIDefaultsLoaderAccessor.parsePercentage( amountStr );
+		boolean relative = false;
+		boolean autoInverse = false;
+		boolean derived = false;
+		boolean lazy = false;
+
+		if( params.size() > 2 ) {
+			String options = params.get( 2 );
+			relative = UIDefaultsLoaderAccessor.hasOption( options, "relative" );
+			autoInverse = UIDefaultsLoaderAccessor.hasOption( options, "autoInverse" );
+			derived = UIDefaultsLoaderAccessor.hasOption( options, "derived" );
+			lazy = UIDefaultsLoaderAccessor.hasOption( options, "lazy" );
+
+			// use autoInverse by default for derived colors, except if noAutoInverse is set
+			if( derived && !UIDefaultsLoaderAccessor.hasOption( options, "noAutoInverse" ) )
+				autoInverse = true;
+		}
+		boolean relative2 = relative;
+		boolean autoInverse2 = autoInverse;
+
+		// parse base color
+		Color baseColor = lazy ? getColorLazy( colorStr ) : getParsedColor( colorStr );
+
+		// create function
+		DoubleFunction<Color> function = weight -> {
+			return ColorFunctions.applyFunctions( baseColor, new ColorFunctions.HSLIncreaseDecrease(
+				hslIndex, increase, (float) (weight * 100), relative2, autoInverse2 ) );
+		};
+
+		// update preview
+		updatePreview( baseColor, null, function.apply( amount / 100. ), amountStr );
+		gradientPreview.set( function, amount / 100f );
+	}
+
+	/**
+	 * Syntax: fade(color,amount[,options])
+	 *   - color: a color (e.g. #f00) or a color function
+	 *   - amount: percentage 0-100%
+	 *   - options: [derived] [lazy]
+	 */
+	private void parseColorFade( List<String> params )
+		throws IllegalArgumentException
+	{
+		String colorStr = params.get( 0 );
+		String amountStr = params.get( 1 );
+		int amount = UIDefaultsLoaderAccessor.parsePercentage( amountStr );
+		boolean lazy = false;
+
+		if( params.size() > 2 ) {
+			String options = params.get( 2 );
+			lazy = UIDefaultsLoaderAccessor.hasOption( options, "lazy" );
+		}
+
+		// parse base color
+		Color baseColor = lazy ? getColorLazy( colorStr ) : getParsedColor( colorStr );
+
+		// create function
+		DoubleFunction<Color> function = weight -> {
+			return ColorFunctions.applyFunctions( baseColor, new ColorFunctions.Fade(
+				(float) (weight * 100) ) );
+		};
+
+		// update preview
+		updatePreview( baseColor, null, function.apply( amount / 100. ), amountStr );
+		gradientPreview.set( function, amount / 100f );
+	}
+
+	/**
+	 * Syntax: spin(color,angle[,options])
+	 *   - color: a color (e.g. #f00) or a color function
+	 *   - angle: number of degrees to rotate
+	 *   - options: [derived] [lazy]
+	 */
+	private void parseColorSpin( List<String> params )
+		throws IllegalArgumentException
+	{
+		String colorStr = params.get( 0 );
+		String amountStr = params.get( 1 );
+		int amount = UIDefaultsLoaderAccessor.parseInteger( amountStr );
+		boolean lazy = false;
+
+		if( params.size() > 2 ) {
+			String options = params.get( 2 );
+			lazy = UIDefaultsLoaderAccessor.hasOption( options, "lazy" );
+		}
+
+		// parse base color
+		Color baseColor = lazy ? getColorLazy( colorStr ) : getParsedColor( colorStr );
+
+		// create function
+		DoubleFunction<Color> function = weight -> {
+			return ColorFunctions.applyFunctions( baseColor, new ColorFunctions.HSLIncreaseDecrease(
+				0, true, (float) (weight * 360), false, false ) );
+		};
+
+		// update preview
+		updatePreview( baseColor, null, function.apply( amount / 360. ), amountStr );
+		gradientPreview.set( function, amount / 360f );
+	}
+
+	/**
+	 * Syntax: changeHue(color,value[,options]) or
+	 *         changeSaturation(color,value[,options]) or
+	 *         changeLightness(color,value[,options]) or
+	 *         changeAlpha(color,value[,options])
+	 *   - color: a color (e.g. #f00) or a color function
+	 *   - value: for hue: number of degrees; otherwise: percentage 0-100%
+	 *   - options: [derived] [lazy]
+	 */
+	private void parseColorChange( int hslIndex, List<String> params )
+		throws IllegalArgumentException
+	{
+		String colorStr = params.get( 0 );
+		String valueStr = params.get( 1 );
+		int value = (hslIndex == 0)
+			? UIDefaultsLoaderAccessor.parseInteger( valueStr )
+			: UIDefaultsLoaderAccessor.parsePercentage( valueStr );
+		boolean lazy = false;
+
+		if( params.size() > 2 ) {
+			String options = params.get( 2 );
+			lazy = UIDefaultsLoaderAccessor.hasOption( options, "lazy" );
+		}
+
+		// parse base color
+		Color baseColor = lazy ? getColorLazy( colorStr ) : getParsedColor( colorStr );
+
+		// create function
+		float factor = (hslIndex == 0) ? 360 : 100;
+		DoubleFunction<Color> function = weight -> {
+			return ColorFunctions.applyFunctions( baseColor, new ColorFunctions.HSLChange(
+				hslIndex, (float) (weight * factor) ) );
+		};
+
+		// update preview
+		updatePreview( baseColor, null, function.apply( value / factor ), valueStr );
+		gradientPreview.set( function, value / factor );
+	}
+
+	/**
+	 * Syntax: mix(color1,color2[,weight][,options]) or
+	 *         tint(color[,weight][,options]) or
+	 *         shade(color[,weight][,options])
+	 *   - color1: a color (e.g. #f00) or a color function
+	 *   - color2: a color (e.g. #f00) or a color function
+	 *   - weight: the weight (in range 0-100%) to mix the two colors
+	 *             larger weight uses more of first color, smaller weight more of second color
+	 *   - options: [rgb|lrgb|oklab] [derived] [lazy]
+	 */
+	private void parseColorMix( boolean isTintOrShade, String color1Str, List<String> params )
+		throws IllegalArgumentException
+	{
+		int i = 0;
+		if( color1Str == null )
+			color1Str = params.get( i++ );
+		String color2Str = params.get( i++ );
+		String weightStr = "50%";
+		int weight = 50;
+		boolean lazy = false;
+		int method = ColorFunctions.RGB;
+
+		if( params.size() > i ) {
+			weightStr = params.get( i );
+			if( !weightStr.isEmpty() && Character.isDigit( weightStr.charAt( 0 ) ) ) {
+				weight = UIDefaultsLoaderAccessor.parsePercentage( weightStr );
+				i++;
+			}
+		}
+		if( params.size() > i ) {
+			String options = params.get( i );
+			if( UIDefaultsLoaderAccessor.hasOption( options, "rgb" ) )
+				method = ColorFunctions.RGB;
+			else if( UIDefaultsLoaderAccessor.hasOption( options, "lrgb" ) )
+				method = ColorFunctions.LRGB;
+			else if( UIDefaultsLoaderAccessor.hasOption( options, "oklab" ) )
+				method = ColorFunctions.OKLAB;
+			lazy = UIDefaultsLoaderAccessor.hasOption( options, "lazy" );
+		}
+		int method2 = method;
+
+		// parse colors
+		Color color1 = getParsedColor( color1Str );
+		Color color2 = lazy ? getColorLazy( color2Str ) : getParsedColor( color2Str );
+
+		// create function
+		DoubleFunction<Color> function = weight2 -> {
+			return ColorFunctions.applyFunctions( color2, new ColorFunctions.Mix2(
+				color1, (float) (weight2 * 100), method2 ) );
+		};
+
+		// update preview
+		if( isTintOrShade )
+			updatePreview( color2, null, function.apply( weight / 100. ), weightStr );
+		else
+			updatePreview( color1, color2, function.apply( weight / 100. ), weightStr );
+		gradientPreview.set( function, weight / 100f );
+	}
+
+	private Color getParsedColor( String colorStr )
+		throws IllegalArgumentException
+	{
+		Object value = textArea.propertiesSupport.getParsedValue( "someColor", colorStr );
+		if( !(value instanceof Color) )
+			throw new IllegalArgumentException();
+		return (Color) value;
+	}
+
+	private Color getColorLazy( String colorStr )
+		throws IllegalArgumentException
+	{
+		Object[] pValue = { null };
+		FlatLaf.runWithUIDefaultsGetter( key -> {
+			return (key instanceof String)
+				? textArea.propertiesSupport.getParsedProperty( (String) key )
+				: null;
+		}, () -> {
+			pValue[0] = UIDefaultsLoaderAccessor.lazyUIManagerGet( colorStr );
+		} );
+		if( !(pValue[0] instanceof Color) )
+			throw new IllegalArgumentException();
+		return (Color) pValue[0];
+	}
+
+	private void updatePreview( Color color1, Color color2, Color newColor, String newText ) {
+		color1HSLLabel.setText( colorToHSLString( color1 ) );
+		newColorHSLLabel.setText( colorToHSLString( newColor ) );
+
+		color1RGBLabel.setText( FlatSyntaxTextAreaActions.colorToString( color1 ) );
+		newColorRGBLabel.setText( FlatSyntaxTextAreaActions.colorToString( newColor ) );
+
+		color1Preview.setBackground( color1 );
+		newColorPreview.setBackground( newColor );
+		newColorPreview.setForeground( (ColorFunctions.luma( newColor ) * 100 < 43) ? Color.white : Color.black );
+		newColorPreview.setText( newText );
+
+		boolean hasColor2 = (color2 != null);
+		color2HSLLabel.setVisible( hasColor2 );
+		color2RGBLabel.setVisible( hasColor2 );
+		color2Preview.setVisible( hasColor2 );
+		if( hasColor2 ) {
+			color2HSLLabel.setText( colorToHSLString( color2 ) );
+			color2RGBLabel.setText( FlatSyntaxTextAreaActions.colorToString( color2 ) );
+			color2Preview.setBackground( color2 );
+		}
+	}
+
+	@SuppressWarnings( "FormatString" ) // Error Prone
+	private String colorToHSLString( Color color ) {
+		// necessary to convert float colors (produced by class HSLColor)  to int colors
+		// (e.g. HUE may be 359.99997 in float colors, but becomes 0 in int colors)
+		color = new Color( color.getRGB(), true );
+
+		float[] hsl = HSLColor.fromRGB( color );
+		int alpha = color.getAlpha();
+		return String.format( (alpha != 255) ? "HSLA %d %d %d %d" : "HSL %d %d %d",
+			Math.round( hsl[0] ), Math.round( hsl[1] ), Math.round( hsl[2] ),
+			Math.round( alpha / 255f * 100 ) );
+	}
+
+	private void initComponents() {
+		// JFormDesigner - Component initialization - DO NOT MODIFY  //GEN-BEGIN:initComponents  @formatter:off
+		JPanel previewPanel = new JPanel();
+		functionLabel = new JLabel();
+		color1HSLLabel = new JLabel();
+		newColorHSLLabel = new JLabel();
+		color2HSLLabel = new JLabel();
+		color1RGBLabel = new JLabel();
+		newColorRGBLabel = new JLabel();
+		color2RGBLabel = new JLabel();
+		color1Preview = new FlatColorFunctionPreview.Preview();
+		newColorPreview = new FlatColorFunctionPreview.Preview();
+		color2Preview = new FlatColorFunctionPreview.Preview();
+		gradientPreview = new FlatColorFunctionPreview.GradientPreview();
+
+		//======== this ========
+		setLayout(new MigLayout(
+			"hidemode 3",
+			// columns
+			"[grow,fill]",
+			// rows
+			"[]" +
+			"[]"));
+
+		//======== previewPanel ========
+		{
+			previewPanel.setLayout(new MigLayout(
+				"fillx,insets 0,hidemode 3",
+				// columns
+				"[grow,sizegroup 1,fill]0" +
+				"[grow,sizegroup 1,fill]0" +
+				"[grow,sizegroup 1,fill]",
+				// rows
+				"[]" +
+				"[]0" +
+				"[]0" +
+				"[30,fill]"));
+
+			//---- functionLabel ----
+			functionLabel.setText("text");
+			functionLabel.putClientProperty(FlatClientProperties.STYLE_CLASS, "h3");
+			previewPanel.add(functionLabel, "cell 0 0 3 1,wmax 100%");
+
+			//---- color1HSLLabel ----
+			color1HSLLabel.setText("text");
+			previewPanel.add(color1HSLLabel, "cell 0 1,wmax 33%");
+
+			//---- newColorHSLLabel ----
+			newColorHSLLabel.setText("text");
+			previewPanel.add(newColorHSLLabel, "cell 1 1,wmax 33%");
+
+			//---- color2HSLLabel ----
+			color2HSLLabel.setText("text");
+			previewPanel.add(color2HSLLabel, "cell 2 1,wmax 33%");
+
+			//---- color1RGBLabel ----
+			color1RGBLabel.setText("text");
+			previewPanel.add(color1RGBLabel, "cell 0 2,wmax 33%");
+
+			//---- newColorRGBLabel ----
+			newColorRGBLabel.setText("text");
+			previewPanel.add(newColorRGBLabel, "cell 1 2,wmax 33%");
+
+			//---- color2RGBLabel ----
+			color2RGBLabel.setText("text");
+			previewPanel.add(color2RGBLabel, "cell 2 2,wmax 33%");
+
+			//---- color1Preview ----
+			color1Preview.setBackground(Color.red);
+			color1Preview.setHorizontalAlignment(SwingConstants.CENTER);
+			previewPanel.add(color1Preview, "cell 0 3,width 33%");
+
+			//---- newColorPreview ----
+			newColorPreview.setBackground(Color.blue);
+			newColorPreview.setHorizontalAlignment(SwingConstants.CENTER);
+			previewPanel.add(newColorPreview, "cell 1 3,width 33%");
+
+			//---- color2Preview ----
+			color2Preview.setBackground(Color.green);
+			color2Preview.setHorizontalAlignment(SwingConstants.CENTER);
+			previewPanel.add(color2Preview, "cell 2 3,width 33%");
+		}
+		add(previewPanel, "cell 0 0");
+		add(gradientPreview, "cell 0 1");
+		// JFormDesigner - End of component initialization  //GEN-END:initComponents  @formatter:on
+	}
+
+	// JFormDesigner - Variables declaration - DO NOT MODIFY  //GEN-BEGIN:variables  @formatter:off
+	private JLabel functionLabel;
+	private JLabel color1HSLLabel;
+	private JLabel newColorHSLLabel;
+	private JLabel color2HSLLabel;
+	private JLabel color1RGBLabel;
+	private JLabel newColorRGBLabel;
+	private JLabel color2RGBLabel;
+	private FlatColorFunctionPreview.Preview color1Preview;
+	private FlatColorFunctionPreview.Preview newColorPreview;
+	private FlatColorFunctionPreview.Preview color2Preview;
+	private FlatColorFunctionPreview.GradientPreview gradientPreview;
+	// JFormDesigner - End of variables declaration  //GEN-END:variables  @formatter:on
+
+	//---- class Preview ------------------------------------------------------
+
+	private static class Preview
+		extends JLabel
+	{
+		@Override
+		protected void paintComponent( Graphics g ) {
+			int width = getWidth();
+			int height = getHeight();
+
+			Color background = getBackground();
+
+			// paint checkerboard pattern
+			if( background.getAlpha() != 255 )
+				GradientPreview.paintCheckerboard( g, 0, 0, width, height );
+
+			// paint color preview
+			g.setColor( background );
+			g.fillRect( 0, 0, width, height );
+
+			// paint text
+			super.paintComponent( g );
+		}
+	}
+
+	//---- class GradientPreview ----------------------------------------------
+
+	private static class GradientPreview
+		extends JComponent
+	{
+		private static final int
+			GRADIENT_HEIGHT = 30,
+			TICK_HEIGHT = 8;
+
+		private DoubleFunction<Color> function;
+		private float weight;
+
+		private BufferedImage image;
+		private final JLabel label = new JLabel( "123" );
+
+		void set( DoubleFunction<Color> function, float weight ) {
+			this.function = function;
+			this.weight = weight;
+
+			image = null;
+			repaint();
+		}
+
+		@Override
+		public Dimension getPreferredSize() {
+			return new Dimension(
+				UIScale.scale( 100 ),
+				UIScale.scale( GRADIENT_HEIGHT + TICK_HEIGHT ) + this.label.getPreferredSize().height );
+		}
+
+		@Override
+		protected void paintComponent( Graphics g ) {
+			int width = getWidth();
+			int height = getHeight();
+
+			if( image == null || image.getWidth() != width ) {
+				image = new BufferedImage( width, 1, BufferedImage.TYPE_INT_ARGB );
+
+				for( int i = 0; i < width; i++ ) {
+					float weight = (float) i / width;
+					Color result = (function != null)
+						? function.apply( weight )
+						: ColorFunctions.mix( Color.red, Color.green, 1f - weight );
+					image.setRGB( i, 0, result.getRGB() );
+				}
+			}
+
+			int gradientHeight = UIScale.scale( GRADIENT_HEIGHT );
+			GradientPreview.paintCheckerboard( g, 0, 0, width, gradientHeight );
+			g.drawImage( image, 0, 0, width, gradientHeight, null );
+
+			Object[] oldRenderingHints = FlatUIUtils.setRenderingHints( g );
+
+			// paint ticks
+			int tickHeight = UIScale.scale( TICK_HEIGHT );
+			int y = gradientHeight + UIScale.scale( 2 );
+			float w10th = width / 10f;
+			int w20th = Math.round( width / 20f );
+			g.setColor( UIManager.getColor( "Slider.tickColor" ) );
+			for( int i = 0; i <= 10; i++ ) {
+				int x = Math.min( Math.round( (w10th * i) ), width - 1 );
+				g.drawLine( x, y, x, y + tickHeight );
+				g.drawLine( x + w20th, y, x + w20th, y + (tickHeight / 2) );
+			}
+
+			// paint current weight
+			g.setColor( UIManager.getColor( "Objects.RedStatus" ) );
+			((Graphics2D)g).setStroke( new BasicStroke( UIScale.scale( 3 ) ) );
+			int wx = Math.min( Math.round( width * weight ), width - 1 );
+			g.drawLine( wx, y, wx, y + tickHeight );
+
+			FlatUIUtils.resetRenderingHints( g, oldRenderingHints );
+
+			// paint labels
+			g.setColor( UIManager.getColor( "Label.foreground" ) );
+			g.setFont( UIManager.getFont( "small.font" ) );
+			FontMetrics fm = g.getFontMetrics();
+			for( int i = 0; i <= 10; i++ ) {
+				if( i == 9 )
+					continue;
+
+				int x = Math.min( Math.round( (w10th * i) ), width - 1 );
+
+				String str = String.format( "%d%%", i * 10 );
+				int lw = fm.stringWidth( str );
+				int lx = Math.min( Math.max( 0, x - (lw / 2) ), width - lw );
+				FlatUIUtils.drawString( label, g, str, lx, height );
+			}
+		}
+
+		static void paintCheckerboard( Graphics g, int x, int y, int width, int height ) {
+			Color c = UIManager.getColor( "Panel.background" );
+			g.setColor( FlatLaf.isLafDark()
+				? ColorFunctions.lighten( c, 0.2f )
+				: ColorFunctions.darken( c, 0.2f ) );
+
+			Shape oldClip = g.getClip();
+			g.setClip( x, y, width, height );
+
+			int cw = UIScale.scale( 8 );
+			int cw2 = cw * 2;
+			for( int cx = x; cx < width; cx += cw2 ) {
+				for( int cy = y; cy < height; cy += cw2 ) {
+					g.fillRect( cx, cy, cw, cw );
+					g.fillRect( cx + cw, cy + cw, cw, cw );
+				}
+			}
+
+			g.setClip( oldClip );
+		}
+	}
+}

--- a/flatlaf-theme-editor/src/main/java/com/formdev/flatlaf/themeeditor/FlatColorFunctionPreview.jfd
+++ b/flatlaf-theme-editor/src/main/java/com/formdev/flatlaf/themeeditor/FlatColorFunctionPreview.jfd
@@ -1,0 +1,98 @@
+JFDML JFormDesigner: "8.3" encoding: "UTF-8"
+
+new FormModel {
+	contentType: "form/swing"
+	root: new FormRoot {
+		add( new FormContainer( "javax.swing.JPanel", new FormLayoutManager( class net.miginfocom.swing.MigLayout ) {
+			"$layoutConstraints": "hidemode 3"
+			"$columnConstraints": "[grow,fill]"
+			"$rowConstraints": "[][]"
+		} ) {
+			name: "this"
+			add( new FormContainer( "javax.swing.JPanel", new FormLayoutManager( class net.miginfocom.swing.MigLayout ) {
+				"$layoutConstraints": "fillx,insets 0,hidemode 3"
+				"$columnConstraints": "[grow,sizegroup 1,fill]0[grow,sizegroup 1,fill]0[grow,sizegroup 1,fill]"
+				"$rowConstraints": "[][]0[]0[30,fill]"
+			} ) {
+				name: "previewPanel"
+				auxiliary() {
+					"JavaCodeGenerator.variableLocal": true
+				}
+				add( new FormComponent( "javax.swing.JLabel" ) {
+					name: "functionLabel"
+					"text": "text"
+					"$client.FlatLaf.styleClass": "h3"
+				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+					"value": "cell 0 0 3 1,wmax 100%"
+				} )
+				add( new FormComponent( "javax.swing.JLabel" ) {
+					name: "color1HSLLabel"
+					"text": "text"
+				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+					"value": "cell 0 1,wmax 33%"
+				} )
+				add( new FormComponent( "javax.swing.JLabel" ) {
+					name: "newColorHSLLabel"
+					"text": "text"
+				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+					"value": "cell 1 1,wmax 33%"
+				} )
+				add( new FormComponent( "javax.swing.JLabel" ) {
+					name: "color2HSLLabel"
+					"text": "text"
+				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+					"value": "cell 2 1,wmax 33%"
+				} )
+				add( new FormComponent( "javax.swing.JLabel" ) {
+					name: "color1RGBLabel"
+					"text": "text"
+				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+					"value": "cell 0 2,wmax 33%"
+				} )
+				add( new FormComponent( "javax.swing.JLabel" ) {
+					name: "newColorRGBLabel"
+					"text": "text"
+				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+					"value": "cell 1 2,wmax 33%"
+				} )
+				add( new FormComponent( "javax.swing.JLabel" ) {
+					name: "color2RGBLabel"
+					"text": "text"
+				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+					"value": "cell 2 2,wmax 33%"
+				} )
+				add( new FormComponent( "com.formdev.flatlaf.themeeditor.FlatColorFunctionPreview$Preview" ) {
+					name: "color1Preview"
+					"background": sfield java.awt.Color red
+					"horizontalAlignment": 0
+				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+					"value": "cell 0 3,width 33%"
+				} )
+				add( new FormComponent( "com.formdev.flatlaf.themeeditor.FlatColorFunctionPreview$Preview" ) {
+					name: "newColorPreview"
+					"background": sfield java.awt.Color blue
+					"horizontalAlignment": 0
+				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+					"value": "cell 1 3,width 33%"
+				} )
+				add( new FormComponent( "com.formdev.flatlaf.themeeditor.FlatColorFunctionPreview$Preview" ) {
+					name: "color2Preview"
+					"background": sfield java.awt.Color green
+					"horizontalAlignment": 0
+				}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+					"value": "cell 2 3,width 33%"
+				} )
+			}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+				"value": "cell 0 0"
+			} )
+			add( new FormComponent( "com.formdev.flatlaf.themeeditor.FlatColorFunctionPreview$GradientPreview" ) {
+				name: "gradientPreview"
+			}, new FormLayoutConstraints( class net.miginfocom.layout.CC ) {
+				"value": "cell 0 1"
+			} )
+		}, new FormLayoutConstraints( null ) {
+			"location": new java.awt.Point( 0, 0 )
+			"size": new java.awt.Dimension( 400, 300 )
+		} )
+	}
+}

--- a/flatlaf-theme-editor/src/main/java/com/formdev/flatlaf/themeeditor/FlatCompletionProvider.java
+++ b/flatlaf-theme-editor/src/main/java/com/formdev/flatlaf/themeeditor/FlatCompletionProvider.java
@@ -43,6 +43,7 @@ import org.fife.ui.autocomplete.ParameterizedCompletion;
 import org.fife.ui.autocomplete.ParameterizedCompletion.Parameter;
 import org.fife.ui.rsyntaxtextarea.RSyntaxTextArea;
 import com.formdev.flatlaf.FlatLaf;
+import com.formdev.flatlaf.util.StringUtils;
 
 /**
  * @author Karl Tauber
@@ -405,6 +406,8 @@ class FlatCompletionProvider
 		extends BaseCompletionProvider
 		implements ParameterChoicesProvider
 	{
+		private static final String OPTIONAL = "(optional) ";
+
 		ValueCompletionProvider( CompletionProvider parent ) {
 			setParent( parent );
 			setAutoActivationRules( true, null );
@@ -446,7 +449,7 @@ class FlatCompletionProvider
 			String[] hslIncreaseDecreaseParams = {
 				"color", colorParamDesc,
 				"amount", "0-100%",
-				"options", "(optional) [relative] [autoInverse] [noAutoInverse] [lazy] [derived]"
+				"options", OPTIONAL + "[relative] [autoInverse] [noAutoInverse] [lazy] [derived]"
 			};
 			addFunction( "lighten", hslIncreaseDecreaseParams );
 			addFunction( "darken", hslIncreaseDecreaseParams );
@@ -458,42 +461,45 @@ class FlatCompletionProvider
 			addFunction( "fade",
 				"color", colorParamDesc,
 				"amount", "0-100%",
-				"options", "(optional) [derived]" );
+				"options", OPTIONAL + "[derived]" );
 			addFunction( "spin",
 				"color", colorParamDesc,
 				"angle", "number of degrees to rotate (0-360)",
-				"options", "(optional) [derived]" );
+				"options", OPTIONAL + "[derived]" );
 
 			addFunction( "changeHue",
 				"color", colorParamDesc,
 				"angle", "number of degrees (0-360)",
-				"options", "(optional) [derived]" );
+				"options", OPTIONAL + "[derived]" );
 			String[] hslChangeParams = {
 				"color", colorParamDesc,
 				"value", "0-100%",
-				"options", "(optional) [derived]"
+				"options", OPTIONAL + "[derived]"
 			};
 			addFunction( "changeSaturation", hslChangeParams );
 			addFunction( "changeLightness", hslChangeParams );
 			addFunction( "changeAlpha", hslChangeParams );
 
-			String weightParamDesc = "(optional) 0-100%, default is 50%";
+			String weightParamDesc = OPTIONAL + "0-100%, default is 50%";
 			addFunction( "mix",
 				"color1", colorParamDesc,
 				"color2", colorParamDesc,
-				"weight", weightParamDesc );
+				"weight", weightParamDesc,
+				"options", OPTIONAL + "[rgb|lrgb|oklab] [derived] [lazy]" );
 			addFunction( "tint",
 				"color", colorParamDesc,
-				"weight", weightParamDesc );
+				"weight", weightParamDesc,
+				"options", OPTIONAL + "[rgb|lrgb|oklab] [derived] [lazy]" );
 			addFunction( "shade",
 				"color", colorParamDesc,
-				"weight", weightParamDesc );
+				"weight", weightParamDesc,
+				"options", OPTIONAL + "[rgb|lrgb|oklab] [derived] [lazy]" );
 
 			addFunction( "contrast",
 				"color", colorParamDesc,
 				"dark", colorParamDesc,
 				"light", colorParamDesc,
-				"threshold", "(optional) 0-100%, default is 43%" );
+				"threshold", OPTIONAL + "0-100%, default is 43%" );
 
 			addFunction( "over",
 				"foreground", colorParamDesc,
@@ -526,10 +532,13 @@ class FlatCompletionProvider
 		public List<Completion> getParameterChoices( JTextComponent tc, Parameter param ) {
 			switch( param.getName() ) {
 				case "amount":
+				case "weight":
 					return createParameterChoices( "5%", "10%", "15%", "20%", "25%" );
 
 				case "options":
-					return createParameterChoices( "relative", "autoInverse", "noAutoInverse", "lazy", "derived" );
+					String description = param.getDescription();
+					description = StringUtils.removeLeading( description, OPTIONAL );
+					return createParameterChoices( description.split( "[ \\[\\]\\|]" ) );
 			}
 
 			return null;
@@ -537,8 +546,11 @@ class FlatCompletionProvider
 
 		private List<Completion> createParameterChoices( String... values ) {
 			List<Completion> result = new ArrayList<>();
-			for( String value : values )
-				result.add( new BasicCompletion( this, value ) );
+			for( String value : values ) {
+				value = value.trim();
+				if( !value.isEmpty() )
+					result.add( new BasicCompletion( this, value ) );
+			}
 			return result;
 		}
 	}

--- a/flatlaf-theme-editor/src/main/java/com/formdev/flatlaf/themeeditor/FlatThemeEditorPane.java
+++ b/flatlaf-theme-editor/src/main/java/com/formdev/flatlaf/themeeditor/FlatThemeEditorPane.java
@@ -330,6 +330,11 @@ class FlatThemeEditorPane
 		revalidate();
 	}
 
+	void showColorFunctionPreview( boolean show ) {
+		if( preview != null )
+			preview.showColorFunctionPreview( show );
+	}
+
 	void notifyTextAreaAction( String actionKey ) {
 		Action action = textArea.getActionMap().get( actionKey );
 		if( action != null && action.isEnabled() )

--- a/flatlaf-theme-editor/src/main/java/com/formdev/flatlaf/themeeditor/FlatThemeFileEditor.java
+++ b/flatlaf-theme-editor/src/main/java/com/formdev/flatlaf/themeeditor/FlatThemeFileEditor.java
@@ -92,6 +92,7 @@ class FlatThemeFileEditor
 	private static final String KEY_RECENT_FILE = "recentFile";
 	private static final String KEY_WINDOW_BOUNDS = "windowBounds";
 	private static final String KEY_PREVIEW = "preview";
+	private static final String KEY_PREVIEW_COLOR_FUNCTION = "previewColorFunction";
 	private static final String KEY_LAF = "laf";
 	private static final String KEY_FONT_SIZE_INCR = "fontSizeIncr";
 	private static final String KEY_SHOW_HSL_COLORS = "showHslColors";
@@ -475,6 +476,8 @@ class FlatThemeFileEditor
 
 		if( state.getBoolean( KEY_PREVIEW, true ) )
 			themeEditorPane.showPreview( true );
+		if( state.getBoolean( KEY_PREVIEW_COLOR_FUNCTION, true ) )
+			themeEditorPane.showColorFunctionPreview( true );
 
 		tabbedPane.addTab( titleFun.get(), null, themeEditorPane, file.getAbsolutePath() );
 
@@ -795,6 +798,17 @@ class FlatThemeFileEditor
 		for( FlatThemeEditorPane themeEditorPane : getThemeEditorPanes() )
 			themeEditorPane.showPreview( show );
 		putPrefsBoolean( state, KEY_PREVIEW, show, true );
+
+		previewColorFunctionMenuItem.setEnabled( show );
+		if( show )
+			showHideColorFunctionPreview();
+	}
+
+	private void showHideColorFunctionPreview() {
+		boolean show = previewColorFunctionMenuItem.isSelected();
+		for( FlatThemeEditorPane themeEditorPane : getThemeEditorPanes() )
+			themeEditorPane.showColorFunctionPreview( show );
+		putPrefsBoolean( state, KEY_PREVIEW_COLOR_FUNCTION, show, true );
 	}
 
 	private void lightLaf() {
@@ -918,6 +932,8 @@ class FlatThemeFileEditor
 
 		// restore menu item selection
 		previewMenuItem.setSelected( state.getBoolean( KEY_PREVIEW, true ) );
+		previewColorFunctionMenuItem.setSelected( state.getBoolean( KEY_PREVIEW_COLOR_FUNCTION, true ) );
+		previewColorFunctionMenuItem.setEnabled( previewMenuItem.isSelected() );
 		showHSLColorsMenuItem.setSelected( FlatThemeEditorOverlay.showHSL );
 		showRGBColorsMenuItem.setSelected( FlatThemeEditorOverlay.showRGB );
 		showColorLumaMenuItem.setSelected( FlatThemeEditorOverlay.showLuma );
@@ -1036,6 +1052,7 @@ class FlatThemeFileEditor
 		pickColorMenuItem = new JMenuItem();
 		viewMenu = new JMenu();
 		previewMenuItem = new JCheckBoxMenuItem();
+		previewColorFunctionMenuItem = new JCheckBoxMenuItem();
 		lightLafMenuItem = new JRadioButtonMenuItem();
 		darkLafMenuItem = new JRadioButtonMenuItem();
 		incrFontSizeMenuItem = new JMenuItem();
@@ -1155,6 +1172,11 @@ class FlatThemeFileEditor
 				previewMenuItem.setAccelerator(KeyStroke.getKeyStroke(KeyEvent.VK_P, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
 				previewMenuItem.addActionListener(e -> showHidePreview());
 				viewMenu.add(previewMenuItem);
+
+				//---- previewColorFunctionMenuItem ----
+				previewColorFunctionMenuItem.setText("Color Function Preview");
+				previewColorFunctionMenuItem.addActionListener(e -> showHideColorFunctionPreview());
+				viewMenu.add(previewColorFunctionMenuItem);
 				viewMenu.addSeparator();
 
 				//---- lightLafMenuItem ----
@@ -1319,6 +1341,7 @@ class FlatThemeFileEditor
 	private JMenuItem pickColorMenuItem;
 	private JMenu viewMenu;
 	private JCheckBoxMenuItem previewMenuItem;
+	private JCheckBoxMenuItem previewColorFunctionMenuItem;
 	private JRadioButtonMenuItem lightLafMenuItem;
 	private JRadioButtonMenuItem darkLafMenuItem;
 	private JMenuItem incrFontSizeMenuItem;

--- a/flatlaf-theme-editor/src/main/java/com/formdev/flatlaf/themeeditor/FlatThemeFileEditor.jfd
+++ b/flatlaf-theme-editor/src/main/java/com/formdev/flatlaf/themeeditor/FlatThemeFileEditor.jfd
@@ -1,4 +1,4 @@
-JFDML JFormDesigner: "8.1.0.0.283" Java: "19.0.2" encoding: "UTF-8"
+JFDML JFormDesigner: "8.3" encoding: "UTF-8"
 
 new FormModel {
 	contentType: "form/swing"
@@ -140,6 +140,11 @@ new FormModel {
 						"text": "Preview"
 						"accelerator": static javax.swing.KeyStroke getKeyStroke( 80, 4356, false )
 						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "showHidePreview", false ) )
+					} )
+					add( new FormComponent( "javax.swing.JCheckBoxMenuItem" ) {
+						name: "previewColorFunctionMenuItem"
+						"text": "Color Function Preview"
+						addEvent( new FormEvent( "java.awt.event.ActionListener", "actionPerformed", "showHideColorFunctionPreview", false ) )
 					} )
 					add( new FormComponent( "javax.swing.JPopupMenu$Separator" ) {
 						name: "separator3"

--- a/flatlaf-theme-editor/src/main/java/com/formdev/flatlaf/themeeditor/FlatThemePreview.java
+++ b/flatlaf-theme-editor/src/main/java/com/formdev/flatlaf/themeeditor/FlatThemePreview.java
@@ -56,6 +56,8 @@ class FlatThemePreview
 	private boolean inGetDefaultFont;
 	private boolean inGetVariables;
 
+	private final FlatColorFunctionPreview colorFunctionPreview;
+
 	FlatThemePreview( FlatSyntaxTextArea textArea ) {
 		this.textArea = textArea;
 		state = Preferences.userRoot().node( FlatThemeFileEditor.PREFS_ROOT_PATH );
@@ -87,6 +89,8 @@ class FlatThemePreview
 				selectRecentTab();
 				updateLater();
 		} );
+
+		colorFunctionPreview = new FlatColorFunctionPreview( textArea );
 	}
 
 	private JScrollPane createPreviewTab( JComponent c ) {
@@ -114,6 +118,16 @@ class FlatThemePreview
 	private void selectedTabChanged() {
 		update();
 		state.putInt( KEY_SELECTED_TAB, tabbedPane.getSelectedIndex() );
+	}
+
+	void showColorFunctionPreview( boolean show ) {
+		if( show )
+			centerPanel.add( colorFunctionPreview, BorderLayout.SOUTH );
+		else
+			centerPanel.remove( colorFunctionPreview );
+
+		revalidate();
+		repaint();
 	}
 
 	@Override
@@ -232,6 +246,7 @@ class FlatThemePreview
 
 	private void initComponents() {
 		// JFormDesigner - Component initialization - DO NOT MODIFY  //GEN-BEGIN:initComponents
+		centerPanel = new JPanel();
 		tabbedPane = new FlatTabbedPane();
 		previewSeparator = new JSeparator();
 		previewLabel = new JLabel();
@@ -239,13 +254,19 @@ class FlatThemePreview
 		//======== this ========
 		setLayout(new BorderLayout());
 
-		//======== tabbedPane ========
+		//======== centerPanel ========
 		{
-			tabbedPane.setLeadingComponent(previewLabel);
-			tabbedPane.setTabAreaAlignment(FlatTabbedPane.TabAreaAlignment.trailing);
-			tabbedPane.setTabLayoutPolicy(JTabbedPane.SCROLL_TAB_LAYOUT);
+			centerPanel.setLayout(new BorderLayout());
+
+			//======== tabbedPane ========
+			{
+				tabbedPane.setLeadingComponent(previewLabel);
+				tabbedPane.setTabAreaAlignment(FlatTabbedPane.TabAreaAlignment.trailing);
+				tabbedPane.setTabLayoutPolicy(JTabbedPane.SCROLL_TAB_LAYOUT);
+			}
+			centerPanel.add(tabbedPane, BorderLayout.CENTER);
 		}
-		add(tabbedPane, BorderLayout.CENTER);
+		add(centerPanel, BorderLayout.CENTER);
 
 		//---- previewSeparator ----
 		previewSeparator.setOrientation(SwingConstants.VERTICAL);
@@ -258,6 +279,7 @@ class FlatThemePreview
 	}
 
 	// JFormDesigner - Variables declaration - DO NOT MODIFY  //GEN-BEGIN:variables
+	private JPanel centerPanel;
 	private FlatTabbedPane tabbedPane;
 	private JSeparator previewSeparator;
 	private JLabel previewLabel;

--- a/flatlaf-theme-editor/src/main/java/com/formdev/flatlaf/themeeditor/FlatThemePreview.jfd
+++ b/flatlaf-theme-editor/src/main/java/com/formdev/flatlaf/themeeditor/FlatThemePreview.jfd
@@ -1,15 +1,20 @@
-JFDML JFormDesigner: "7.0.4.0.360" Java: "16" encoding: "UTF-8"
+JFDML JFormDesigner: "8.3" encoding: "UTF-8"
 
 new FormModel {
 	contentType: "form/swing"
 	root: new FormRoot {
 		add( new FormContainer( "javax.swing.JPanel", new FormLayoutManager( class java.awt.BorderLayout ) ) {
 			name: "this"
-			add( new FormContainer( "com.formdev.flatlaf.extras.components.FlatTabbedPane", new FormLayoutManager( class javax.swing.JTabbedPane ) ) {
-				name: "tabbedPane"
-				"leadingComponent": new FormReference( "previewLabel" )
-				"tabAreaAlignment": enum com.formdev.flatlaf.extras.components.FlatTabbedPane$TabAreaAlignment trailing
-				"tabLayoutPolicy": 1
+			add( new FormContainer( "javax.swing.JPanel", new FormLayoutManager( class java.awt.BorderLayout ) ) {
+				name: "centerPanel"
+				add( new FormContainer( "com.formdev.flatlaf.extras.components.FlatTabbedPane", new FormLayoutManager( class javax.swing.JTabbedPane ) ) {
+					name: "tabbedPane"
+					"leadingComponent": new FormReference( "previewLabel" )
+					"tabAreaAlignment": enum com.formdev.flatlaf.extras.components.FlatTabbedPane$TabAreaAlignment trailing
+					"tabLayoutPolicy": 1
+				}, new FormLayoutConstraints( class java.lang.String ) {
+					"value": "Center"
+				} )
 			}, new FormLayoutConstraints( class java.lang.String ) {
 				"value": "Center"
 			} )

--- a/flatlaf-theme-editor/src/main/java/com/formdev/flatlaf/themeeditor/FlatThemePropertiesSupport.java
+++ b/flatlaf-theme-editor/src/main/java/com/formdev/flatlaf/themeeditor/FlatThemePropertiesSupport.java
@@ -109,6 +109,17 @@ class FlatThemePropertiesSupport
 		}
 	}
 
+	Object getParsedValue( String key, String str ) {
+		try {
+			AtomicReference<Object> resultValueType = new AtomicReference<>();
+			String value = resolveValue( str );
+			return UIDefaultsLoaderAccessor.parseValue( key, value, resultValueType, resolver );
+		} catch( Exception ex ) {
+			System.out.println( textArea.getFileName() + ": " + ex.getMessage() ); //TODO
+			return null;
+		}
+	}
+
 	private KeyValue getKeyValueAtLine( int line ) {
 		try {
 			// get text at line

--- a/flatlaf-theme-editor/src/main/java/com/formdev/flatlaf/themeeditor/FlatThemeTokenMaker.java
+++ b/flatlaf-theme-editor/src/main/java/com/formdev/flatlaf/themeeditor/FlatThemeTokenMaker.java
@@ -84,6 +84,9 @@ public class FlatThemeTokenMaker
 		tokenMap.put( "derived", Token.RESERVED_WORD );
 		tokenMap.put( "autoInverse", Token.RESERVED_WORD );
 		tokenMap.put( "noAutoInverse", Token.RESERVED_WORD );
+		tokenMap.put( "rgb", Token.RESERVED_WORD );
+		tokenMap.put( "lrgb", Token.RESERVED_WORD );
+		tokenMap.put( "oklab", Token.RESERVED_WORD );
 	}
 
 	/**

--- a/flatlaf-theme-editor/theme-editor-test-color-function-preview.properties
+++ b/flatlaf-theme-editor/theme-editor-test-color-function-preview.properties
@@ -1,0 +1,83 @@
+# lighten
+a = lighten(#f00,30%)
+a = lighten(#f00,30%,relative)
+a = lighten(#f88,30%,autoInverse)
+a = lighten(#f88,30%,relative autoInverse)
+a = lighten(Actions.Red,10%,lazy)
+
+# darken
+a = darken(#f00,30%)
+a = darken(#f00,30%,relative)
+a = darken(#a00,30%,autoInverse)
+a = darken(#a00,30%,relative autoInverse)
+a = darken(Actions.Red,10%,lazy)
+
+# saturate
+a = saturate(#966,30%)
+a = saturate(#966,30%,relative)
+a = saturate(#d33,30%,autoInverse)
+a = saturate(#d33,30%,relative autoInverse)
+a = saturate(Actions.Red,10%,lazy)
+
+# desaturate
+a = desaturate(#d33,30%)
+a = desaturate(#d33,30%,relative)
+a = desaturate(#966,30%,autoInverse)
+a = desaturate(#966,30%,relative autoInverse)
+a = desaturate(Actions.Red,10%,lazy)
+
+# fadein
+a = fadein(#f004,30%)
+a = fadein(#f004,30%,relative)
+a = fadein(#f00a,30%,autoInverse)
+a = fadein(#f00a,30%,relative autoInverse)
+a = fadein(Actions.Red,50%,lazy)
+
+# fadeout
+a = fadeout(#f00a,30%)
+a = fadeout(#f00a,30%,relative)
+a = fadeout(#f004,30%,autoInverse)
+a = fadeout(#f004,30%,relative autoInverse)
+a = fadeout(Actions.Red,50%,lazy)
+
+# fade
+a = fade(#f00,50%)
+a = fade(Actions.Red,50%,lazy)
+
+# spin
+a = spin(#f00,30)
+a = spin(Actions.Red,30,lazy)
+
+# changeHue
+a = changeHue(#f00,180)
+a = changeHue(Actions.Red,180,lazy)
+
+# changeSaturation
+a = changeSaturation(#f00,50%)
+a = changeSaturation(Actions.Red,50%,lazy)
+
+# changeLightness
+a = changeLightness(#f00,80%)
+a = changeLightness(Actions.Red,80%,lazy)
+
+# changeAlpha
+a = changeAlpha(#f00,50%)
+a = changeAlpha(Actions.Red,50%,lazy)
+
+# mix
+a = mix(#f00,#0f0,40%)
+a = mix(#f00,#0f0,40%,lrgb)
+a = mix(#f00,#0f0,40%,oklab)
+a = mix(#0f0,Actions.Red,50%,lazy)
+
+# tint
+a = tint(#f00,40%)
+a = tint(#f00,40%,lrgb)
+a = tint(#f00,40%,oklab)
+a = tint(Actions.Red,50%,lazy)
+
+# shade
+a = shade(#f00,20%)
+a = shade(#f00,20%,lrgb)
+a = shade(#f00,20%,oklab)
+a = shade(Actions.Red,20%,lazy)


### PR DESCRIPTION
This PR adds support for [Oklab](https://bottosson.github.io/posts/oklab/) and linear sRGB color spaces to color functions `mix()`, `tint()` and `shade()`. (issue #1109)
It also adds preview for color functions to [FlatLaf Theme Editor](https://github.com/JFormDesigner/FlatLaf/tree/main/flatlaf-theme-editor).

## Color Spaces

To use [Oklab](https://bottosson.github.io/posts/oklab/) or linear sRGB color spaces in color functions `mix()`, `tint()` and `shade()`,
pass `oklab` or `lrgb` as last parameter:

~~~java
mix(#f00,#0f0,40%,lrgb)
mix(#f00,#0f0,40%,oklab)

tint(#f00,40%,lrgb)
tint(#f00,40%,oklab)

shade(#f00,20%,lrgb)
shade(#f00,20%,oklab)
~~~

Following screenshot shows some differences between the color spaces:

<img width="378" height="372" alt="grafik" src="https://github.com/user-attachments/assets/9dd22449-bec5-44f8-a450-e6abcf1865d2" />

## Color Function Preview in FlatLaf Theme Editor

If the editor cursor is at a color function, a preview of the result and the whole percentage range is shown at the bottom of the "Preview" area. This makes it easier to choose a good percentage value and color space.

<img width="326" height="172" alt="grafik" src="https://github.com/user-attachments/assets/0b2c35fb-64eb-4b76-b03c-a37c4391b647" />

The color function is shown at top.
Then the initial color and the resulting color (with percentage).
The bottom gradient shows the color function result in range from 0% to 100%.

<img width="320" height="169" alt="grafik" src="https://github.com/user-attachments/assets/e30e95d8-a896-45a3-8f7b-a43515294ac9" />

<img width="316" height="168" alt="grafik" src="https://github.com/user-attachments/assets/65250c66-2db1-49c5-b6a4-06a9a643d765" />
