### PR TITLE
macOS: Add support for the Cmd+Backspace and Cmd+Delete text shortcuts in textboxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ FlatLaf Change Log
   (issue #1135)
 - Make sure that `META-INF/MANIFEST.MF` is first jar entry, so that tools that
   use `JarInputStream` readers see `Multi-Release: true`. (issue #1139)
-- macOS: The `Cmd+Baskspace` and `Cmd+Delete` shortcuts were not supported.
+- macOS: The `Cmd+Baskspace` and `Cmd+Delete` text shortcuts were not supported. (PR #1142)
 
 
 ## 3.7.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ FlatLaf Change Log
   (issue #1135)
 - Make sure that `META-INF/MANIFEST.MF` is first jar entry, so that tools that
   use `JarInputStream` readers see `Multi-Release: true`. (issue #1139)
+- macOS: The `Cmd+Baskspace` and `Cmd+Delete` shortcuts were not supported.
 
 
 ## 3.7.2

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/FlatInputMaps.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/FlatInputMaps.java
@@ -16,16 +16,16 @@
 
 package com.formdev.flatlaf;
 
-import javax.swing.InputMap;
-import javax.swing.JTextField;
-import javax.swing.KeyStroke;
-import javax.swing.LookAndFeel;
-import javax.swing.UIDefaults;
+import javax.swing.*;
 import javax.swing.UIDefaults.LazyValue;
-import javax.swing.UIManager;
 import javax.swing.plaf.InputMapUIResource;
+import javax.swing.text.BadLocationException;
+import javax.swing.text.JTextComponent;
+import javax.swing.text.Utilities;
 import com.formdev.flatlaf.util.SystemInfo;
 import static javax.swing.text.DefaultEditorKit.*;
+import java.awt.*;
+import java.awt.event.ActionEvent;
 import java.util.function.BooleanSupplier;
 
 /**
@@ -172,6 +172,54 @@ class FlatInputMaps
 			"control shift O", "toggle-componentOrientation", // DefaultEditorKit.toggleComponentOrientation
 		};
 
+		AbstractAction deleteToBeginLineAction = new AbstractAction()
+		{
+			@Override
+			public void actionPerformed( ActionEvent e ) {
+				if ( !(e.getSource() instanceof JTextComponent) ) {
+					return;
+				}
+				JTextComponent textComponent = (JTextComponent) e.getSource();
+
+				if ( textComponent.getSelectionStart() != textComponent.getSelectionEnd() ) {
+					textComponent.replaceSelection("");
+					return;
+				}
+
+				try {
+					int caretPosition = textComponent.getCaretPosition();
+					int lineStart = Utilities.getRowStart(textComponent, caretPosition);
+					if ( lineStart >= 0 && lineStart < caretPosition )
+						textComponent.getDocument().remove( lineStart, caretPosition - lineStart );
+				} catch ( BadLocationException ignored ) {
+				}
+			}
+		};
+
+		AbstractAction deleteToEndLineAction = new AbstractAction()
+		{
+			@Override
+			public void actionPerformed( ActionEvent e ) {
+				if ( !(e.getSource() instanceof JTextComponent) ) {
+					return;
+				}
+				JTextComponent textComponent = (JTextComponent) e.getSource();
+
+				if ( textComponent.getSelectionStart() != textComponent.getSelectionEnd() ) {
+					textComponent.replaceSelection("");
+					return;
+				}
+
+				try {
+					int caretPosition = textComponent.getCaretPosition();
+					int lineEnd = Utilities.getRowEnd(textComponent, caretPosition);
+					if ( lineEnd >= 0 && lineEnd > caretPosition )
+						textComponent.getDocument().remove( caretPosition, lineEnd - caretPosition );
+				} catch ( BadLocationException ignored ) {
+				}
+			}
+		};
+
 		Object[] macCommonTextComponentBindings = SystemInfo.isMacOS ? new Object[] {
 			// move caret one character (without selecting text)
 			"ctrl B", backwardAction,
@@ -213,6 +261,10 @@ class FlatInputMaps
 			// delete previous/next word
 			"ctrl W", deletePrevWordAction,
 			"ctrl D", deleteNextCharAction,
+
+			// delete to line begin/emd with custom actions
+			"meta BACK_SPACE", deleteToBeginLineAction,
+			"meta DELETE", deleteToEndLineAction
 		} : null;
 
 		Object[] singleLineTextComponentBindings = {

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/FlatInputMaps.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/FlatInputMaps.java
@@ -215,7 +215,7 @@ class FlatInputMaps
 			"ctrl W", deletePrevWordAction,
 			"ctrl D", deleteNextCharAction,
 
-			// delete to line begin/emd with custom actions
+			// delete to line begin/end with custom actions
 			"meta BACK_SPACE", new FlatTextFieldUI.DeleteToBeginLineAction( "delete-to-begin-line" ),
 			"meta DELETE", new FlatTextFieldUI.DeleteToEndLineAction( "delete-to-end-line" )
 		} : null;

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/FlatInputMaps.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/FlatInputMaps.java
@@ -16,15 +16,20 @@
 
 package com.formdev.flatlaf;
 
-import javax.swing.*;
+import javax.swing.AbstractAction;
+import javax.swing.InputMap;
+import javax.swing.JTextField;
+import javax.swing.KeyStroke;
+import javax.swing.LookAndFeel;
+import javax.swing.UIDefaults;
 import javax.swing.UIDefaults.LazyValue;
+import javax.swing.UIManager;
 import javax.swing.plaf.InputMapUIResource;
 import javax.swing.text.BadLocationException;
 import javax.swing.text.JTextComponent;
 import javax.swing.text.Utilities;
 import com.formdev.flatlaf.util.SystemInfo;
 import static javax.swing.text.DefaultEditorKit.*;
-import java.awt.*;
 import java.awt.event.ActionEvent;
 import java.util.function.BooleanSupplier;
 

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/FlatInputMaps.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/FlatInputMaps.java
@@ -16,7 +16,6 @@
 
 package com.formdev.flatlaf;
 
-import javax.swing.AbstractAction;
 import javax.swing.InputMap;
 import javax.swing.JTextField;
 import javax.swing.KeyStroke;
@@ -27,6 +26,7 @@ import javax.swing.UIManager;
 import javax.swing.plaf.InputMapUIResource;
 import javax.swing.text.BadLocationException;
 import javax.swing.text.JTextComponent;
+import javax.swing.text.TextAction;
 import javax.swing.text.Utilities;
 import com.formdev.flatlaf.util.SystemInfo;
 import static javax.swing.text.DefaultEditorKit.*;
@@ -177,54 +177,6 @@ class FlatInputMaps
 			"control shift O", "toggle-componentOrientation", // DefaultEditorKit.toggleComponentOrientation
 		};
 
-		AbstractAction deleteToBeginLineAction = new AbstractAction()
-		{
-			@Override
-			public void actionPerformed( ActionEvent e ) {
-				if ( !(e.getSource() instanceof JTextComponent) ) {
-					return;
-				}
-				JTextComponent textComponent = (JTextComponent) e.getSource();
-
-				if ( textComponent.getSelectionStart() != textComponent.getSelectionEnd() ) {
-					textComponent.replaceSelection("");
-					return;
-				}
-
-				try {
-					int caretPosition = textComponent.getCaretPosition();
-					int lineStart = Utilities.getRowStart(textComponent, caretPosition);
-					if ( lineStart >= 0 && lineStart < caretPosition )
-						textComponent.getDocument().remove( lineStart, caretPosition - lineStart );
-				} catch ( BadLocationException ignored ) {
-				}
-			}
-		};
-
-		AbstractAction deleteToEndLineAction = new AbstractAction()
-		{
-			@Override
-			public void actionPerformed( ActionEvent e ) {
-				if ( !(e.getSource() instanceof JTextComponent) ) {
-					return;
-				}
-				JTextComponent textComponent = (JTextComponent) e.getSource();
-
-				if ( textComponent.getSelectionStart() != textComponent.getSelectionEnd() ) {
-					textComponent.replaceSelection("");
-					return;
-				}
-
-				try {
-					int caretPosition = textComponent.getCaretPosition();
-					int lineEnd = Utilities.getRowEnd(textComponent, caretPosition);
-					if ( lineEnd >= 0 && lineEnd > caretPosition )
-						textComponent.getDocument().remove( caretPosition, lineEnd - caretPosition );
-				} catch ( BadLocationException ignored ) {
-				}
-			}
-		};
-
 		Object[] macCommonTextComponentBindings = SystemInfo.isMacOS ? new Object[] {
 			// move caret one character (without selecting text)
 			"ctrl B", backwardAction,
@@ -268,8 +220,8 @@ class FlatInputMaps
 			"ctrl D", deleteNextCharAction,
 
 			// delete to line begin/emd with custom actions
-			"meta BACK_SPACE", deleteToBeginLineAction,
-			"meta DELETE", deleteToEndLineAction
+			"meta BACK_SPACE", new DeleteToBeginLineAction( "delete-to-begin-line" ),
+			"meta DELETE", new DeleteToEndLineAction( "delete-to-end-line" )
 		} : null;
 
 		Object[] singleLineTextComponentBindings = {
@@ -713,6 +665,62 @@ class FlatInputMaps
 			}
 
 			return inputMap;
+		}
+	}
+
+	//---- class DeleteToBeginLineAction --------------------------------------
+
+	private static class DeleteToBeginLineAction
+		extends TextAction
+	{
+		public DeleteToBeginLineAction( String name ) {
+			super( name );
+		}
+
+		@Override
+		public void actionPerformed( ActionEvent e ) {
+			JTextComponent textComponent = super.getTextComponent( e );
+
+			if( textComponent.getSelectionStart() != textComponent.getSelectionEnd() ) {
+				textComponent.replaceSelection( "" );
+				return;
+			}
+
+			try {
+				int caretPosition = textComponent.getCaretPosition();
+				int lineStart = Utilities.getRowStart( textComponent, caretPosition );
+				if( lineStart >= 0 && lineStart < caretPosition )
+					textComponent.getDocument().remove( lineStart, caretPosition - lineStart );
+			} catch( BadLocationException ignored ) {
+			}
+		}
+	}
+
+	//---- class DeleteToEndLineAction ----------------------------------------
+
+	private static class DeleteToEndLineAction
+		extends TextAction
+	{
+		public DeleteToEndLineAction( String name ) {
+			super( name );
+		}
+
+		@Override
+		public void actionPerformed( ActionEvent e ) {
+			JTextComponent textComponent = super.getTextComponent( e );
+
+			if( textComponent.getSelectionStart() != textComponent.getSelectionEnd() ) {
+				textComponent.replaceSelection( "" );
+				return;
+			}
+
+			try {
+				int caretPosition = textComponent.getCaretPosition();
+				int lineEnd = Utilities.getRowEnd( textComponent, caretPosition );
+				if( lineEnd >= 0 && lineEnd > caretPosition )
+					textComponent.getDocument().remove( caretPosition, lineEnd - caretPosition );
+			} catch( BadLocationException ignored ) {
+			}
 		}
 	}
 }

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/FlatInputMaps.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/FlatInputMaps.java
@@ -24,13 +24,9 @@ import javax.swing.UIDefaults;
 import javax.swing.UIDefaults.LazyValue;
 import javax.swing.UIManager;
 import javax.swing.plaf.InputMapUIResource;
-import javax.swing.text.BadLocationException;
-import javax.swing.text.JTextComponent;
-import javax.swing.text.TextAction;
-import javax.swing.text.Utilities;
+import com.formdev.flatlaf.ui.FlatTextFieldUI;
 import com.formdev.flatlaf.util.SystemInfo;
 import static javax.swing.text.DefaultEditorKit.*;
-import java.awt.event.ActionEvent;
 import java.util.function.BooleanSupplier;
 
 /**
@@ -220,8 +216,8 @@ class FlatInputMaps
 			"ctrl D", deleteNextCharAction,
 
 			// delete to line begin/emd with custom actions
-			"meta BACK_SPACE", new DeleteToBeginLineAction( "delete-to-begin-line" ),
-			"meta DELETE", new DeleteToEndLineAction( "delete-to-end-line" )
+			"meta BACK_SPACE", new FlatTextFieldUI.DeleteToBeginLineAction( "delete-to-begin-line" ),
+			"meta DELETE", new FlatTextFieldUI.DeleteToEndLineAction( "delete-to-end-line" )
 		} : null;
 
 		Object[] singleLineTextComponentBindings = {
@@ -665,62 +661,6 @@ class FlatInputMaps
 			}
 
 			return inputMap;
-		}
-	}
-
-	//---- class DeleteToBeginLineAction --------------------------------------
-
-	private static class DeleteToBeginLineAction
-		extends TextAction
-	{
-		public DeleteToBeginLineAction( String name ) {
-			super( name );
-		}
-
-		@Override
-		public void actionPerformed( ActionEvent e ) {
-			JTextComponent textComponent = super.getTextComponent( e );
-
-			if( textComponent.getSelectionStart() != textComponent.getSelectionEnd() ) {
-				textComponent.replaceSelection( "" );
-				return;
-			}
-
-			try {
-				int caretPosition = textComponent.getCaretPosition();
-				int lineStart = Utilities.getRowStart( textComponent, caretPosition );
-				if( lineStart >= 0 && lineStart < caretPosition )
-					textComponent.getDocument().remove( lineStart, caretPosition - lineStart );
-			} catch( BadLocationException ignored ) {
-			}
-		}
-	}
-
-	//---- class DeleteToEndLineAction ----------------------------------------
-
-	private static class DeleteToEndLineAction
-		extends TextAction
-	{
-		public DeleteToEndLineAction( String name ) {
-			super( name );
-		}
-
-		@Override
-		public void actionPerformed( ActionEvent e ) {
-			JTextComponent textComponent = super.getTextComponent( e );
-
-			if( textComponent.getSelectionStart() != textComponent.getSelectionEnd() ) {
-				textComponent.replaceSelection( "" );
-				return;
-			}
-
-			try {
-				int caretPosition = textComponent.getCaretPosition();
-				int lineEnd = Utilities.getRowEnd( textComponent, caretPosition );
-				if( lineEnd >= 0 && lineEnd > caretPosition )
-					textComponent.getDocument().remove( caretPosition, lineEnd - caretPosition );
-			} catch( BadLocationException ignored ) {
-			}
 		}
 	}
 }

--- a/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatTextFieldUI.java
+++ b/flatlaf-core/src/main/java/com/formdev/flatlaf/ui/FlatTextFieldUI.java
@@ -30,6 +30,7 @@ import java.awt.Insets;
 import java.awt.LayoutManager;
 import java.awt.LayoutManager2;
 import java.awt.Rectangle;
+import java.awt.event.ActionEvent;
 import java.awt.event.FocusListener;
 import java.beans.PropertyChangeEvent;
 import java.util.Map;
@@ -52,9 +53,12 @@ import javax.swing.event.DocumentListener;
 import javax.swing.plaf.ComponentUI;
 import javax.swing.plaf.UIResource;
 import javax.swing.plaf.basic.BasicTextFieldUI;
+import javax.swing.text.BadLocationException;
 import javax.swing.text.Caret;
 import javax.swing.text.Document;
 import javax.swing.text.JTextComponent;
+import javax.swing.text.TextAction;
+import javax.swing.text.Utilities;
 import com.formdev.flatlaf.ui.FlatStylingSupport.Styleable;
 import com.formdev.flatlaf.ui.FlatStylingSupport.StyleableUI;
 import com.formdev.flatlaf.util.HiDPIUtils;
@@ -1010,6 +1014,62 @@ debug*/
 		@Override
 		public void changedUpdate( DocumentEvent e ) {
 			documentChanged( e );
+		}
+	}
+
+	//---- class DeleteToBeginLineAction --------------------------------------
+
+	public static class DeleteToBeginLineAction
+		extends TextAction
+	{
+		public DeleteToBeginLineAction( String name ) {
+			super( name );
+		}
+
+		@Override
+		public void actionPerformed( ActionEvent e ) {
+			JTextComponent textComponent = super.getTextComponent( e );
+
+			if( textComponent.getSelectionStart() != textComponent.getSelectionEnd() ) {
+				textComponent.replaceSelection( "" );
+				return;
+			}
+
+			try {
+				int caretPosition = textComponent.getCaretPosition();
+				int lineStart = Utilities.getRowStart( textComponent, caretPosition );
+				if( lineStart >= 0 && lineStart < caretPosition )
+					textComponent.getDocument().remove( lineStart, caretPosition - lineStart );
+			} catch( BadLocationException ignored ) {
+			}
+		}
+	}
+
+	//---- class DeleteToEndLineAction ----------------------------------------
+
+	public static class DeleteToEndLineAction
+		extends TextAction
+	{
+		public DeleteToEndLineAction( String name ) {
+			super( name );
+		}
+
+		@Override
+		public void actionPerformed( ActionEvent e ) {
+			JTextComponent textComponent = super.getTextComponent( e );
+
+			if( textComponent.getSelectionStart() != textComponent.getSelectionEnd() ) {
+				textComponent.replaceSelection( "" );
+				return;
+			}
+
+			try {
+				int caretPosition = textComponent.getCaretPosition();
+				int lineEnd = Utilities.getRowEnd( textComponent, caretPosition );
+				if( lineEnd >= 0 && lineEnd > caretPosition )
+					textComponent.getDocument().remove( caretPosition, lineEnd - caretPosition );
+			} catch( BadLocationException ignored ) {
+			}
 		}
 	}
 }


### PR DESCRIPTION
On macOS, `cmd` + `backspace` is a standard shortcut for deleting to the line beginning and `cmd` + `delete` is an equivalent to the line end.

Swing does not natively support these shortcuts, so this PR adds custom swing action definitions inside of `FlatInputMaps.initTextComponentInputMaps()` and maps those to `meta` + `BACK_SPACE`/`DELETE`.